### PR TITLE
Okay, here's the improved `SimpleChart.tsx` component incorporating yo

### DIFF
--- a/components/vpr/SimpleChart.tsx
+++ b/components/vpr/SimpleChart.tsx
@@ -1,39 +1,75 @@
 import React from 'react';
-    import type { VprChartData } from '@/lib/vprVisualData';
+import type { VprChartData } from '@/lib/vprVisualData';
 
-    interface SimpleChartProps {
-      chartData: VprChartData;
-    }
+interface SimpleChartProps {
+  chartData: VprChartData;
+}
 
-    export function SimpleChart({ chartData }: SimpleChartProps) {
-      const { data, labels, title } = chartData;
-      if (!data || data.length === 0 || data.length !== labels?.length) {
-        return <div className="text-center text-yellow-500 italic">Данные для диаграммы некорректны.</div>;
-      }
+export function SimpleChart({ chartData }: SimpleChartProps) {
+  const { data, labels, title } = chartData;
 
-      const maxValue = Math.max(...data, 1); // Avoid division by zero if all data is 0
+  // Basic validation
+  if (!data || data.length === 0 || !labels || data.length !== labels.length) {
+    return (
+      <div className="text-center text-yellow-500 italic p-4">
+        Данные для диаграммы некорректны или отсутствуют.
+      </div>
+    );
+  }
 
-      return (
-        <div className="my-4 p-4 bg-gray-800 border border-gray-700 rounded-lg shadow-inner">
-          {title && <h4 className="text-sm font-semibold text-center text-gray-300 mb-3">{title}</h4>}
-          <div className="h-48 flex items-end justify-around space-x-2 px-2">
-            {data.map((value, index) => (
-              <div key={index} className="flex flex-col items-center flex-grow min-w-0" title={`${labels[index]}: ${value}`}>
-                {/* Bar */}
-                <div
-                  className="w-full bg-brand-blue hover:bg-accent transition-colors duration-200 rounded-t"
-                  style={{ height: `${Math.max((value / maxValue) * 100, 1)}%` }} // Ensure minimum visible height
-                >
-                  {/* Optional: Value inside bar if enough space */}
-                  {/* <span className="text-xs text-white block text-center pt-1">{value}</span> */}
-                </div>
-                 {/* Label */}
-                <span className="mt-1 text-xs text-center text-gray-400 break-words">
-                  {labels[index]}
-                </span>
+  // Find max value, ensure it's at least 1 to avoid division by zero or overly large bars if max is < 1
+  const maxValue = Math.max(...data, 1);
+  const valueLabelThresholdPercent = 15; // Show label inside bar if height is >= 15%
+
+  return (
+    <div className="my-4 p-4 bg-card border border-border rounded-lg shadow-md">
+      {title && (
+        <h4 className="text-sm font-semibold text-center text-card-foreground mb-4">
+          {title}
+        </h4>
+      )}
+      <div className="h-48 flex items-end justify-around space-x-2 px-2" aria-label={title || 'Chart'}>
+        {data.map((value, index) => {
+          const barHeightPercent = Math.max((value / maxValue) * 100, 0.5); // Min height 0.5% for visibility
+          const showValueInside = barHeightPercent >= valueLabelThresholdPercent;
+          const labelText = labels[index] ?? `Item ${index + 1}`; // Fallback label
+
+          return (
+            <div
+              key={index}
+              className="flex flex-col items-center flex-grow min-w-0 h-full justify-end" // Ensure columns take full height for alignment
+              title={`${labelText}: ${value}`} // Tooltip for accessibility and desktop hover
+            >
+              {/* Value Label (shown above if bar is too short) */}
+              {!showValueInside && value > 0 && (
+                 <span className="text-xs text-card-foreground font-medium mb-0.5" aria-hidden="true">
+                   {value}
+                 </span>
+               )}
+
+              {/* Bar */}
+              <div
+                className="w-full bg-brand-blue hover:bg-secondary transition-colors duration-200 rounded-t relative flex justify-center items-start" // Use secondary for hover, relative positioning for inner text
+                style={{ height: `${barHeightPercent}%` }}
+                role="img" // Indicate it's a graphical element
+                aria-label={`${labelText}, value ${value}`} // More specific aria-label for screen readers
+              >
+                {/* Value Label (shown inside if bar is tall enough) */}
+                {showValueInside && (
+                  <span className="absolute top-0 text-xs text-black font-semibold block text-center pt-0.5 px-0.5 overflow-hidden text-ellipsis whitespace-nowrap w-full" aria-hidden="true">
+                    {value}
+                  </span>
+                )}
               </div>
-            ))}
-          </div>
-        </div>
-      );
-    }
+
+              {/* Category Label (X-axis) */}
+              <span className="mt-1.5 text-xs text-center text-muted-foreground break-words w-full">
+                {labelText}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Okay, here's the improved `SimpleChart.tsx` component incorporating your requests:

1.  **Theme Colors:** Uses theme colors (`bg-card`, `border-border`, `text-card-foreground`, `text-muted-foreground`) instead of hardcoded grays.
2.  **Text Inside Bars:** Displays the numerical value inside the bar if the bar is tall enough, otherwise displays it just above the bar. Uses `text-black` for better contrast against the default `brand-blue` background.
3.  **Different Hover Color:** Uses `hover:bg-secondary` for the hover effect, which should correspond to the cyan/teal color (`#4ECDC4`) defined in your theme.
4.  **Transition:** Includes `transition-colors` for a smoother hover effect.
5.  **Error Message Color:** Retained `text-yellow-500` for the error message for now, as it's distinct. You could change it to `text-destructive` if that fits better.

**Key Changes Explained:**

*   **Theme Colors:** Replaced `bg-gray-800` with `bg-card`, `border-gray-700` with `border-border`, etc.
*   **`hover:bg-secondary`:** Applied to the bar div. When hovered (or tapped on mobile), the bar background should change to your `--secondary` color.
*   **Text Logic:**
    *   Calculates `barHeightPercent`.
    *   Sets `showValueInside` based on `valueLabelThresholdPercent`.
    *   Conditionally renders the value `<span>`:
        *   *Above* the bar (`!showValueInside && value > 0`) using `text-card-foreground`.
        *   *Inside* the bar (`showValueInside`) using `text-black font-semibold` for contrast, positioned absolutely at the top. Added `overflow-hidden text-ellipsis whitespace-nowrap` to prevent ugly text overflow on narrow bars.
*   **Layout/Accessibility:**
    *   Added `h-full justify-end` to the column container to ensure bars align at the bottom correctly.
    *   Added `aria-hidden="true"` to the value labels as the `aria-label` on the bar itself provides the info for screen readers.
    *   Added `role="img"` and a more descriptive `aria-label` to the bar div.
    *   Improved fallback for missing labels.
    *   Added `w-full` to labels/values to help with alignment and wrapping.

Remember to **test** this visually in both light and dark modes (if applicable) and on different screen sizes, including mobile, to ensure the text positioning and hover effects work as expected. Check the contrast of the black text inside the blue bars visually.

**Файлы в этом PR (1):**
- `components/vpr/SimpleChart.tsx`