### PR TITLE
✨ "Dummy Mode" 

### DIFF
--- a/app/actions/dummy_actions.ts
+++ b/app/actions/dummy_actions.ts
@@ -1,0 +1,83 @@
+"use server";
+
+import { v4 as uuidv4 } from 'uuid';
+import { supabaseAdmin } from "@/hooks/supabase";
+import { sendTelegramInvoice } from "@/app/actions"; // Import from the main actions file
+import { logger } from "@/lib/logger";
+import { debugLogger } from "@/lib/debugLogger";
+
+/**
+ * Sends an invoice for purchasing the ability to DISABLE Dummy Mode.
+ * This is intended for parents who want to enforce "real" test conditions.
+ */
+export async function purchaseDisableDummyMode(userId: string) {
+  logger.log(`Initiating purchase to DISABLE Dummy Mode for user: ${userId}`);
+  try {
+    // Check if user's dummy mode is already permanently disabled
+    const { data: user, error: userError } = await supabaseAdmin
+      .from("users")
+      .select("metadata")
+      .eq("user_id", userId)
+      .single();
+
+    if (userError) {
+      logger.error(`Error fetching user ${userId} before purchase:`, userError);
+      // Don't necessarily block purchase, maybe log and continue
+    }
+
+    // Access the specific flag within metadata safely
+    const isAlreadyDisabled = user?.metadata?.is_dummy_mode_disabled_by_parent === true;
+
+    if (isAlreadyDisabled) {
+      logger.warn(`User ${userId} already has Dummy Mode permanently disabled. Purchase skipped.`);
+      return { success: true, alreadyDisabled: true, message: "Режим подсказок уже отключен для этого пользователя." };
+    }
+
+    const amount = 15000; // 150 XTR (adjust price for disabling)
+    const title = "🔒 Отключить Режим Подсказок";
+    const description = "Приобретите эту опцию, чтобы отключить возможность использования режима подсказок (Dummy Mode) в тестах ВПР для этого пользователя.";
+    // Unique payload incorporating user ID and a random element
+    const invoicePayload = `disable_dummy_${userId}_${uuidv4()}`;
+
+    // Send the invoice via Telegram
+    const invoiceResult = await sendTelegramInvoice(
+      userId, // Send invoice *to the user* (parent needs to interact with their bot)
+      title,
+      description,
+      invoicePayload,
+      amount,
+      0, // No subscription ID needed
+      // Optional: Add a lock image or something relevant
+      "https://images.unsplash.com/photo-1558017393-0a11d16f92bd?q=80&w=800" // Example lock image
+    );
+
+    if (!invoiceResult.success) {
+      throw new Error(invoiceResult.error || "Failed to send invoice via Telegram");
+    }
+
+    // Store the invoice in the database
+    const { error: insertError } = await supabaseAdmin
+      .from("invoices")
+      .insert({
+        id: invoicePayload,
+        user_id: userId,
+        amount: amount / 100, // Store the actual XTR amount
+        type: "disable_dummy_mode", // New type
+        status: "pending",
+        metadata: { description },
+        subscription_id: 0,
+      });
+
+    if (insertError) {
+      logger.error("Failed to save disable_dummy_mode invoice to DB:", insertError);
+      throw new Error(`Failed to save invoice: ${insertError.message}`);
+    }
+
+    logger.log(`Disable Dummy Mode invoice ${invoicePayload} sent and saved for user ${userId}`);
+    return { success: true, alreadyDisabled: false, message: "Счет на отключение режима подсказок отправлен в Telegram!" };
+
+  } catch (error) {
+    logger.error("Error in purchaseDisableDummyMode:", error);
+    return { success: false, alreadyDisabled: false, error: error instanceof Error ? error.message : "Не удалось инициировать отключение режима подсказок." };
+  }
+}

--- a/app/vpr-test/[subjectId]/page.tsx
+++ b/app/vpr-test/[subjectId]/page.tsx
@@ -1,13 +1,23 @@
 "use client";
 import { useEffect, useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { RotateCcw, Loader2 } from "lucide-react";
-import { supabaseAdmin } from "@/hooks/supabase";
+import { RotateCcw, Loader2, Zap, HelpCircle, Sparkles, Eye, EyeOff, Lock } from "lucide-react"; // Added icons
+// Use client for reads if possible, keep admin for specific tasks like deletion
+
+import { supabaseAdmin } from "@/hooks/supabase"; // Used for deleting attempts on reset
 import { useAppContext } from "@/contexts/AppContext";
 import { debugLogger } from "@/lib/debugLogger";
 import { useParams, useRouter } from 'next/navigation';
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
-// Import VPR components
+// Import VPR components (Restoring original paths from context)
 import { VprProgressIndicator } from "@/components/VprProgressIndicator";
 import { ExplanationDisplay } from "@/components/ExplanationDisplay";
 import { VprLoadingIndicator } from "@/components/vpr/VprLoadingIndicator";
@@ -20,13 +30,17 @@ import { VprAnswerList } from "@/components/vpr/VprAnswerList";
 import { VprTimeUpModal } from "@/components/vpr/VprTimeUpModal";
 
 import { toast } from "sonner";
-import { notifyAdmin } from "@/app/actions"; // <--- ИМПОРТ ДОБАВЛЕН
+// Import specific actions needed (Restoring notifyAdmin, adding new dummy action)
+import { notifyAdmin } from "@/app/actions";
+import { purchaseDisableDummyMode } from "@/app/actions/dummy_actions";
 
-// --- Interfaces ---
+// --- Interfaces --- (Restoring original definitions from context)
 interface SubjectData {
     id: number;
     name: string;
     description?: string;
+    // Assuming grade_level might be needed based on schema, adding it back if relevant
+    grade_level?: number; // Make optional or ensure it's always fetched
 }
 
 interface VprQuestionData {
@@ -37,7 +51,7 @@ interface VprQuestionData {
     explanation?: string;
     position: number;
     vpr_answers: VprAnswerData[];
-    visual_data?: any | null; // Add the new field (type 'any' for now, or create specific types)
+    visual_data?: any | null; // Keep 'any' or define specific type
 }
 
 export interface VprAnswerData {
@@ -62,11 +76,14 @@ interface VprTestAttempt {
 
 export default function VprTestPage() {
     // --- States ---
-    const { user } = useAppContext();
+    // Using `user` from useAppContext as per context, rename dbUser usage to user
+    const { user, token } = useAppContext(); // Use `user` which corresponds to `dbUser`
+    
     const params = useParams();
     const router = useRouter();
     const subjectId = parseInt(params.subjectId as string, 10);
 
+    // .. (keep existing states from context, matching names)
     const [subject, setSubject] = useState<SubjectData | null>(null);
     const [questions, setQuestions] = useState<VprQuestionData[]>([]);
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
@@ -83,21 +100,32 @@ export default function VprTestPage() {
     const [showDescription, setShowDescription] = useState(false);
     const [timerKey, setTimerKey] = useState(Date.now());
     const [isTimerRunning, setIsTimerRunning] = useState(false);
-    const [timeLimit] = useState(3600);
+    const [timeLimit] = useState(3600); // 1 hour
     const [timeUpModal, setTimeUpModal] = useState(false);
     const [isCurrentQuestionNonAnswerable, setIsCurrentQuestionNonAnswerable] = useState(false);
     const [resetCounter, setResetCounter] = useState(0);
     const [selectedVariant, setSelectedVariant] = useState<number | null>(null);
 
-    // --- Timer Functions ---
+    // --- NEW Dummy Mode States ---
+    const [isDummyModeActive, setIsDummyModeActive] = useState(false);
+    const [isPurchasingDisable, setIsPurchasingDisable] = useState(false);
+
+    // Check if dummy mode is permanently disabled using `user.metadata`
+    const isDummyModeGloballyDisabled = user?.metadata?.is_dummy_mode_disabled_by_parent === true;
+    // --- End Dummy Mode States ---
+
+    // --- Timer Functions --- (Restoring originals and adding dummy check)
     const handleTimeUp = useCallback(() => {
         debugLogger.log("Timer: Time is up!");
-        if (!isTestComplete && !timeUpModal) {
+        // Don't trigger time up if dummy mode is active or test already handled
+        if (!isTestComplete && !timeUpModal && !isDummyModeActive) {
             setIsTimerRunning(false);
-            setShowFeedback(false);
-            setTimeUpModal(true);
+            setShowFeedback(false); // Hide any pending feedback
+            setTimeUpModal(true);   // Show the time up modal
+        } else if (isDummyModeActive) {
+            debugLogger.log("Timer: Time up ignored, Dummy Mode is active.");
         }
-    }, [isTestComplete, timeUpModal]);
+    }, [isTestComplete, timeUpModal, isDummyModeActive]); // Add isDummyModeActive dependency
 
     const completeTestDueToTime = useCallback(async () => {
          setTimeUpModal(false);
@@ -107,10 +135,12 @@ export default function VprTestPage() {
          try {
              const currentScore = currentAttempt.score || 0;
              const updates: Partial<VprTestAttempt> = {
-                 last_question_index: questions.length,
+                 last_question_index: questions.length, // Mark all questions as 'passed'
                  completed_at: new Date().toISOString(),
-                 score: currentScore
+                 score: currentScore // Keep the score as it was
              };
+             
+             // Let's use supabaseAdmin for consistency with original context's completion logic
              const { data: updatedAttempt, error: updateError } = await supabaseAdmin
                  .from('vpr_test_attempts')
                  .update(updates)
@@ -121,15 +151,15 @@ export default function VprTestPage() {
               if (updateError) throw updateError;
               if (!updatedAttempt) throw new Error("Attempt not found after forced completion update.");
 
-              // --- НАЧАЛО: Отправка уведомления админу (Время вышло) ---
+              // --- Notify Admin (Time up) - Using `user` from context ---
               if (user && subject && updatedAttempt) {
                 const message = `🔔 Тест ВПР завершен (Время вышло)!
-Пользователь: ${user.username || user.id} (${user.id})
+Пользователь: ${user.username || user.user_id} (${user.user_id})
 Предмет: ${subject.name}
 Вариант: ${updatedAttempt.variant_number}
 Результат: ${updatedAttempt.score ?? 0} из ${updatedAttempt.total_questions}`;
                   try {
-                      await notifyAdmin(message);
+                      await notifyAdmin(message); // Use imported notifyAdmin
                       debugLogger.log("Admin notified of time-up completion.");
                   } catch (notifyError) {
                       debugLogger.error("Failed to notify admin about time-up completion:", notifyError);
@@ -137,7 +167,7 @@ export default function VprTestPage() {
               } else {
                   debugLogger.warn("Could not notify admin (time-up): missing user, subject, or attempt data.");
               }
-              // --- КОНЕЦ: Отправка уведомления админу (Время вышло) ---
+              // --- End Notify Admin ---
 
               setCurrentAttempt(updatedAttempt);
               setIsTestComplete(true);
@@ -146,27 +176,39 @@ export default function VprTestPage() {
          } catch (err: any) {
              debugLogger.error("Error forcing test completion:", err);
              setError(`Не удалось завершить тест (${err.message || 'Неизвестная ошибка'}). Попробуйте обновить страницу.`);
+             toast.error("Ошибка принудительного завершения теста.");
          } finally {
             setIsSaving(false);
          }
-    // Добавлены user и subject в зависимости для использования в уведомлении
-    }, [currentAttempt, isSaving, isTestComplete, questions.length, user, subject]);
-    // --- End Timer Functions ---
+    }, [currentAttempt, isSaving, isTestComplete, questions.length, user, subject]); // Keep dependencies
 
 
-    // --- Data Fetching & Attempt Handling (Includes Variant Selection) ---
+    // --- Data Fetching & Attempt Handling (Restoring context's useEffect logic) ---
     useEffect(() => {
         debugLogger.log(`useEffect running. Reset Counter: ${resetCounter}`);
 
-        if (!user?.id || !subjectId || isNaN(subjectId)) {
-            if (!user?.id) router.push('/login');
-            else setError("Неверный ID предмета");
-            setIsLoading(false);
+        // Use `user.user_id` as per context
+        if (!user?.user_id || !token || !subjectId || isNaN(subjectId)) {
+            if (!user?.user_id) {
+                 // Let AppContext handle redirection or show loading/error
+                 debugLogger.warn("No user ID found in AppContext yet.");
+                 // Don't redirect immediately, show loading or wait
+                 // setError("Ожидание данных пользователя..."); // Or keep loading
+                 // return; // Wait for user context
+                 // Redirecting as per original context if no user
+                 router.push('/login');
+                 return;
+            }
+            else if (isNaN(subjectId)) {
+                 setError("Неверный ID предмета");
+                 setIsLoading(false);
+            }
             return;
         }
 
-        debugLogger.log(`Initializing test for Subject ID: ${subjectId}`);
+        debugLogger.log(`Initializing test for Subject ID: ${subjectId}, User ID: ${user.user_id}`);
         let isMounted = true;
+        
 
         const initializeTest = async () => {
             if (!isMounted) {
@@ -174,100 +216,79 @@ export default function VprTestPage() {
                 return;
             }
             debugLogger.log("InitializeTest starting...");
-            setIsLoading(true);
-            setError(null);
-            setShowDescription(false);
-            setIsTestComplete(false);
-            setShowFeedback(false);
-            setSelectedAnswerId(null);
-            setIsTimerRunning(false);
-            setTimerKey(Date.now());
-            setTimeUpModal(false);
-            setIsCorrect(false);
-            setFeedbackExplanation(null);
-            setFinalScore(0);
-            setCurrentQuestionIndex(0);
-            setCurrentAttempt(null);
-            setQuestions([]);
-            setIsCurrentQuestionNonAnswerable(false);
-            setSelectedVariant(null);
+            // Reset states thoroughly
+            setIsLoading(true); setError(null); setShowDescription(false);
+            setIsTestComplete(false); setShowFeedback(false); setSelectedAnswerId(null);
+            setIsTimerRunning(false); setTimerKey(Date.now()); setTimeUpModal(false);
+            setIsCorrect(false); setFeedbackExplanation(null); setFinalScore(0);
+            setCurrentQuestionIndex(0); setCurrentAttempt(null); setQuestions([]);
+            setIsCurrentQuestionNonAnswerable(false); setSelectedVariant(null);
+            setIsDummyModeActive(false); // Reset dummy mode on init/reset
 
             let variantToLoad: number | null = null;
 
             try {
+                // --- Variant Selection Logic (using supabaseClient) ---
                 debugLogger.log("Selecting variant...");
-                const { data: variantData, error: variantError } = await supabaseAdmin
+                // Using supabaseClient for reads
+                const { data: variantData, error: variantError } = await supabaseClient
                     .from('vpr_questions')
                     .select('variant_number')
                     .eq('subject_id', subjectId);
 
-                if (!isMounted) return;
-                if (variantError) throw new Error(`Ошибка получения вариантов: ${variantError.message}`);
-                if (!variantData || variantData.length === 0) throw new Error('Для этого предмета не найдено ни одного варианта.');
+                 if (!isMounted) return;
+                 if (variantError) throw new Error(`Ошибка получения вариантов: ${variantError.message}`);
+                 if (!variantData || variantData.length === 0) throw new Error('Для этого предмета не найдено ни одного варианта.');
+                 const allAvailableVariants = [...new Set(variantData.map(q => q.variant_number))].sort((a,b) => a - b);
 
-                const allAvailableVariants = [...new Set(variantData.map(q => q.variant_number))].sort((a,b) => a - b);
-                debugLogger.log("Available variants:", allAvailableVariants);
+                 // Using supabaseClient for reads
+                 const { data: completedAttemptsData, error: completedError } = await supabaseClient
+                     .from('vpr_test_attempts')
+                     .select('variant_number')
+                     .eq('user_id', user.user_id) // Use user.user_id
+                     .eq('subject_id', subjectId)
+                     .not('completed_at', 'is', null);
+                  if (!isMounted) return;
+                  if (completedError) throw new Error(`Ошибка получения пройденных попыток: ${completedError.message}`);
+                  const completedVariants = [...new Set(completedAttemptsData.map(a => a.variant_number))];
+                  const untriedVariants = allAvailableVariants.filter(v => !completedVariants.includes(v));
+                  if (untriedVariants.length > 0) { variantToLoad = untriedVariants[Math.floor(Math.random() * untriedVariants.length)]; }
+                  else if (allAvailableVariants.length > 0) { variantToLoad = allAvailableVariants[Math.floor(Math.random() * allAvailableVariants.length)]; }
+                  else { throw new Error('Не удалось определить вариант для загрузки.'); }
+                  setSelectedVariant(variantToLoad);
+                  if (!variantToLoad) throw new Error("Variant selection failed.");
 
-                const { data: completedAttemptsData, error: completedError } = await supabaseAdmin
-                    .from('vpr_test_attempts')
-                    .select('variant_number')
-                    .eq('user_id', user.id)
-                    .eq('subject_id', subjectId)
-                    .not('completed_at', 'is', null);
-
-                if (!isMounted) return;
-                if (completedError) throw new Error(`Ошибка получения пройденных попыток: ${completedError.message}`);
-
-                const completedVariants = [...new Set(completedAttemptsData.map(a => a.variant_number))];
-                debugLogger.log("User has completed variants:", completedVariants);
-
-                const untriedVariants = allAvailableVariants.filter(v => !completedVariants.includes(v));
-                debugLogger.log("Untried variants:", untriedVariants);
-
-                if (untriedVariants.length > 0) {
-                    variantToLoad = untriedVariants[Math.floor(Math.random() * untriedVariants.length)];
-                    debugLogger.log(`Selected random untried variant: ${variantToLoad}`);
-                } else if (allAvailableVariants.length > 0) {
-                    variantToLoad = allAvailableVariants[Math.floor(Math.random() * allAvailableVariants.length)];
-                    debugLogger.log(`All variants tried. Selected random variant from all: ${variantToLoad}`);
-                } else {
-                    throw new Error('Не удалось определить вариант для загрузки.');
-                }
-
-                setSelectedVariant(variantToLoad);
-
-                if (!variantToLoad) throw new Error("Variant selection failed.");
-
+                // --- Fetch Subject Data (using supabaseClient) ---
                 debugLogger.log("Fetching subject data...");
-                const { data: subjectData, error: subjectError } = await supabaseAdmin
+                const { data: subjectData, error: subjectError } = await supabaseClient
                     .from('subjects')
-                    .select('*')
+                    .select('*') // Select all fields, including potential grade_level
                     .eq('id', subjectId)
                     .single();
-                if (!isMounted) return;
-                if (subjectError) throw new Error(`Ошибка загрузки предмета: ${subjectError.message}`);
-                if (!subjectData) throw new Error('Предмет не найден');
-                setSubject(subjectData); // <--- setSubject ЗДЕСЬ
-                debugLogger.log("Subject data loaded:", subjectData.name);
+                 if (!isMounted) return;
+                 if (subjectError || !subjectData) throw subjectError || new Error('Предмет не найден');
+                 setSubject(subjectData);
+                 debugLogger.log("Subject data loaded:", subjectData.name);
 
+                // --- Fetch Questions (using supabaseClient) ---
                 debugLogger.log(`Fetching questions for selected variant ${variantToLoad}...`);
-                const { data: questionData, error: questionError } = await supabaseAdmin
+                const { data: questionData, error: questionError } = await supabaseClient
                     .from('vpr_questions')
-                    .select(`*, vpr_answers ( * )`)
+                    .select(`*, vpr_answers ( * )`) // Fetch nested answers
                     .eq('subject_id', subjectId)
                     .eq('variant_number', variantToLoad)
                     .order('position', { ascending: true });
-                if (!isMounted) return;
-                if (questionError) throw new Error(`Ошибка загрузки вопросов: ${questionError.message}`);
-                if (!questionData || questionData.length === 0) throw new Error(`Вопросы для варианта ${variantToLoad} не найдены`);
-                setQuestions(questionData);
-                debugLogger.log(`Loaded ${questionData.length} questions.`);
+                 if (!isMounted) return;
+                 if (questionError || !questionData || questionData.length === 0) throw questionError || new Error(`Вопросы для варианта ${variantToLoad} не найдены`);
+                 setQuestions(questionData);
+                 debugLogger.log(`Loaded ${questionData.length} questions.`);
 
+                // --- Find or Create Attempt (using supabaseClient for read, supabaseAdmin for delete, client for insert) ---
                 debugLogger.log(`Finding active test attempt for variant ${variantToLoad}...`);
-                const { data: existingAttempts, error: attemptError } = await supabaseAdmin
+                const { data: existingAttempts, error: attemptError } = await supabaseClient // Use client
                     .from('vpr_test_attempts')
                     .select('*')
-                    .eq('user_id', user.id)
+                    .eq('user_id', user.user_id) // Use user.user_id
                     .eq('subject_id', subjectId)
                     .eq('variant_number', variantToLoad)
                     .is('completed_at', null)
@@ -281,45 +302,67 @@ export default function VprTestPage() {
                 if (existingAttempts && existingAttempts.length > 0) {
                     const potentialAttempt = existingAttempts[0];
                     if (potentialAttempt.total_questions !== questionData.length) {
-                        debugLogger.warn(`Question count mismatch for variant ${variantToLoad}. Active attempt outdated. Will create new one.`);
-                         try {
-                            debugLogger.log(`Attempting to delete outdated attempt ID: ${potentialAttempt.id}`);
-                             await supabaseAdmin.from('vpr_test_attempts').delete().eq('id', potentialAttempt.id);
-                         } catch (deleteErr) {
+                        debugLogger.warn(`Question count mismatch for variant ${variantToLoad}. Active attempt outdated. Deleting old and creating new.`);
+                        try {
+                            // Use supabaseAdmin for delete as per original reset logic
+                            const { error: deleteErr } = await supabaseAdmin.from('vpr_test_attempts').delete().eq('id', potentialAttempt.id);
+                            if (deleteErr) throw deleteErr;
+                            debugLogger.log(`Deleted outdated attempt ID: ${potentialAttempt.id}`);
+                        } catch (deleteErr: any) {
                              debugLogger.error("Failed to delete outdated attempt:", deleteErr);
-                         }
+                             toast.error("Не удалось удалить старую попытку, возможны несоответствия.");
+                             // Continue to create a new one
+                        }
                     } else {
                         attemptToUse = potentialAttempt;
                         debugLogger.log(`Resuming active attempt ID: ${attemptToUse.id} for variant ${variantToLoad}, Last Index: ${attemptToUse.last_question_index}`);
-                        setFinalScore(attemptToUse.score || 0);
+                        setFinalScore(attemptToUse.score || 0); // Restore score on resume
                     }
                 } else {
-                    debugLogger.log(`No active attempt found in DB for variant ${variantToLoad}.`);
+                     debugLogger.log(`No active attempt found in DB for variant ${variantToLoad}.`);
                 }
 
+                // Create new attempt if needed (using client, assuming RLS allows)
                 if (!attemptToUse) {
                      debugLogger.log(`Creating new attempt for variant ${variantToLoad}.`);
-                     const { data: newAttemptData, error: newAttemptError } = await createNewAttempt(user.id, subjectId, variantToLoad, questionData.length);
+                     // Use client for insert (check RLS policies)
+                     const { data: newAttemptData, error: newAttemptError } = await supabaseClient
+                         .from('vpr_test_attempts')
+                         .insert({ user_id: user.user_id, subject_id: subjectId, variant_number: variantToLoad, total_questions: questionData.length, last_question_index: 0, score: 0 })
+                         .select()
+                         .single();
                      if (!isMounted) return;
                      if (newAttemptError || !newAttemptData) throw newAttemptError || new Error('Не удалось создать новую попытку');
                      attemptToUse = newAttemptData;
-                     debugLogger.log(`New attempt created ID: ${attemptToUse.id} for variant ${variantToLoad}`);
-                     setFinalScore(0);
+                     debugLogger.log(`New attempt created ID: ${attemptToUse.id}`);
+                     setFinalScore(0); // Reset score for new attempt
                 }
 
                 setCurrentAttempt(attemptToUse);
                 const resumeIndex = Math.max(0, Math.min(attemptToUse.last_question_index, questionData.length - 1));
-                setCurrentQuestionIndex(resumeIndex);
-                debugLogger.log(`Setting current question index to: ${resumeIndex}`);
+                // Ensure resumeIndex doesn't exceed actual questions length if attempt is somehow ahead
+                 const validResumeIndex = Math.min(resumeIndex, questionData.length > 0 ? questionData.length - 1 : 0);
 
-                const currentQ = questionData[resumeIndex];
-                const currentAnswers = currentQ?.vpr_answers || [];
-                const isNonAnswerable = currentAnswers.length > 0 && currentAnswers.every(a => /^\[(Рисунок|Ввод текста|Диаграмма|Изображение|Площадь)\].*/.test(a.text));
-                setIsCurrentQuestionNonAnswerable(isNonAnswerable);
-                debugLogger.log(`Is current question (${resumeIndex}) non-answerable? ${isNonAnswerable}`);
+                 // If attempt is already completed, jump to the end state immediately
+                 if (attemptToUse.completed_at) {
+                    debugLogger.log("Attempt already completed, setting completion state.");
+                    setCurrentQuestionIndex(questionData.length); // Go past last question index
+                    setIsTestComplete(true);
+                    setFinalScore(attemptToUse.score ?? 0);
+                    setIsTimerRunning(false);
+                 } else {
+                    setCurrentQuestionIndex(validResumeIndex);
+                    debugLogger.log(`Setting current question index to: ${validResumeIndex}`);
 
-                debugLogger.log("Attempt is active. Starting timer.");
-                setIsTimerRunning(true);
+                    const currentQ = questionData[validResumeIndex];
+                    const currentAnswers = currentQ?.vpr_answers || [];
+                    const isNonAnswerable = currentAnswers.length > 0 && currentAnswers.every(a => /^\[(Рисунок|Ввод текста|Диаграмма|Изображение|Площадь)\].*/.test(a.text));
+                    setIsCurrentQuestionNonAnswerable(isNonAnswerable);
+                    debugLogger.log(`Is current question (${validResumeIndex}) non-answerable? ${isNonAnswerable}`);
+
+                    debugLogger.log("Attempt is active. Starting timer.");
+                    setIsTimerRunning(true); // Start timer only for active attempts
+                 }
 
             } catch (err: any) {
                 if (!isMounted) return;
@@ -334,82 +377,99 @@ export default function VprTestPage() {
             }
         };
 
-        const createNewAttempt = async (userId: string, subjId: number, variantNum: number, totalQ: number) => {
-             debugLogger.log(`Helper: Creating new attempt for user ${userId}, subject ${subjId}, variant ${variantNum}, totalQ ${totalQ}`);
-             return await supabaseAdmin
-                 .from('vpr_test_attempts')
-                 .insert({ user_id: userId, subject_id: subjId, variant_number: variantNum, total_questions: totalQ, last_question_index: 0, score: 0 })
-                 .select()
-                 .single();
-         };
-
+        // Removing createNewAttempt helper as insert is done directly above
         initializeTest();
 
         return () => {
             isMounted = false;
-            const currentQuestionData = questions[currentQuestionIndex];
             debugLogger.log("useEffect cleanup: component unmounting or dependencies changed.");
         };
-     }, [user, subjectId, resetCounter, router]); // router добавлен обратно, так как используется в if (!user?.id)
+     }, [user, subjectId, resetCounter, router, token]); // Keep dependencies
     // --- End Data Fetching ---
 
 
-    // --- Answer Handling ---
+    // --- Answer Handling (Restoring context's version + dummy check) ---
     const handleAnswer = useCallback(async (selectedAnswer: VprAnswerData) => {
+        // --- Add check for Dummy Mode ---
+        if (isDummyModeActive) {
+            debugLogger.log("Answer clicked while Dummy Mode is active. Ignoring.");
+            toast.info("В Режиме Подсказок выбор ответа отключен.", { duration: 2000 });
+            return;
+        }
+        // --- End Dummy Mode Check ---
+
+        // Standard checks from context
         if (!currentAttempt || showFeedback || isTestComplete || isSaving || !isTimerRunning || timeUpModal || !questions[currentQuestionIndex]) return;
+
         debugLogger.log(`Handling answer selection: Answer ID ${selectedAnswer.id} for Question ID ${questions[currentQuestionIndex].id} (Variant: ${currentAttempt.variant_number})`);
-        setIsTimerRunning(false);
+        setIsTimerRunning(false); // Pause timer on answer selection
         setIsSaving(true);
         setSelectedAnswerId(selectedAnswer.id);
+
         const correct = selectedAnswer.is_correct;
         setIsCorrect(correct);
         setFeedbackExplanation(questions[currentQuestionIndex]?.explanation || "Объяснение отсутствует.");
-        setShowFeedback(true);
+        setShowFeedback(true); // Show normal feedback
+
         const scoreIncrement = correct ? 1 : 0;
         const newScore = (currentAttempt.score || 0) + scoreIncrement;
         debugLogger.log(`Answer Correct: ${correct}. Proposed Score: ${newScore}`);
+
+        // Use supabaseAdmin for DB operations as per original context
         try {
-            debugLogger.log("Recording answer to DB...");
+            debugLogger.log("Recording answer to DB using supabaseAdmin...");
             const { error: recordError } = await supabaseAdmin.from('vpr_attempt_answers').insert({ attempt_id: currentAttempt.id, question_id: questions[currentQuestionIndex].id, selected_answer_id: selectedAnswer.id, was_correct: correct });
             // Игнорируем ошибку дубликата (23505), но выводим остальные
             if (recordError && recordError.code !== '23505') throw new Error(`Ошибка записи ответа: ${recordError.message}`);
             if (recordError?.code === '23505') debugLogger.warn("Attempt answer already recorded."); else debugLogger.log("Answer recorded successfully.");
-            debugLogger.log("Updating attempt score in DB...");
+
+            debugLogger.log("Updating attempt score in DB using supabaseAdmin...");
             const { data: updatedData, error: updateScoreError } = await supabaseAdmin.from('vpr_test_attempts').update({ score: newScore }).eq('id', currentAttempt.id).select().single();
             if (updateScoreError) throw new Error(`Ошибка обновления счета: ${updateScoreError.message}`);
             if (!updatedData) throw new Error("Attempt data not returned after score update.");
-            setCurrentAttempt(updatedData); // Update local state with confirmed score
+
+            setCurrentAttempt(updatedData); // Update local state with confirmed score from DB
             debugLogger.log("Attempt score updated successfully.");
         } catch (err: any) {
             debugLogger.error("Error saving answer/score:", err);
             toast.error(`Не удалось сохранить результат: ${err.message}`);
-            // Важно: Не устанавливаем setShowFeedback(false) здесь, чтобы пользователь видел фидбек, даже если сохранение не удалось
+            // Keep feedback showing even if save fails
         } finally {
              setIsSaving(false);
-             // Таймер не перезапускаем здесь, он запустится при handleNextQuestion
+             // Timer remains paused until 'Next' is clicked
         }
-    }, [currentAttempt, showFeedback, isTestComplete, isSaving, isTimerRunning, timeUpModal, questions, currentQuestionIndex]);
-    // --- End Answer Handling ---
+    }, [currentAttempt, showFeedback, isTestComplete, isSaving, isTimerRunning, timeUpModal, questions, currentQuestionIndex, isDummyModeActive, token]); // Added isDummyModeActive, token
 
 
-    // --- Navigation Logic ---
+    // --- Navigation Logic (Restoring context's version + dummy logic) ---
     const handleNextQuestion = useCallback(async (isSkip: boolean = false) => {
+        // Standard checks from context
         if (!currentAttempt || isSaving || isTestComplete || timeUpModal || !questions.length) return;
+
         const currentQIndex = currentQuestionIndex;
         const nextIndex = currentQIndex + 1;
         const isFinishing = nextIndex >= questions.length;
-        debugLogger.log(`Handling next question. From: ${currentQIndex}, To: ${nextIndex}, Finishing: ${isFinishing}, Skip: ${isSkip}`);
+        debugLogger.log(`Handling next question. From: ${currentQIndex}, To: ${nextIndex}, Finishing: ${isFinishing}, Skip: ${isSkip}, DummyActive: ${isDummyModeActive}`);
+
         setIsSaving(true);
+        // Reset feedback/selection states
         setShowFeedback(false); setSelectedAnswerId(null); setIsCorrect(false); setFeedbackExplanation(null);
+        // Keep dummy mode state as it is unless explicitly changed
+
         let nextIsNonAnswerable = false;
         if (!isFinishing) {
             const nextQ = questions[nextIndex]; const nextAnswers = nextQ?.vpr_answers || [];
             nextIsNonAnswerable = nextAnswers.length > 0 && nextAnswers.every(a => /^\[(Рисунок|Ввод текста|Диаграмма|Изображение|Площадь)\].*/.test(a.text));
             debugLogger.log(`Next question (${nextIndex}) non-answerable? ${nextIsNonAnswerable}`);
         }
+
+        // Use supabaseAdmin for updates as per original context
         try {
-            const updates: Partial<VprTestAttempt> = isFinishing ? { last_question_index: questions.length, completed_at: new Date().toISOString() } : { last_question_index: nextIndex };
-            debugLogger.log(`Updating attempt progress/completion in DB to index: ${updates.last_question_index}`);
+            const updates: Partial<VprTestAttempt> = isFinishing
+                ? { last_question_index: questions.length, completed_at: new Date().toISOString() }
+                : { last_question_index: nextIndex };
+            debugLogger.log(`Updating attempt progress/completion in DB to index: ${updates.last_question_index} using supabaseAdmin`);
+
             const { data: updatedAttempt, error: updateError } = await supabaseAdmin.from('vpr_test_attempts').update(updates).eq('id', currentAttempt.id).select().single();
             if (updateError) throw new Error(`Ошибка обновления прогресса: ${updateError.message}`);
             if (!updatedAttempt) throw new Error("Attempt not found after update.");
@@ -419,50 +479,54 @@ export default function VprTestPage() {
             if (!isFinishing) {
                 setCurrentQuestionIndex(nextIndex);
                 setIsCurrentQuestionNonAnswerable(nextIsNonAnswerable);
-                setIsTimerRunning(true);
-                debugLogger.log(`Moved to question index: ${nextIndex}. Timer restarted.`);
+                // Timer logic: Run only if not finishing AND dummy mode is OFF
+                if (!isDummyModeActive) {
+                    setIsTimerRunning(true);
+                    debugLogger.log(`Moved to question index: ${nextIndex}. Timer restarted.`);
+                } else {
+                    setIsTimerRunning(false); // Ensure timer is paused if dummy mode is ON
+                    debugLogger.log(`Moved to question index: ${nextIndex}. Timer remains paused (Dummy Mode Active).`);
+                }
             } else {
-                // ТЕСТ ЗАВЕРШЕН НОРМАЛЬНО
+                // Test completion logic (restored from context)
                 setIsCurrentQuestionNonAnswerable(false);
-                setIsTimerRunning(false);
+                setIsTimerRunning(false); // Ensure timer stops on completion
                 setIsTestComplete(true);
                 setFinalScore(updatedAttempt.score ?? 0);
                 debugLogger.log("Test marked as complete. Final Score from DB:", updatedAttempt.score);
                 toast.success("Тест завершен!", { duration: 4000 });
 
-                // --- НАЧАЛО: Отправка уведомления админу ---
+                // --- Notify Admin (Normal Completion) - Using `user` from context ---
                 if (user && subject && updatedAttempt) {
                     const message = `✅ Тест ВПР завершен!
-Пользователь: ${user.username || user.id} (${user.id})
+Пользователь: ${user.username || user.user_id} (${user.user_id})
 Предмет: ${subject.name}
 Вариант: ${updatedAttempt.variant_number}
 Результат: ${updatedAttempt.score ?? 0} из ${updatedAttempt.total_questions}`;
                     try {
-                        await notifyAdmin(message);
+                        await notifyAdmin(message); // Use imported notifyAdmin
                         debugLogger.log("Admin notified of normal test completion.");
                     } catch (notifyError) {
                         debugLogger.error("Failed to notify admin about normal completion:", notifyError);
-                        // Можно добавить toast.warning("Не удалось уведомить администратора.") если нужно
                     }
                 } else {
-                    debugLogger.warn("Could not notify admin: missing user, subject, or attempt data.");
+                    debugLogger.warn("Could not notify admin (normal completion): missing user, subject, or attempt data.");
                 }
-                // --- КОНЕЦ: Отправка уведомления админу ---
+                // --- End Notify Admin ---
             }
         } catch(err: any) {
             debugLogger.error("Error updating attempt on navigation:", err);
             setError(`Не удалось сохранить прогресс (${err.message}). Попробуйте обновить страницу.`);
             toast.error("Ошибка сохранения прогресса.");
-            if (!isFinishing) setIsTimerRunning(false); // Stop timer if nav failed
+            // Stop timer if navigation failed before completion
+            if (!isFinishing) setIsTimerRunning(false);
         } finally {
             setIsSaving(false);
         }
-    // Добавлены user и subject в зависимости для использования в уведомлении
-    }, [currentAttempt, isSaving, isTestComplete, timeUpModal, questions, currentQuestionIndex, user, subject]);
-    // --- End Navigation Logic ---
+    }, [currentAttempt, isSaving, isTestComplete, timeUpModal, questions, currentQuestionIndex, user, subject, isDummyModeActive]); // Added isDummyModeActive
 
 
-    // --- Reset Logic ---
+    // --- Reset Logic (Restoring context's version + dummy reset) ---
      const resetTest = useCallback(async () => {
          if (isSaving) {
              toast.warning("Подождите, идет сохранение...");
@@ -473,93 +537,310 @@ export default function VprTestPage() {
 
          try {
              setIsTimerRunning(false);
+             setIsDummyModeActive(false); // Ensure dummy mode is off on reset
 
-             debugLogger.log(`Attempting to delete ANY active attempt for subject ${subjectId} and user before reset.`);
-             const { error: deleteError } = await supabaseAdmin
-                 .from('vpr_test_attempts')
-                 .delete()
-                 .eq('user_id', user?.id)
-                 .eq('subject_id', subjectId)
-                 .is('completed_at', null);
+             // Using user.user_id and supabaseAdmin for delete as per context
+             if (user?.user_id && subjectId) {
+                 debugLogger.log(`Attempting to delete ANY active attempt for subject ${subjectId} and user ${user.user_id} before reset using supabaseAdmin.`);
+                 const { error: deleteError } = await supabaseAdmin
+                     .from('vpr_test_attempts')
+                     .delete()
+                     .eq('user_id', user.user_id) // Use user.user_id
+                     .eq('subject_id', subjectId)
+                     .is('completed_at', null);
 
-             if (deleteError) {
-                  debugLogger.error("Error deleting active attempt(s) during reset:", deleteError);
+                 if (deleteError) {
+                      debugLogger.error("Error deleting active attempt(s) during reset:", deleteError);
+                      toast.warning(`Не удалось удалить предыдущую попытку: ${deleteError.message}`);
+                 } else {
+                      debugLogger.log("Any active attempts for this subject/user deleted successfully.");
+                 }
              } else {
-                  debugLogger.log("Any active attempts for this subject/user deleted successfully.");
+                  debugLogger.warn("Cannot delete active attempt during reset: missing user ID or subject ID.");
              }
 
-             setCurrentAttempt(null);
-             setQuestions([]);
-             setCurrentQuestionIndex(0);
-             setError(null);
-             setSelectedVariant(null);
-             setSubject(null); // Сбрасываем предмет тоже
+             // Reset frontend state fully
+             setCurrentAttempt(null); setQuestions([]); setCurrentQuestionIndex(0);
+             setError(null); setSelectedVariant(null); setSubject(null);
+             setFinalScore(0); setIsTestComplete(false); setShowFeedback(false);
+             setSelectedAnswerId(null); setTimeUpModal(false);
 
              toast.info("Сброс теста...", { duration: 1500});
+             // Increment counter to trigger useEffect reload
              setResetCounter(prev => prev + 1);
              debugLogger.log("Reset counter incremented, useEffect will re-run.");
 
          } catch (err: any) {
               debugLogger.error("Error during reset process:", err);
               setError(`Ошибка сброса теста: ${err.message}`);
-              setIsLoading(false);
+              setIsLoading(false); // Stop loading on error
          }
-     }, [isSaving, user?.id, subjectId]);
-    // --- End Reset Logic ---
+         // Let useEffect handle setting isLoading to false after re-fetch
+     }, [isSaving, user?.user_id, subjectId]); // Dependency on user.user_id
 
 
-    // --- Rendering Logic ---
-    if (isLoading) return <VprLoadingIndicator />;
-    if (error) return <VprErrorDisplay error={error} onRetry={resetTest} />;
+    // --- NEW: Purchase Disabling of Dummy Mode ---
+    const handlePurchaseDisableDummy = async () => {
+        if (!user?.user_id) { // Use user.user_id
+            toast.error("Не удалось определить пользователя для покупки.");
+            return;
+        }
+        if (isPurchasingDisable) return;
+
+        debugLogger.log("Attempting to purchase DISABLE Dummy Mode feature...");
+        setIsPurchasingDisable(true);
+        toast.loading("Отправка запроса на покупку...", { id: "purchase-disable-dummy" });
+
+        try {
+            // Use user.user_id
+            const result = await purchaseDisableDummyMode(user.user_id);
+            if (result.success) {
+                if (result.alreadyDisabled) {
+                    toast.success("Режим подсказок уже отключен для этого пользователя.", { id: "purchase-disable-dummy" });
+                    // AppContext should update user eventually, maybe force refresh context?
+                } else {
+                    toast.success("Счет на отключение отправлен в Telegram! Пожалуйста, оплатите его там.", { id: "purchase-disable-dummy", duration: 5000 });
+                }
+            } else {
+                throw new Error(result.error || "Неизвестная ошибка при покупке отключения.");
+            }
+        } catch (error: any) {
+            debugLogger.error("Failed to initiate disable dummy mode purchase:", error);
+            toast.error(`Ошибка покупки: ${error.message}`, { id: "purchase-disable-dummy" });
+        } finally {
+            setIsPurchasingDisable(false);
+        }
+    };
+    // --- End Purchase Disable ---
+
+    // --- Toggle Dummy Mode ---
+    const toggleDummyMode = () => {
+        if (isDummyModeGloballyDisabled) {
+             toast.info("Режим подсказок отключен родителем.", { duration: 3000 });
+             return;
+        }
+        if (isTestComplete || timeUpModal) return; // Don't allow toggle if test finished
+
+        setIsDummyModeActive(prev => {
+            const newState = !prev;
+            debugLogger.log(`Dummy Mode Toggled: ${newState}`);
+            if (newState) {
+                // Turning ON Dummy Mode
+                setIsTimerRunning(false); // Pause timer
+                setShowFeedback(false); // Hide normal feedback if it was shown
+                setSelectedAnswerId(null); // Clear selection
+                toast.info("🧠 Режим Подсказок ВКЛ", { duration: 1500 });
+            } else {
+                // Turning OFF Dummy Mode
+                // Restart timer only if the test is ongoing and not showing feedback
+                if (!isTestComplete && !showFeedback) {
+                     setIsTimerRunning(true);
+                }
+                toast.info("💪 Режим Подсказок ВЫКЛ", { duration: 1500 });
+            }
+            return newState;
+        });
+    };
+    // --- End Toggle Dummy Mode ---
+
+    // --- Rendering Logic (Restoring structure from context + merging new UI) ---
+    // Loading state from context
+    if (isLoading && !currentAttempt) return <VprLoadingIndicator />; // Adjusted condition slightly
+    // Error state from context
+    if (error && !currentAttempt) return <VprErrorDisplay error={error} onRetry={resetTest} />; // Adjusted condition
+    // Completion screen from context
     if (isTestComplete) {
-        // Передаем данные в компонент завершения
         return ( <VprCompletionScreen
                     subjectName={subject?.name}
                     variantNumber={currentAttempt?.variant_number}
                     finalScore={finalScore}
-                    totalQuestions={questions.length}
+                    // Use attempt's total questions if available, fallback to question length
+                    totalQuestions={currentAttempt?.total_questions ?? questions.length}
                     onReset={resetTest}
                     onGoToList={() => router.push('/vpr-tests')} /> );
     }
-    // Проверка после загрузки и ошибок, перед рендером основного теста
-    if (!currentAttempt || questions.length === 0 || !selectedVariant || !subject) {
-         return <VprErrorDisplay error={error || "Данные теста (предмет, вариант или вопросы) не загружены. Попробуйте сбросить."} onRetry={resetTest} />;
+    // Safeguard check from context
+    if (!isLoading && (!currentAttempt || questions.length === 0 || !selectedVariant || !subject)) {
+         return <VprErrorDisplay error={error || "Критические данные теста (предмет, вариант или вопросы) не загружены. Попробуйте сбросить."} onRetry={resetTest} />;
     }
 
-    const currentQuestionData = questions[currentQuestionIndex];
-    const answersForCurrent = currentQuestionData?.vpr_answers || [];
+    const currentQuestionData = questions?.[currentQuestionIndex];
+    // Add check for currentQuestionData validity
+    if (!currentQuestionData) {
+        debugLogger.warn("currentQuestionData is undefined for index:", currentQuestionIndex);
+        // Avoid rendering components that rely on it if it's missing
+        return <VprLoadingIndicator text="Загрузка вопроса..." />;
+        // Or show error if this state persists
+        // return <VprErrorDisplay error="Не удалось загрузить данные текущего вопроса." onRetry={resetTest} />;
+    }
+
+    const answersForCurrent = currentQuestionData.vpr_answers || [];
     const showSavingOverlay = isSaving;
 
+    // Determine if explanation should be shown (dummy mode OR normal feedback)
+    const shouldShowExplanation = isDummyModeActive || showFeedback;
+    const correctAnswer = isDummyModeActive ? answersForCurrent.find(a => a.is_correct) : null;
+    const explanationToShow = isDummyModeActive
+                                ? (currentQuestionData?.explanation || "Объяснение отсутствует.") // Show general explanation in dummy mode
+                                : feedbackExplanation; // Normal feedback explanation
+    const explanationIsCorrectState = isDummyModeActive ? true : isCorrect;
+
+
     return (
-        <motion.div key={currentAttempt.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="min-h-screen bg-page-gradient text-light-text flex flex-col items-center pt-6 pb-10 px-4">
-            <VprTimeUpModal show={timeUpModal} onConfirm={completeTestDueToTime} />
-            <div className="max-w-3xl w-full bg-dark-card shadow-xl rounded-2xl p-5 md:p-8 flex-grow flex flex-col border border-brand-blue/20 relative">
-                 {showSavingOverlay && ( <div className="absolute inset-0 bg-dark-card/80 backdrop-blur-sm flex items-center justify-center z-40 rounded-2xl"> <Loader2 className="h-8 w-8 animate-spin text-brand-blue" /> <span className="ml-3 text-light-text">Сохранение...</span> </div> )}
-                 <VprHeader
-                    subjectName={subject?.name}
-                    variantNumber={selectedVariant} // Передаем выбранный вариант
-                    showDescriptionButton={!!subject?.description}
-                    isDescriptionShown={showDescription}
-                    onToggleDescription={() => setShowDescription(!showDescription)}
-                    timerKey={timerKey}
-                    timeLimit={timeLimit}
-                    onTimeUp={handleTimeUp}
-                    isTimerRunning={isTimerRunning && !isSaving && !isTestComplete && !showFeedback && !timeUpModal}
-                />
-                <VprDescription description={subject?.description} show={showDescription} />
-                <VprProgressIndicator current={currentQuestionIndex} total={questions.length} />
-                <VprQuestionContent
-                        questionData={currentQuestionData}
-                        questionNumber={currentQuestionIndex + 1}
-                        totalQuestions={questions.length}
-                    />
-                <VprAnswerList answers={answersForCurrent} selectedAnswerId={selectedAnswerId} showFeedback={showFeedback} timeUpModal={timeUpModal} handleAnswer={handleAnswer} />
-                 {isCurrentQuestionNonAnswerable && !showFeedback && !isTestComplete && !timeUpModal && (
-                     <div className="mt-4 text-center"> <button onClick={() => handleNextQuestion(true)} disabled={isSaving} className="bg-brand-purple text-white px-6 py-2 rounded-lg font-semibold hover:bg-brand-purple/80 transition-colors disabled:opacity-50 disabled:cursor-wait"> Пропустить / Далее </button> <p className="text-xs text-gray-400 mt-2">Этот вопрос требует рисунка, ввода текста или анализа изображения.</p> </div>
-                 )}
-                 <AnimatePresence> {showFeedback && ( <ExplanationDisplay explanation={feedbackExplanation} isCorrect={isCorrect} onNext={() => handleNextQuestion(false)} isLastQuestion={currentQuestionIndex >= questions.length - 1} /> )} </AnimatePresence>
-                <div className="mt-auto pt-6 text-center"> <button onClick={resetTest} disabled={isSaving || isLoading} className="text-xs text-gray-500 hover:text-brand-pink underline transition-colors flex items-center justify-center gap-1 mx-auto disabled:opacity-50 disabled:cursor-not-allowed"> <RotateCcw className="h-3 w-3"/> Сбросить и начать заново </button> </div>
-            </div>
-        </motion.div>
+        <TooltipProvider>
+            {/* Using motion.div key from context */}
+            <motion.div
+                key={currentAttempt.id}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="min-h-screen bg-page-gradient text-light-text flex flex-col items-center pt-6 pb-10 px-4"
+            >
+                <VprTimeUpModal show={timeUpModal} onConfirm={completeTestDueToTime} />
+
+                {/* Using layout structure from context */}
+                <div className="max-w-3xl w-full bg-dark-card shadow-xl rounded-2xl p-5 md:p-8 flex-grow flex flex-col border border-brand-blue/20 relative">
+                     {showSavingOverlay && (
+                        <div className="absolute inset-0 bg-dark-card/80 backdrop-blur-sm flex items-center justify-center z-40 rounded-2xl">
+                            <Loader2 className="h-8 w-8 animate-spin text-brand-blue" />
+                            <span className="ml-3 text-light-text">Сохранение...</span>
+                        </div>
+                     )}
+
+                    {/* --- HEADER AREA (Merging VprHeader and Dummy Toggle) --- */}
+                    <div className="flex flex-col sm:flex-row justify-between items-center mb-4 gap-y-3">
+                        {/* VprHeader component as in context */}
+                        <VprHeader
+                            subjectName={subject?.name}
+                            variantNumber={selectedVariant} // Pass variant number
+                            showDescriptionButton={!!subject?.description}
+                            isDescriptionShown={showDescription}
+                            onToggleDescription={() => setShowDescription(!showDescription)}
+                            timerKey={timerKey}
+                            timeLimit={timeLimit}
+                            onTimeUp={handleTimeUp}
+                            // Adjust timer running condition based on merged logic
+                            isTimerRunning={isTimerRunning && !isSaving && !isTestComplete && !timeUpModal && !isDummyModeActive}
+                        />
+                        {/* --- Dummy Mode Toggle & Purchase Button --- */}
+                        <div className="flex items-center space-x-3 self-center sm:self-auto">
+                             <Tooltip>
+                                <TooltipTrigger asChild>
+                                     <div className="flex items-center space-x-2">
+                                         {isDummyModeGloballyDisabled ? (
+                                            <Lock className="h-5 w-5 text-yellow-500" />
+                                         ) : (
+                                            <Sparkles className={`h-5 w-5 transition-colors ${isDummyModeActive ? 'text-yellow-400' : 'text-gray-500'}`} />
+                                         )}
+                                        <Switch
+                                            id="dummy-mode-toggle"
+                                            checked={isDummyModeActive}
+                                            onCheckedChange={toggleDummyMode}
+                                            disabled={isDummyModeGloballyDisabled || isTestComplete || timeUpModal || isSaving}
+                                            aria-label="Режим Подсказок"
+                                            className="data-[state=checked]:bg-yellow-500 data-[state=unchecked]:bg-gray-600"
+                                        />
+                                        <label htmlFor="dummy-mode-toggle" className={`text-sm font-medium transition-colors ${isDummyModeActive ? 'text-yellow-400' : 'text-gray-400'} ${isDummyModeGloballyDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}>
+                                             Подсказки
+                                         </label>
+                                    </div>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    {isDummyModeGloballyDisabled
+                                        ? <p>Режим подсказок отключен родителем.</p>
+                                        : <p>{isDummyModeActive ? 'Выключить' : 'Включить'} режим подсказок (показать правильный ответ)</p>
+                                    }
+                                </TooltipContent>
+                            </Tooltip>
+                            {/* Show button to disable if not already disabled */}
+                            {!isDummyModeGloballyDisabled && (
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={handlePurchaseDisableDummy}
+                                            disabled={isPurchasingDisable || !user?.user_id}
+                                            className="border-red-500/50 text-red-400 hover:bg-red-900/30 hover:text-red-300 px-2 py-1 h-auto"
+                                        >
+                                            {isPurchasingDisable ? <Loader2 className="h-4 w-4 animate-spin" /> : <Lock className="h-4 w-4"/>}
+                                            <span className="ml-1 text-xs hidden sm:inline">Отключить</span>
+                                        </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom">
+                                        <p>Купить опцию для родителя: <br/> навсегда отключить режим подсказок.</p>
+                                    </TooltipContent>
+                                </Tooltip>
+                             )}
+                        </div>
+                    </div>
+                    {/* --- END HEADER AREA --- */}
+
+                    <VprDescription description={subject?.description} show={showDescription} />
+                    <VprProgressIndicator current={currentQuestionIndex} total={questions.length} />
+
+                    {/* Question and Answer area with animation */}
+                     <motion.div
+                        key={currentQuestionIndex} // Animate when question changes
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.3 }}
+                    >
+                         <VprQuestionContent
+                             questionData={currentQuestionData} // Pass the whole data object
+                             questionNumber={currentQuestionIndex + 1}
+                             totalQuestions={questions.length}
+                         />
+                         <VprAnswerList
+                            answers={answersForCurrent}
+                            selectedAnswerId={selectedAnswerId}
+                            showFeedback={showFeedback} // For normal feedback
+                            timeUpModal={timeUpModal}
+                            handleAnswer={handleAnswer}
+                            isDummyModeActive={isDummyModeActive} // Pass dummy state
+                        />
+                     </motion.div>
+
+                     {/* Non-answerable question skip button (restored from context) */}
+                     {isCurrentQuestionNonAnswerable && !showFeedback && !isTestComplete && !timeUpModal && !isDummyModeActive && (
+                         <div className="mt-4 text-center">
+                             <button
+                                onClick={() => handleNextQuestion(true)} // Skip non-answerable question
+                                disabled={isSaving}
+                                className="bg-brand-purple text-white px-6 py-2 rounded-lg font-semibold hover:bg-brand-purple/80 transition-colors disabled:opacity-50 disabled:cursor-wait"
+                             >
+                                 Пропустить / Далее
+                             </button>
+                             <p className="text-xs text-gray-400 mt-2">Этот вопрос требует рисунка, ввода текста или анализа изображения.</p>
+                         </div>
+                     )}
+
+                     {/* Explanation Display (Animated, shown in dummy mode or normal feedback) */}
+                     <AnimatePresence>
+                        {shouldShowExplanation && (
+                            <ExplanationDisplay
+                                key={`exp-${currentQuestionIndex}`} // Ensure re-render on question change
+                                explanation={explanationToShow}
+                                isCorrect={explanationIsCorrectState} // Contextual correctness
+                                onNext={() => handleNextQuestion(false)} // Normal next action
+                                isLastQuestion={currentQuestionIndex >= questions.length - 1}
+                                isDummyModeExplanation={isDummyModeActive} // Indicate if shown due to dummy mode
+                            />
+                        )}
+                     </AnimatePresence>
+
+                    {/* Reset button (restored from context) */}
+                    <div className="mt-auto pt-6 text-center">
+                        <button
+                            onClick={resetTest}
+                            disabled={isSaving || isLoading}
+                            className="text-xs text-gray-500 hover:text-brand-pink underline transition-colors flex items-center justify-center gap-1 mx-auto disabled:opacity-50 disabled:cursor-not-allowed"
+                         >
+                             <RotateCcw className="h-3 w-3"/>
+                             Сбросить и начать заново
+                        </button>
+                    </div>
+                </div>
+            </motion.div>
+        </TooltipProvider>
     );
 }

--- a/app/webhook-handlers/disable-dummy-mode.ts
+++ b/app/webhook-handlers/disable-dummy-mode.ts
@@ -1,0 +1,102 @@
+import { WebhookHandler } from "./types";
+import { sendTelegramMessage } from "../actions"; // Import from main actions
+import { debugLogger } from "@/lib/debugLogger";
+import { logger } from "@/lib/logger"; // Import logger for consistency
+import { supabaseAdmin } from '@/hooks/supabase'
+import type { Database } from "@/types/database.types"; // Import Database type
+
+
+
+
+
+
+
+export const disableDummyModeHandler: WebhookHandler = {
+  canHandle: (invoice, payload) => {
+    // Check both the invoice type from DB and the raw payload prefix
+    const isCorrectType = invoice?.type === "disable_dummy_mode";
+    const isCorrectPayload = typeof payload === 'string' && payload.startsWith("disable_dummy_");
+    debugLogger.log(`[disableDummyModeHandler] Checking canHandle: type=${invoice?.type}, payload=${payload}, isCorrectType=${isCorrectType}, isCorrectPayload=${isCorrectPayload}`);
+    // Rely primarily on the DB invoice type
+    return isCorrectType;
+  },
+
+  handle: async (invoice, userId, userData, totalAmount, supabase, telegramToken, adminChatId, baseUrl) => {
+    // Note: totalAmount received from proxy is already in XTR (not smallest unit)
+    debugLogger.log(`[disableDummyModeHandler] Handling successful payment to DISABLE Dummy Mode. Invoice ID: ${invoice.id}, User: ${userId}, Amount: ${totalAmount} XTR`);
+
+    try {
+      // 1. Update user's metadata to disable dummy mode permanently
+      // Use the passed supabase client (which is supabaseAdmin from proxy.ts)
+      
+
+      // Fetch the current metadata first to merge safely
+      const { data: currentUserData, error: fetchError } = await supabaseAdmin
+        .from('users')
+        .select('metadata')
+        .eq('user_id', userId)
+        .single();
+
+      if (fetchError) {
+        logger.error(`[disableDummyModeHandler] Failed to fetch user ${userId} metadata before update:`, fetchError);
+        throw new Error(`Failed to fetch user metadata: ${fetchError.message}`);
+      }
+
+      // Merge new flag into existing metadata, handling null case
+      const currentMetadata = currentUserData?.metadata || {};
+      const updatedMetadata = {
+        ...currentMetadata,
+        is_dummy_mode_disabled_by_parent: true,
+      };
+
+      const { error: updateError } = await supabaseAdmin
+        .from("users")
+        .update({ metadata: updatedMetadata })
+        .eq("user_id", userId);
+
+      if (updateError) {
+        debugLogger.error(`[disableDummyModeHandler] Failed to update user ${userId} metadata to disable dummy mode:`, updateError);
+        // Notify admin about the failure
+        await sendTelegramMessage(
+          telegramToken,
+          `⚠️ Ошибка отключения Dummy Mode! Не удалось обновить метаданные пользователя ${userId} (${userData?.username || 'N/A'}) после оплаты ${invoice.id}. Ошибка: ${updateError.message}`,
+          [],
+          undefined,
+          adminChatId
+        );
+        // Don't throw here, try to notify user anyway
+      } else {
+        debugLogger.log(`[disableDummyModeHandler] User ${userId} metadata updated successfully. Dummy Mode permanently disabled.`);
+      }
+
+      // 2. Notify the user (Parent) who paid
+      await sendTelegramMessage(
+        telegramToken,
+        "✅ Опция отключения Режима Подсказок успешно приобретена! ✨ Возможность использовать подсказки в тестах для этого пользователя теперь отключена.",
+        [], // Optional: Add button to go back to tests or settings?
+        undefined,
+        userId // Notify the user who paid
+      );
+
+      // 3. Notify the admin
+      await sendTelegramMessage(
+        telegramToken,
+        `💰 Пользователь ${userData.username || userId} (${userId}) оплатил ОТКЛЮЧЕНИЕ Режима Подсказок (Dummy Mode)! Сумма: ${totalAmount} XTR.`,
+        [],
+        undefined,
+        adminChatId
+      );
+
+    } catch (error) {
+      debugLogger.error(`[disableDummyModeHandler] Error processing Disable Dummy Mode payment for invoice ${invoice.id}:`, error);
+      // Send a generic error message to admin if something unexpected happened
+      await sendTelegramMessage(
+        telegramToken,
+        `🚨 Критическая ошибка при обработке платежа на ОТКЛЮЧЕНИЕ Dummy Mode для инвойса ${invoice.id}, пользователя ${userId}. Детали: ${error instanceof Error ? error.message : String(error)}`,
+        [],
+        undefined,
+        adminChatId
+      );
+    }
+  },
+};

--- a/app/webhook-handlers/proxy.ts
+++ b/app/webhook-handlers/proxy.ts
@@ -1,85 +1,177 @@
-"use server";
-import axios from "axios";
-import { supabaseAdmin } from "@/hooks/supabase";
-import { logger } from "@/lib/logger";
-
-// Import all specific handlers
+import { WebhookHandler } from "./types";
 import { subscriptionHandler } from "./subscription";
-import { carRentalHandler } from "./car-rental";
+import { carRentalHandler } from "./car-rental"; // Assuming you have these
 import { supportHandler } from "./support";
 import { donationHandler } from "./donation";
 import { scriptAccessHandler } from "./script-access";
 import { inventoryScriptAccessHandler } from "./inventory-script-access";
-import { selfDevBoostHandler } from "./selfdev-boost"; // New import
 
-// List of all webhook handlers
-const handlers = [
+import { disableDummyModeHandler } from "./disable-dummy-mode"; // Handler for DISABLING
+// Import the specific supabaseAdmin instance from your hook
+import { supabaseAdmin } from "@/hooks/supabase";
+import { sendTelegramMessage } from "../actions"; // Import from main actions
+import { logger } from "@/lib/logger";
+import { getBaseUrl } from "@/lib/utils"; // Assuming utils is the correct path
+
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN!;
+const ADMIN_CHAT_ID = process.env.ADMIN_CHAT_ID!;
+
+// Ensure all required handlers are in this array
+const handlers: WebhookHandler[] = [
   subscriptionHandler,
   carRentalHandler,
   supportHandler,
   donationHandler,
   scriptAccessHandler,
   inventoryScriptAccessHandler,
-  selfDevBoostHandler, // Add here
+  dummyModeHandler, // Keep if you have logic for it
+  disableDummyModeHandler, // Keep the handler for disabling dummy mode
+  // Add selfDevBoostHandler if it should also exist:
+  // selfDevBoostHandler,
 ];
 
-// Utility to get the base URL dynamically
-function getBaseUrl() {
-  return process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "https://v0-car-test.vercel.app";
-}
-
 export async function handleWebhookProxy(update: any) {
-  try {
-    if (update.pre_checkout_query) {
-      await axios.post(`https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}/answerPreCheckoutQuery`, {
-        pre_checkout_query_id: update.pre_checkout_query.id,
-        ok: true,
+  // Using logger as in the target version
+  logger.log("Webhook Proxy: Received update", update);
+
+  // Handle pre_checkout_query (consistent with both versions)
+  if (update.pre_checkout_query) {
+    logger.log("Webhook Proxy: Handling pre_checkout_query", update.pre_checkout_query.id);
+    try {
+      // Using fetch as in the target version
+      await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/answerPreCheckoutQuery`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pre_checkout_query_id: update.pre_checkout_query.id, ok: true }),
       });
+      logger.log("Webhook Proxy: Answered pre_checkout_query successfully");
+    } catch (error) {
+      logger.error("Webhook Proxy: Failed to answer pre_checkout_query:", error);
     }
+    return; // Stop processing here for pre-checkout
+  }
 
-    if (update.message?.successful_payment) {
-      const { invoice_payload, total_amount } = update.message.successful_payment;
+  // Handle successful_payment (using logic from the target version)
+  if (update.message?.successful_payment) {
+    const payment = update.message.successful_payment;
+    const userId = update.message.chat.id.toString(); // Ensure user ID is string
+    const { invoice_payload, total_amount } = payment;
+    logger.log(`Webhook Proxy: Handling successful_payment. Payload: ${invoice_payload}, Amount: ${total_amount}, UserID: ${userId}`);
 
+    try {
+      // Fetch invoice details using supabaseAdmin from the hook
       const { data: invoice, error: invoiceError } = await supabaseAdmin
         .from("invoices")
         .select("*")
         .eq("id", invoice_payload)
-        .single();
+        .maybeSingle(); // Use maybeSingle to handle not found case gracefully
 
-      if (invoiceError || !invoice) throw new Error(`Invoice error: ${invoiceError?.message}`);
+      if (invoiceError) {
+        logger.error(`Webhook Proxy: Error fetching invoice ${invoice_payload}:`, invoiceError);
+        // Don't throw immediately, maybe log and notify admin later if needed
+        // Let's throw for now as invoice is crucial
+        throw new Error(`Invoice fetch error: ${invoiceError.message}`);
+      }
 
-      await supabaseAdmin.from("invoices").update({ status: "paid" }).eq("id", invoice_payload);
+      if (!invoice) {
+        // Critical issue: Payment received but no matching invoice
+        logger.error(`Webhook Proxy: Invoice not found in DB for payload: ${invoice_payload}. Payment amount: ${total_amount}, User: ${userId}`);
+        // Notify admin about the orphaned payment
+        await sendTelegramMessage(
+          TELEGRAM_BOT_TOKEN,
+          `🚨 ВНИМАНИЕ: Получен платеж (${total_amount / 100} XTR) с неизвестным payload: ${invoice_payload} от пользователя ${userId}. Инвойс не найден в базе!`,
+          [],
+          undefined,
+          ADMIN_CHAT_ID
+        );
+        // Throw an error to stop processing this payment further
+        throw new Error(`Invoice not found for payload: ${invoice_payload}`);
+      }
 
-      const userId = update.message.chat.id;
+      // Check if invoice is already processed
+      if (invoice.status === 'paid') {
+        logger.warn(`Webhook Proxy: Invoice ${invoice_payload} already marked as paid. Skipping processing.`);
+        return; // Avoid reprocessing
+      }
+
+      // Mark invoice as paid using supabaseAdmin
+      const { error: updateInvoiceError } = await supabaseAdmin
+        .from("invoices")
+        .update({ status: "paid", updated_at: new Date().toISOString() })
+        .eq("id", invoice_payload);
+
+      if (updateInvoiceError) {
+        logger.error(`Webhook Proxy: Error marking invoice ${invoice_payload} as paid:`, updateInvoiceError);
+        // Decide if you should stop processing. For now, throw.
+        throw new Error(`Failed to update invoice status: ${updateInvoiceError.message}`);
+      }
+      logger.log(`Webhook Proxy: Invoice ${invoice_payload} marked as paid.`);
+
+      // Fetch user data using supabaseAdmin
       const { data: userData, error: userError } = await supabaseAdmin
         .from("users")
-        .select("*")
+        .select("*") // Select all fields, including metadata
         .eq("user_id", userId)
-        .single();
+        .single(); // Assuming user must exist if they made a payment
 
-      if (userError) throw new Error(`User fetch error: ${userError.message}`);
+      // userData can be null if user deleted account between payment and webhook processing
+      if (userError && userError.code !== 'PGRST116') { // PGRST116 = 'No rows returned' which is handled by !userData check
+         logger.error(`Webhook Proxy: Error fetching user ${userId} for invoice ${invoice_payload}:`, userError);
+         // If user data is critical for all handlers, might throw here.
+         // For now, proceed and let handlers decide.
+      }
+      if (!userData) {
+          logger.warn(`Webhook Proxy: User ${userId} not found in DB for invoice ${invoice_payload}. Proceeding with basic info.`);
+          // Handlers need to be robust enough to handle missing userData
+      } else {
+          logger.log(`Webhook Proxy: Fetched user data for ${userId}:`, userData.username || 'No username');
+      }
 
-      const baseUrl = getBaseUrl();
-      const telegramToken = process.env.TELEGRAM_BOT_TOKEN!;
-      const adminChatId = process.env.ADMIN_CHAT_ID!;
+      // Find the appropriate handler based on invoice type or payload structure
+      const handler = handlers.find(h => h.canHandle(invoice, invoice_payload)); // Pass both invoice data and raw payload
 
-      const handler = handlers.find((h) => h.canHandle(invoice, invoice_payload));
       if (handler) {
+        logger.log(`Webhook Proxy: Found handler for invoice type "${invoice.type || 'type not in DB'}". Executing...`);
+        const baseUrl = getBaseUrl(); // Get base URL dynamically
+        // Execute the handler, passing the supabaseAdmin client instance
         await handler.handle(
           invoice,
           userId,
-          userData,
-          total_amount,
-          supabaseAdmin,
-          telegramToken,
-          adminChatId,
-          baseUrl
+          // Provide a default object if userData is null/undefined
+          userData || { user_id: userId, metadata: {} },
+          total_amount / 100, // Pass amount in actual currency units (e.g., XTR)
+          supabaseAdmin,      // Pass the imported supabaseAdmin client
+          TELEGRAM_BOT_TOKEN,
+          ADMIN_CHAT_ID,
+          baseUrl             // Pass base URL if needed by handlers
         );
+        logger.log(`Webhook Proxy: Handler for invoice ${invoice_payload} executed successfully.`);
       } else {
-        logger.warn(`No handler found for invoice type: ${invoice.type} or payload: ${invoice_payload}`);
+        // No handler found for this invoice type
+        logger.warn(`Webhook Proxy: No handler found for invoice type "${invoice.type || 'unknown'}" with payload ${invoice_payload}.`);
+        // Notify admin about unhandled payment type
+        await sendTelegramMessage(
+          TELEGRAM_BOT_TOKEN,
+          `⚠️ Необработанный платеж! Тип: ${invoice.type || 'Неизвестен (из payload?)'}, Payload: ${invoice_payload}, Сумма: ${total_amount / 100} XTR, Пользователь: ${userId}`,
+          [],
+          undefined,
+          ADMIN_CHAT_ID
+        );
       }
+    } catch (error) {
+      // Catch any errors during the process
+      logger.error("Webhook Proxy: Error processing successful_payment:", error);
+      // Notify admin about the failure
+      await sendTelegramMessage(
+        TELEGRAM_BOT_TOKEN,
+        `🚨 Ошибка обработки успешного платежа! Payload: ${update.message?.successful_payment?.invoice_payload || 'N/A'}, User: ${update.message?.chat?.id || 'N/A'}. Ошибка: ${error instanceof Error ? error.message : String(error)}`,
+        [],
+        undefined,
+        ADMIN_CHAT_ID
+      );
     }
-  } catch (error) {
-    logger.error("Error handling webhook update in proxy:", error);
+  } else {
+    // Log if the update is neither pre_checkout_query nor successful_payment
+    logger.log("Webhook Proxy: Received update that is not pre_checkout_query or successful_payment. Ignoring.", { type: Object.keys(update) });
   }
 }

--- a/components/AnswerOption.tsx
+++ b/components/AnswerOption.tsx
@@ -1,65 +1,81 @@
-import { motion } from 'framer-motion';
-import { CheckCircle, XCircle } from 'lucide-react';
-// Import type from the correct location
-import type { VprAnswerData } from '@/app/vpr-test/[subjectId]/page';
+import { motion } from "framer-motion";
+import { CheckCircle2, XCircle, Circle } from "lucide-react";
+import type { VprAnswerData } from "@/app/vpr-test/[subjectId]/page"; // Adjust import path if needed
 
-// Interface remains the same as current context
 interface AnswerOptionProps {
-    answer: VprAnswerData;
-    isSelected: boolean;
-    showCorrectness: boolean;
-    showIncorrectness: boolean;
-    isDisabled: boolean;
-    onClick: (answer: VprAnswerData) => void;
+  answer: VprAnswerData;
+  isSelected: boolean;
+  showCorrectness: boolean;
+  showIncorrectness: boolean;
+  isDisabled: boolean;
+  onClick: (answer: VprAnswerData) => void;
+  isDummyHighlighted?: boolean; // <-- NEW PROP for dummy mode highlight
 }
 
-export const AnswerOption = ({
-    answer,
-    isSelected,
-    showCorrectness,
-    showIncorrectness,
-    isDisabled,
-    onClick
-}: AnswerOptionProps) => {
+export function AnswerOption({
+  answer,
+  isSelected,
+  showCorrectness,
+  showIncorrectness,
+  isDisabled,
+  onClick,
+  isDummyHighlighted = false, // <-- Default value
+}: AnswerOptionProps) {
 
-    // --- New class definitions for dark theme ---
-    const baseClasses = "w-full text-left p-3.5 md:p-4 rounded-xl border-2 transition-all duration-200 flex items-center justify-between group text-base md:text-lg shadow-md";
-    const interactionClasses = isDisabled
-        ? 'cursor-not-allowed opacity-60' // Adjusted opacity for dark
-        : 'hover:bg-brand-blue/10 hover:border-brand-blue cursor-pointer'; // New hover effect
-    const selectedClasses = isSelected ? 'ring-2 ring-offset-2 ring-offset-dark-card ring-brand-green border-brand-green' : 'border-gray-600 hover:border-brand-blue'; // New selected styles
-    const correctClasses = showCorrectness ? 'bg-green-600/30 border-brand-green text-white' : ''; // New correct style
-    const incorrectClasses = showIncorrectness ? 'bg-red-600/30 border-brand-pink text-white' : ''; // New incorrect style
-    const textClasses = (showCorrectness || showIncorrectness) ? 'font-semibold' : 'text-light-text/90'; // New text color logic
-    // --- End new class definitions ---
+  const getBaseClasses = () => {
+    let classes = "flex items-center w-full p-4 rounded-lg border transition-all duration-200 cursor-pointer text-left ";
+    if (isDisabled) {
+        classes += "cursor-not-allowed ";
+    } else {
+        classes += "hover:bg-brand-blue/10 ";
+    }
+    return classes;
+  };
 
-    return (
-        <motion.button
-            onClick={() => onClick(answer)}
-            disabled={isDisabled}
-            // Combine classes using new logic. Order matters.
-            className={`${baseClasses} ${isDisabled ? '' : interactionClasses} ${isSelected ? selectedClasses : 'border-gray-600'} ${correctClasses} ${incorrectClasses}`}
-            // New hover/tap animations
-            whileHover={!isDisabled ? { scale: 1.03, y: -2, boxShadow: '0 6px 20px rgba(0, 194, 255, 0.2)' } : {}}
-            whileTap={!isDisabled ? { scale: 0.97 } : {}}
-            layout // Keep layout animation
-        >
-            <span className={`${textClasses} mr-2`}>
-                {answer.text}
-            </span>
-            {/* Icons with updated colors */}
-            <div className="flex-shrink-0">
-                 {showCorrectness && (
-                    <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} exit={{ scale: 0 }}>
-                        <CheckCircle className="h-6 w-6 text-brand-green" /> {/* New Color */}
-                    </motion.div>
-                 )}
-                 {showIncorrectness && (
-                    <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} exit={{ scale: 0 }}>
-                        <XCircle className="h-6 w-6 text-brand-pink" /> {/* New Color */}
-                    </motion.div>
-                 )}
-            </div>
-        </motion.button>
-    );
-};
+  const getVariantClasses = () => {
+    if (showCorrectness) {
+        return "border-green-500 bg-green-900/30 text-green-200 scale-[1.01]"; // Correct answer shown
+    }
+    if (showIncorrectness) {
+        return "border-red-500 bg-red-900/30 text-red-200"; // Incorrect answer selected
+    }
+    if (isDummyHighlighted) { // Apply dummy highlight style if correct answer wasn't selected but dummy mode is on
+        return "border-yellow-500 bg-yellow-900/20 ring-2 ring-yellow-500/70 ring-offset-2 ring-offset-dark-card text-yellow-200 scale-[1.01]"; // Highlight for dummy mode
+    }
+    if (isSelected) {
+        return "border-brand-blue bg-brand-blue/20 text-light-text"; // Selected but feedback not shown yet
+    }
+    // Default / Not Selected
+    return "border-gray-700 bg-dark-bg/50 hover:border-brand-blue/50 text-gray-300";
+  };
+
+  const IconComponent = showCorrectness || isDummyHighlighted
+    ? CheckCircle2
+    : showIncorrectness
+    ? XCircle
+    : Circle; // Default or selected but no feedback yet
+
+  const iconColor = showCorrectness || isDummyHighlighted
+    ? "text-green-400"
+    : showIncorrectness
+    ? "text-red-400"
+    : isSelected
+    ? "text-brand-blue"
+    : "text-gray-500";
+
+  return (
+    <motion.button
+      onClick={() => onClick(answer)}
+      disabled={isDisabled}
+      className={`${getBaseClasses()} ${getVariantClasses()}`}
+      whileHover={!isDisabled ? { scale: 1.02 } : {}}
+      whileTap={!isDisabled ? { scale: 0.98 } : {}}
+      initial={{ opacity: 0, y: 5 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.15 }}
+    >
+      <IconComponent className={`h-5 w-5 mr-3 flex-shrink-0 ${iconColor}`} />
+      <span className="flex-grow">{answer.text}</span>
+    </motion.button>
+  );
+}

--- a/components/ExplanationDisplay.tsx
+++ b/components/ExplanationDisplay.tsx
@@ -1,50 +1,56 @@
-import { motion } from 'framer-motion';
+import { motion } from "framer-motion";
 import ReactMarkdown from 'react-markdown';
-import { CheckCircle, XCircle, Lightbulb } from 'lucide-react';
+import { Lightbulb, XOctagon, CheckCircle, ArrowRight } from "lucide-react"; // Added icons
 
-// Interface remains the same as current context
 interface ExplanationDisplayProps {
-    explanation: string | null;
-    isCorrect: boolean;
-    onNext: () => void;
-    isLastQuestion: boolean;
+  explanation: string | null;
+  isCorrect: boolean;
+  onNext: () => void;
+  isLastQuestion: boolean;
+  isDummyModeExplanation?: boolean; // <-- NEW PROP
 }
 
-export const ExplanationDisplay = ({ explanation, isCorrect, onNext, isLastQuestion }: ExplanationDisplayProps) => {
-    if (!explanation) return null;
+export function ExplanationDisplay({
+  explanation,
+  isCorrect,
+  onNext,
+  isLastQuestion,
+  isDummyModeExplanation = false, // <-- Default value
+}: ExplanationDisplayProps) {
 
-    return (
-        <motion.div
-            initial={{ opacity: 0, y: 10, height: 0 }}
-            animate={{ opacity: 1, y: 0, height: 'auto' }}
-            exit={{ opacity: 0, y: -10, height: 0 }}
-            transition={{ duration: 0.3 }}
-            // New classes for dark theme, border, background, shadow
-            className="mt-6 p-4 md:p-6 rounded-xl border-2 border-brand-orange/50 bg-dark-bg shadow-inner shadow-black/20"
-        >
-            {/* Feedback Title with new colors */}
-            <div className={`flex items-center mb-3 ${isCorrect ? 'text-brand-green' : 'text-brand-pink'}`}>
-                 {isCorrect ? <CheckCircle className="h-6 w-6 mr-2 flex-shrink-0" /> : <XCircle className="h-6 w-6 mr-2 flex-shrink-0" />}
-                <span className="font-semibold text-lg">{isCorrect ? "Правильно!" : "Неверно."}</span>
-            </div>
+  const borderColor = isDummyModeExplanation ? 'border-yellow-500/50' : isCorrect ? 'border-green-500/50' : 'border-red-500/50';
+  const bgColor = isDummyModeExplanation ? 'bg-yellow-900/20' : isCorrect ? 'bg-green-900/20' : 'bg-red-900/20';
+  const iconColor = isDummyModeExplanation ? 'text-yellow-400' : isCorrect ? 'text-green-400' : 'text-red-400';
+  const Icon = isDummyModeExplanation ? Lightbulb : isCorrect ? CheckCircle : XOctagon;
 
-            {/* Explanation Text section */}
-             <div className="flex items-start mb-4">
-                 <Lightbulb className="h-5 w-5 text-yellow-400 mr-2.5 mt-1 flex-shrink-0" /> {/* Updated color */}
-                 {/* Add prose-invert for dark theme markdown */}
-                 <div className="prose prose-sm md:prose-base max-w-none text-light-text/90 prose-invert prose-p:my-1 prose-li:my-0.5">
-                     <ReactMarkdown>{explanation}</ReactMarkdown>
-                 </div>
-             </div>
-
-            {/* Next Button with new bright style */}
-            <button
-                onClick={onNext}
-                // New classes for bright button
-                className="w-full mt-4 bg-brand-green text-dark-bg px-4 py-2.5 rounded-lg font-bold text-base md:text-lg hover:bg-neon-lime transition-all duration-300 transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-neon-lime focus:ring-offset-2 focus:ring-offset-dark-bg shadow-md hover:shadow-lg shadow-brand-green/30"
-            >
-                {isLastQuestion ? "Завершить тест" : "Следующий вопрос"}
-            </button>
-        </motion.div>
-    );
-};
+  return (
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: 'auto' }}
+      exit={{ opacity: 0, height: 0 }}
+      transition={{ duration: 0.3 }}
+      className={`mt-6 p-4 rounded-lg border ${borderColor} ${bgColor} overflow-hidden`}
+    >
+      <div className="flex items-start mb-3">
+          <Icon className={`h-6 w-6 mr-3 flex-shrink-0 ${iconColor}`} />
+          <h3 className={`text-lg font-semibold ${iconColor}`}>
+              {isDummyModeExplanation ? "Подсказка" : (isCorrect ? "Верно!" : "Неверно")}
+          </h3>
+      </div>
+      <div className="prose prose-invert prose-sm max-w-none text-light-text/90 mb-4 prose-p:my-1">
+           {explanation ? (
+             <ReactMarkdown>{explanation}</ReactMarkdown>
+           ) : (
+             <p>Объяснение отсутствует.</p>
+           )}
+      </div>
+      <button
+        onClick={onNext}
+        className="w-full sm:w-auto float-right bg-brand-blue hover:bg-brand-blue/80 text-white px-5 py-2 rounded-md font-semibold text-sm flex items-center justify-center gap-2 transition-colors"
+      >
+        {isLastQuestion ? "Завершить тест" : "Следующий вопрос"}
+        <ArrowRight className="h-4 w-4" />
+      </button>
+    </motion.div>
+  );
+}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,20 +1,49 @@
-// /types/supabase.ts
 import type { Database } from "./database.types" //GEN IT "npx supabase gen types typescript --local > types/database.types.ts" OR ASK CHATGPT
 
 declare global {
-  // Тип пользователя
+  // Тип пользователя (restored from context)
+  // Added comment about metadata structure
+  // Note: The 'metadata' field is JSONB. It might contain various flags.
+  // For the dummy mode feature, we expect:
+  // metadata: {
+  //   is_dummy_mode_disabled_by_parent?: boolean; // Set to true if parent paid to disable dummy mode
+  //   // .. potentially other metadata keys
+  // }
   type User = Database["public"]["Tables"]["users"]["Row"]
 
-  // Тип автомобиля
+  // Тип автомобиля (restored from context)
   type Car = Database["public"]["Tables"]["cars"]["Row"]
 
-  // Тип прогресса теста
+  // Тип прогресса теста (restored from context)
   type TestProgress = {
     currentQuestion: number
     selectedAnswers: number[]
   }
+
+  // Add VPR specific types based on page component interfaces and schema
+  type VprSubject = Database["public"]["Tables"]["subjects"]["Row"];
+  // Combine generated type with explicit nested 'vpr_answers' if needed,
+  // or rely on select query structure. Assuming select fetches it.
+  type VprQuestion = Database["public"]["Tables"]["vpr_questions"]["Row"] & {
+      vpr_answers: VprAnswer[]; // Explicitly type nested relation
+  };
+  type VprAnswer = Database["public"]["Tables"]["vpr_answers"]["Row"];
+  type VprTestAttempt = Database["public"]["Tables"]["vpr_test_attempts"]["Row"];
+  type VprAttemptAnswer = Database["public"]["Tables"]["vpr_attempt_answers"]["Row"];
+
 }
 
-// Экспорт для явного использования
+// Экспорт для явного использования (restored from context)
 export type { Database }
 
+// Export consolidated types for easier import elsewhere
+export type {
+  User,
+  Car,
+  TestProgress,
+  VprSubject,
+  VprQuestion,
+  VprAnswer,
+  VprTestAttempt,
+  VprAttemptAnswer
+};


### PR DESCRIPTION
Okay, yo, let's build this "Dummy Mode" feature. We'll make it available by default, and add the option for parents to pay to disable it, turning the test into a "real" challenge. We'll use the `metadata` field as requested and create the separate action file.

Here's the full code implementation:

**Step 1: Create New Action File (`app/actions/dummy_actions.ts`)**

This file will contain the action to initiate the purchase for *disabling* the dummy mode.

**Step 2: Create Webhook Handler (`app/webhook-handlers/disable-dummy-mode.ts`)**

This handler processes the payment confirmation for disabling dummy mode.

**Step 3: Register Webhook Handler (`app/webhook-handlers/proxy.ts`)**

Import and add the new `disableDummyModeHandler`.

**Step 5: Modify VprAnswerList (`components/vpr/VprAnswerList.tsx`)**

Accept the `isDummyModeActive` prop and apply conditional styling/disabling.

**Step 6: Modify AnswerOption (`components/AnswerOption.tsx`)**

Add the `isDummyHighlighted` prop to apply specific styles.

**Step 7: Modify ExplanationDisplay (`components/ExplanationDisplay.tsx`)**

Add the `isDummyModeExplanation` prop for subtle visual distinction if needed.

**Summary of Changes:**

1.  **Dummy Mode Logic:** Implemented a toggleable dummy mode available by default.
2.  **Payment for Disabling:** Added a flow for parents to pay to *permanently disable* the dummy mode feature for a user.
3.  **Database:** Used the `metadata` JSONB field (`is_dummy_mode_disabled_by_parent`) to store the disable flag, ensuring safe updates with `jsonb_set`.
4.  **Actions:** Created `dummy_actions.ts` for the purchase logic.
5.  **Webhooks:** Added `disable-dummy-mode.ts` handler and registered it in the `proxy.ts`.
6.  **Frontend (`VprTestPage`):** Added state, toggle UI (with lock state), purchase button, and integrated the dummy mode logic into rendering, timer, and navigation.
7.  **Components (`VprAnswerList`, `AnswerOption`, `ExplanationDisplay`):** Modified to accept `isDummyModeActive` or related props and apply conditional styles/disabling.
8.  **Types:** Updated comments in `types/supabase.ts` to reflect the metadata usage.

Remember to install `uuid` if you haven't already (`npm install uuid @types/uuid`) and regenerate Supabase types if applicable (though the `metadata` change won't be reflected in the generated types). Deploy the webhook handlers. Test the toggle, the display logic, and the full payment flow for disabling the feature.
Okay, I will merge the new feature code with your existing files based on the provided context, restoring the skipped parts.

Here are the updated files with the merged code:

**1. `app/webhook-handlers/disable-dummy-mode.ts` (Full Merged Code)**

**2. `app/vpr-test/[subjectId]/page.tsx` (Full Merged Code)**

**3. `types/supabase.ts` (Full Merged Code)**

These merged files should now correctly integrate the "Dummy Mode" feature (toggle, purchase-to-disable, UI) into your existing VPR test page structure and webhook handling, using the variable names and components from your provided context. Remember to verify RLS policies for client-side inserts/updates if you stick with using `supabaseClient` for those operations in `VprTestPage`.
Okay, I understand. You want the `app/webhook-handlers/proxy.ts` file to use the `supabaseAdmin` client imported from `@/hooks/supabase` and ensure all other logic (including the dummy mode handlers) is correctly in place based on the previous version I provided.

Here is the fully merged `app/webhook-handlers/proxy.ts` using `supabaseAdmin` from your hook:

**Key Changes:**

1.  **`supabaseAdmin` Import:** It now correctly uses `import { supabaseAdmin } from "@/hooks/supabase";`.
2.  **No `createClient` Import:** Removed the import for `@supabase/supabase-js`'s `createClient` as it's not needed here.
3.  **Passing `supabaseAdmin`:** The `handler.handle` function is called with `supabaseAdmin` (the imported instance) as the Supabase client argument.
4.  **Handler List:** The `handlers` array includes `dummyModeHandler` and `disableDummyModeHandler` as per the previous version. I've commented out `selfDevBoostHandler` but you can uncomment it if it should also be present alongside the dummy mode handlers.
5.  **Error Handling & Logging:** Retained the more detailed logging and error handling from the previous version.
6.  **Base URL:** Kept the `getBaseUrl` function call.
7.  **User Data Handling:** Added slightly more robust handling for cases where `userData` might be null (e.g., user deleted account).

This version should function as intended, using your specific `supabaseAdmin` client instance for all database operations within the webhook proxy and its dispatched handlers.

**Файлы в этом PR (8):**
- `app/actions/dummy_actions.ts`
- `components/vpr/VprAnswerList.tsx`
- `components/AnswerOption.tsx`
- `components/ExplanationDisplay.tsx`
- `app/webhook-handlers/disable-dummy-mode.ts`
- `app/vpr-test/[subjectId]/page.tsx`
- `types/supabase.ts`
- `app/webhook-handlers/proxy.ts`