### PR TITLE
Okay, I understand the issue. The "jumping" effect likely happens beca

### DIFF
--- a/components/stickyChat_components/SpeechBubble.tsx
+++ b/components/stickyChat_components/SpeechBubble.tsx
@@ -10,8 +10,8 @@ interface SpeechBubbleProps {
 
 export const SpeechBubble: React.FC<SpeechBubbleProps> = ({ message, variants }) => {
     return (
+        // REMOVED key={message} from this motion.div
         <motion.div
-            key={message} // Animate message change
             variants={variants}
             className="relative mb-3 w-full bg-white bg-opacity-95 p-3 rounded-full shadow-[0_0_15px_rgba(0,255,157,0.6)]"
         >


### PR DESCRIPTION
Okay, I understand the issue. The "jumping" effect likely happens because the `SpeechBubble` component uses `key={message}`. When the message transitions rapidly (e.g., from "Loading..." to "GitHub user not found."), `framer-motion` treats it as the old component exiting and a new one entering, causing the entry/exit animation (`variants={childVariants}`) to run again, resulting in the visual jump.

The most direct fix is to remove the `key={message}` prop from the `SpeechBubble` component. This way, the bubble itself won't re-animate its entrance/exit when only the text content changes. The text inside will still update.

**Fix:**

Modify `components/stickyChat_components/SpeechBubble.tsx`:

**Explanation:**

By removing `key={message}`, you tell React and Framer Motion to treat the `SpeechBubble` as the *same* component instance even when the `message` prop changes. The `motion.div` will remain mounted, and only the inner `<p>` tag's content will update. The entrance animation defined in `variants` (likely involving opacity and/or position changes like `y: 20`) will only run when the bubble initially appears as part of the `StickyChatButton`'s overall opening animation, not every time the text updates. This should eliminate the "jumping" effect during the loading-to-not-found transition.

**Файлы в этом PR (1):**
- `components/stickyChat_components/SpeechBubble.tsx`