### PR TITLE
dynamic pages fix support

### DIFF
--- a/components/StickyChatButton.tsx
+++ b/components/StickyChatButton.tsx
@@ -1,3 +1,6 @@
+// /components/StickyChatButton.tsx
+"use client";
+
 "use client";
 
 import React, { useState, useEffect, useCallback, useMemo } from "react";
@@ -100,7 +103,7 @@ const StickyChatButton: React.FC = () => {
             let taskIdea = "";
             // SPECIAL CASE: /vpr-test/*
             if (cleanPath.startsWith('/vpr-test/')) {
-                taskIdea = "скрой кнопку включения подсказок, пожалуйста";
+                taskIdea = "верни кнопку включения подсказок, пожалуйста";
                 console.log("Special task for /vpr-test/*:", taskIdea);
             } else {
                 // Default task for other pages


### PR DESCRIPTION
**Ключевые изменения:**

1.  **`getPageFilePath` Обновлен:**
    *   Теперь принимает второй аргумент `allActualFilePaths: string[]`, содержащий все пути файлов, извлеченные из репозитория.
    *   **Логика:**
        *   Сначала проверяет точное совпадение с прямым путем (например, `app/vpr-tests/page.tsx`).
        *   Если прямого совпадения нет, он перебирает все *фактические* пути `page.tsx` (или `index.tsx`) из `allActualFilePaths`.
        *   Он сравнивает сегменты входного пути (например, `app`, `vpr-test`, `35`) с сегментами фактического пути (например, `app`, `vpr-test`, `[subjectId]`).
        *   Если сегменты совпадают или фактический сегмент является динамическим (`[...]`), а количество сегментов одинаково, он считает это совпадением и возвращает *фактический* путь файла с динамическим сегментом (например, `app/vpr-test/[subjectId]/page.tsx`).
        *   Если совпадений не найдено, он возвращает исходное предположение прямого пути в качестве запасного варианта.
    *   Зависимости `useCallback` обновлены (в данном случае зависимостей нет, так как он использует только аргументы).

2.  **Вызов `getPageFilePath` в `handleFetch` Обновлен:**
    *   После успешного извлечения файлов (`result.files`) создается массив `allActualFilePaths = fetchedFiles.map(f => f.path)`.
    *   Этот массив передается в качестве второго аргумента при вызове `getPageFilePath`:
        ```typescript
        primaryPath = getPageFilePath(highlightedPathFromUrl, allActualFilePaths);
        ```
    *   Добавлена проверка `pageFile = fetchedFiles.find((file) => file.path === primaryPath);`, чтобы убедиться, что возвращенный (потенциально динамический) путь действительно существует в списке извлеченных файлов, прежде чем пытаться его использовать.

3.  **Зависимости `handleFetch`:** `getPageFilePath` сам по себе стабилен благодаря `useCallback` и отсутствию внешних зависимостей, кроме аргументов. Массив `allActualFilePaths` создается внутри `handleFetch`, поэтому его не нужно добавлять в массив зависимостей `useCallback` для `handleFetch`.

Теперь, если `highlightedPathFromUrl` равен `app/vpr-test/35` (или `/vpr-test/35`) и в репозитории существует файл `app/vpr-test/[subjectId]/page.tsx`, функция `getPageFilePath` вернет именно `app/vpr-test/[subjectId]/page.tsx`. Если же существует `app/vpr-tests/page.tsx`, а путь в URL — `app/vpr-tests`, он вернет этот точный путь.

**Файлы в этом PR (2):**
- `components/RepoTxtFetcher.tsx`
- `components/StickyChatButton.tsx`