### PR TITLE
Ок, понял задачу. Нужно отобразить контент секций (`section_content`),

### DIFF
--- a/app/advice/page.tsx
+++ b/app/advice/page.tsx
@@ -11,8 +11,8 @@ import { logger } from "@/lib/logger";
 import { debugLogger } from "@/lib/debugLogger";
 import { cn } from "@/lib/utils";
 import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-// import remarkBreaks from 'remark-breaks'; // <-- Keep this commented out for now, we'll try CSS first
+import remarkGfm from 'remark-gfm'; // Github Flavored Markdown (tables, etc.)
+import remarkBreaks from 'remark-breaks'; // <-- Re-enable remark-breaks for single newlines
 
 // Define types based on your database schema
 type Article = Database["public"]["Tables"]["articles"]["Row"];
@@ -69,7 +69,7 @@ export default function AdvicePage() {
 
   useEffect(() => {
     const loadArticles = async () => {
-      if (userMetadata === null) return; // Wait for metadata
+      if (userMetadata === null) return;
       setIsLoadingArticles(true);
       setError(null);
       debugLogger.log("Starting to load articles...");
@@ -243,7 +243,7 @@ export default function AdvicePage() {
     )}>
       <div className="relative z-10 container mx-auto px-4 max-w-4xl">
         {!selectedArticle ? (
-          // Articles List View
+          // --- Articles List View ---
           <div className="space-y-6">
             <h1 className="text-3xl md:text-4xl font-bold text-center text-brand-green cyber-text glitch" data-text="Мудрые Советы">
                 Мудрые Советы
@@ -280,7 +280,7 @@ export default function AdvicePage() {
             )}
           </div>
         ) : (
-          // Single Article View
+          // --- Single Article View ---
           <div>
              <h1 className="text-3xl md:text-4xl font-bold mb-3 text-brand-green cyber-text">{selectedArticle.title}</h1>
             {selectedArticle.description && (
@@ -355,29 +355,33 @@ export default function AdvicePage() {
                              <span className="text-brand-blue mr-2">{section.section_order}.</span> {section.title}
                           </h3>
                         )}
-                         {/* --- Use ReactMarkdown with CSS for newlines --- */}
+                         {/* --- Use ReactMarkdown with remarkBreaks and GFM --- */}
                          <ReactMarkdown
-                              remarkPlugins={[remarkGfm]} // GFM handles most things, including basic lists
-                              // Apply Tailwind Typography AND white-space: pre-line
-                              // Updated Prose classes for better list styling
+                              // **Key Change:** Add remarkBreaks here
+                              remarkPlugins={[remarkGfm, remarkBreaks]}
+                              // .. Keep prose classes for general styling, but list styling might be better handled directly if prose conflicts
                               className={cn(
                                   "prose prose-invert prose-sm md:prose-base max-w-none text-gray-300",
                                   "prose-headings:text-brand-cyan prose-strong:text-brand-lime",
                                   "prose-a:text-brand-blue hover:prose-a:text-brand-purple prose-a:transition-colors",
                                   "prose-code:text-brand-pink prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:bg-gray-700/50 prose-code:px-1 prose-code:py-0.5 prose-code:rounded",
                                   "prose-blockquote:border-brand-purple prose-blockquote:text-gray-400",
-                                  "prose-ul:list-disc prose-ol:list-decimal prose-li:marker:text-brand-blue", // Ensure list style type
-                                  "prose-ul:pl-5 prose-ol:pl-5 prose-li:my-1.5", // Indentation and spacing for lists
-                                  "whitespace-pre-line" // <-- Add this class to handle \n as line breaks
+                                  // .. Let remarkGfm handle list rendering, Tailwind prose might interfere sometimes
+                                  // .. Removed prose list specific classes like prose-ul:list-disc etc. Let's see if default HTML list rendering works better now with remark-breaks
+                                  // "prose-ul:list-disc prose-ol:list-decimal prose-li:marker:text-brand-blue",
+                                  // "prose-ul:pl-5 prose-ol:pl-5 prose-li:my-1.5",
+                                  // Removed whitespace-pre-line as remark-breaks should handle \n -> <br>
                               )}
                               components={{
                                   a: ({node, ...props}) => <a {...props} target="_blank" rel="noopener noreferrer" className="hover:underline" />,
-                                  // Custom component for list items if needed for extra styling/logic
-                                  // li: ({node, ordered, ...props}) => <li className="my-1" {...props} />,
+                                  // You might need to add custom components for ul, ol, li if default rendering isn't styled enough
+                                  // ul: ({node, ...props}) => <ul className="list-disc list-outside ml-5 space-y-1" {...props} />,
+                                  // ol: ({node, ...props}) => <ol className="list-decimal list-outside ml-5 space-y-1" {...props} />,
+                                  // li: ({node, ...props}) => <li className="text-gray-300" {...props} />,
                               }}
-                          >
-                             {section.content ?? ''}
-                          </ReactMarkdown>
+                         >
+                            {section.content ?? ''}
+                         </ReactMarkdown>
                       </div>
                     ))}
                   </div>

--- a/app/advice/page.tsx
+++ b/app/advice/page.tsx
@@ -12,7 +12,8 @@ import { debugLogger } from "@/lib/debugLogger";
 import { cn } from "@/lib/utils";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import remarkBreaks from 'remark-breaks'; // <-- Import remark-breaks
+// import remarkBreaks from 'remark-breaks'; // <-- Keep this commented out for now, we'll try CSS first
+
 // Define types based on your database schema
 type Article = Database["public"]["Tables"]["articles"]["Row"];
 type ArticleSection = Database["public"]["Tables"]["article_sections"]["Row"];
@@ -20,382 +21,372 @@ type ArticleSection = Database["public"]["Tables"]["article_sections"]["Row"];
 // Define the structure expected in the user's metadata for this feature
 type UserMetadata = {
   advice_broadcast?: {
-    enabled: boolean;        // Is the broadcast active?
-    article_id: string;      // Which article is being broadcast?
-    remaining_section_ids: string[]; // Ordered list of section IDs yet to be sent
-    last_sent_at?: string; // Optional: Timestamp of the last sent section (for cron logic)
+    enabled: boolean;
+    article_id: string;
+    remaining_section_ids: string[];
+    last_sent_at?: string;
   };
-  // Potentially other metadata fields unrelated to advice
 };
 
-
 export default function AdvicePage() {
-    const { user: tgUser, tg: webApp, dbUser, isLoading: isAuthLoading, isAuthenticated } = useAppContext();
-    const [articles, setArticles] = useState<Article[]>([]);
-    const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
-    const [sections, setSections] = useState<ArticleSection[]>([]);
-    const [isLoadingArticles, setIsLoadingArticles] = useState(true);
-    const [isLoadingSections, setIsLoadingSections] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [broadcastEnabled, setBroadcastEnabled] = useState(false);
-    const [isUpdatingBroadcast, setIsUpdatingBroadcast] = useState(false);
-    const [userMetadata, setUserMetadata] = useState<UserMetadata | null>(null);
+  const { user: tgUser, tg: webApp, dbUser, isLoading: isAuthLoading, isAuthenticated } = useAppContext();
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
+  const [sections, setSections] = useState<ArticleSection[]>([]);
+  const [isLoadingArticles, setIsLoadingArticles] = useState(true);
+  const [isLoadingSections, setIsLoadingSections] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [broadcastEnabled, setBroadcastEnabled] = useState(false);
+  const [isUpdatingBroadcast, setIsUpdatingBroadcast] = useState(false);
+  const [userMetadata, setUserMetadata] = useState<UserMetadata | null>(null);
 
-    const userId = dbUser?.user_id || tgUser?.id?.toString();
+  const userId = dbUser?.user_id || tgUser?.id?.toString();
 
-    // --- Data Fetching ---
-    useEffect(() => {
-        const loadInitialMetadata = async () => {
-            if (!userId) {
-                debugLogger.log("loadInitialMetadata skipped: no userId");
-                setUserMetadata({}); // Set to empty object if no user ID
-                return;
-            };
-            // No need to set loading state here, handled by userMetadata === null check
-            try {
-                debugLogger.log(`loadInitialMetadata fetching for userId: ${userId}`);
-                const userData = await fetchUserData(userId);
-                const metadata = userData?.metadata as UserMetadata | null;
-                setUserMetadata(metadata ?? {}); // Use loaded metadata or empty object
-                debugLogger.log("Initial user metadata loaded:", metadata);
-            } catch (err) {
-                logger.error("Failed to load initial user metadata:", err);
-                setError("Не удалось загрузить настройки пользователя.");
-                setUserMetadata({}); // Set empty object on error to allow article loading attempt
-            }
-        };
-        if (!isAuthLoading) { // Only run after auth check is complete
-           loadInitialMetadata();
-        }
-    }, [userId, isAuthLoading]);
-
-    useEffect(() => {
-        const loadArticles = async () => {
-            setIsLoadingArticles(true);
-            setError(null);
-            debugLogger.log("Starting to load articles...");
-            const { data, error: fetchError } = await fetchArticles();
-            if (fetchError) {
-                logger.error("Failed to fetch articles:", fetchError);
-                setError("Не удалось загрузить список статей.");
-            } else {
-                setArticles(data || []);
-                debugLogger.log(`Loaded ${data?.length || 0} articles.`);
-            }
-            setIsLoadingArticles(false);
-        };
-        // Load articles only when metadata loading is done (userMetadata is not null)
-        if (userMetadata !== null) {
-            loadArticles();
-        } else if (!isAuthLoading && userMetadata === null) {
-            // This case might indicate an error during metadata load or just initial state
-            // Let the global loading spinner handle this until metadata is resolved or errors out
-             debugLogger.log("Waiting for userMetadata before loading articles...");
-        }
-    }, [userMetadata, isAuthLoading]); // Depend on metadata and auth loading status
-
-    const handleSelectArticle = useCallback(async (article: Article) => {
-        setSelectedArticle(article);
-        setIsLoadingSections(true);
-        setSections([]);
-        setError(null);
-        setBroadcastEnabled(false);
-        debugLogger.log(`Article selected: ${article.title} (${article.id})`);
-
-        if (!userMetadata) {
-             debugLogger.warn(`Cannot check broadcast status for ${article.id}: userMetadata not loaded yet.`);
-             // Optionally set an error or just wait? Let's wait for metadata.
-        }
-
-        const { data, error: fetchError } = await fetchArticleSections(article.id);
-        if (fetchError) {
-            logger.error(`Failed to fetch sections for article ${article.id}:`, fetchError);
-            setError("Не удалось загрузить секции статьи.");
-        } else {
-            const sortedSections = (data || []).sort((a, b) => a.section_order - b.section_order);
-            setSections(sortedSections);
-            debugLogger.log(`Loaded ${sortedSections.length || 0} sections for article ${article.id}.`);
-            // Check broadcast status *after* sections are loaded, using the most recent metadata
-            if (userMetadata?.advice_broadcast?.enabled && userMetadata.advice_broadcast.article_id === article.id) {
-                setBroadcastEnabled(true);
-                debugLogger.log(`Broadcast is currently ACTIVE for selected article ${article.id}`);
-            } else {
-                setBroadcastEnabled(false);
-                debugLogger.log(`Broadcast is currently INACTIVE for selected article ${article.id}`);
-            }
-        }
-        setIsLoadingSections(false);
-    }, [userMetadata]); // Added userMetadata dependency
-
-    // --- Broadcast Logic ---
-    const handleToggleBroadcast = async () => {
-        if (!userId || !selectedArticle || isUpdatingBroadcast || userMetadata === null) { // Also check if metadata is loaded
-            debugLogger.warn("handleToggleBroadcast skipped: Missing userId, selectedArticle, updating, or metadata not loaded.");
-            if (userMetadata === null) setError("Настройки пользователя еще не загружены.");
-            return;
-        }
-         if (sections.length === 0 && !broadcastEnabled) {
-            webApp?.showPopup({title: "Нет разделов", message: "В этой статье нет разделов для рассылки.", buttons: [{type: 'ok'}]});
-            setError("В этой статье нет секций для рассылки.");
-            return;
-        }
-
-        setIsUpdatingBroadcast(true);
-        setError(null);
-        let newMetadata: UserMetadata;
-        let successMessage: string;
-        const currentlyEnabled = broadcastEnabled; // Use component state derived from metadata
-        debugLogger.log(`Toggling broadcast. Currently enabled (state): ${currentlyEnabled}`);
-
-        if (currentlyEnabled) {
-            // --- Disable ---
-            const { advice_broadcast, ...restMetadata } = userMetadata; // Destructure from loaded metadata
-            newMetadata = restMetadata;
-            successMessage = "Рассылка советов отключена.";
-            debugLogger.log(`Disabling broadcast for article ${selectedArticle.id}`);
-        } else {
-            // --- Enable ---
-            const sortedSectionIds = sections.map(s => s.id);
-            if (sortedSectionIds.length === 0) {
-                setError("В этой статье нет секций для рассылки.");
-                setIsUpdatingBroadcast(false);
-                return;
-            }
-            newMetadata = {
-                ...userMetadata, // Spread current metadata first
-                advice_broadcast: {
-                    enabled: true,
-                    article_id: selectedArticle.id,
-                    remaining_section_ids: sortedSectionIds,
-                },
-            };
-            successMessage = "Рассылка советов включена! Ожидайте первый выпуск.";
-            debugLogger.log(`Enabling broadcast for article ${selectedArticle.id} with sections:`, sortedSectionIds);
-        }
-
-        // --- Update DB ---
-        const { success, error: updateError, data: updatedUserData } = await updateUserMetadata(userId, newMetadata);
-        if (success && updatedUserData) {
-            setUserMetadata(updatedUserData.metadata as UserMetadata | null ?? {});
-            setBroadcastEnabled(!currentlyEnabled);
-            webApp?.showPopup({title: "Успех", message: successMessage, buttons: [{type: 'ok'}]});
-            debugLogger.log("Metadata update successful.");
-        } else {
-            logger.error("Failed to update user metadata for broadcast:", updateError);
-            const actionText = currentlyEnabled ? 'отключить' : 'включить';
-            const errorMsg = `Не удалось ${actionText} рассылку: ${updateError?.message || 'Неизвестная ошибка'}`; // Include error message
-            setError(errorMsg);
-            webApp?.showPopup({title: "Ошибка", message: errorMsg, buttons: [{type: 'ok'}]});
-        }
-        setIsUpdatingBroadcast(false);
+  // --- Data Fetching ---
+  useEffect(() => {
+    const loadInitialMetadata = async () => {
+      if (!userId) {
+        debugLogger.log("loadInitialMetadata skipped: no userId");
+        setUserMetadata({});
+        return;
+      };
+      try {
+        debugLogger.log(`loadInitialMetadata fetching for userId: ${userId}`);
+        const userData = await fetchUserData(userId);
+        const metadata = userData?.metadata as UserMetadata | null;
+        setUserMetadata(metadata ?? {});
+        debugLogger.log("Initial user metadata loaded:", metadata);
+      } catch (err) {
+        logger.error("Failed to load initial user metadata:", err);
+        setError("Не удалось загрузить настройки пользователя.");
+        setUserMetadata({});
+      }
     };
+    if (!isAuthLoading) {
+        loadInitialMetadata();
+    }
+  }, [userId, isAuthLoading]);
 
-    // --- Navigation & UI ---
-    const handleGoBack = useCallback(() => {
-        setSelectedArticle(null);
-        setSections([]);
-        setError(null);
+  useEffect(() => {
+    const loadArticles = async () => {
+      if (userMetadata === null) return; // Wait for metadata
+      setIsLoadingArticles(true);
+      setError(null);
+      debugLogger.log("Starting to load articles...");
+      const { data, error: fetchError } = await fetchArticles();
+      if (fetchError) {
+        logger.error("Failed to fetch articles:", fetchError);
+        setError("Не удалось загрузить список статей.");
+      } else {
+        setArticles(data || []);
+        debugLogger.log(`Loaded ${data?.length || 0} articles.`);
+      }
+      setIsLoadingArticles(false);
+    };
+     loadArticles();
+  }, [userMetadata]);
+
+  const handleSelectArticle = useCallback(async (article: Article) => {
+    setSelectedArticle(article);
+    setIsLoadingSections(true);
+    setSections([]);
+    setError(null);
+    setBroadcastEnabled(false);
+    debugLogger.log(`Article selected: ${article.title} (${article.id})`);
+
+    const { data, error: fetchError } = await fetchArticleSections(article.id);
+    if (fetchError) {
+      logger.error(`Failed to fetch sections for article ${article.id}:`, fetchError);
+      setError("Не удалось загрузить секции статьи.");
+      setIsLoadingSections(false);
+      return;
+    }
+
+    const sortedSections = (data || []).sort((a, b) => a.section_order - b.section_order);
+    setSections(sortedSections);
+    debugLogger.log(`Loaded ${sortedSections.length || 0} sections for article ${article.id}.`);
+
+    if (userMetadata?.advice_broadcast?.enabled && userMetadata.advice_broadcast.article_id === article.id) {
+        setBroadcastEnabled(true);
+        debugLogger.log(`Broadcast is currently ACTIVE for selected article ${article.id}`);
+    } else {
         setBroadcastEnabled(false);
-    }, []);
+        debugLogger.log(`Broadcast is currently INACTIVE for selected article ${article.id}`);
+    }
+    setIsLoadingSections(false);
+  }, [userMetadata]);
 
-    useEffect(() => {
-        if (!webApp) return;
-        const backButtonClickHandler = () => { handleGoBack(); };
-        if (selectedArticle) {
-            webApp.BackButton?.show();
-            webApp.BackButton?.onClick(backButtonClickHandler);
-        } else {
-            webApp.BackButton?.offClick(backButtonClickHandler);
-            webApp.BackButton?.hide();
-        }
-        return () => {
-            if (webApp.BackButton?.isVisible) {
-                webApp.BackButton?.offClick(backButtonClickHandler);
-                webApp.BackButton?.hide();
-            }
-        };
-    }, [webApp, selectedArticle, handleGoBack]);
-
-    // --- Render Logic ---
-    // .. Simplify global loading check: show if auth isn't done or metadata isn't loaded
-    const showGlobalLoading = isAuthLoading || userMetadata === null;
-
-    if (showGlobalLoading) {
-        return (
-            <div className="flex justify-center items-center h-screen pt-36 bg-black">
-                <FontAwesomeIcon icon={faSpinner} spin size="3x" className="text-brand-green" />
-            </div>
-        );
+  // --- Broadcast Logic ---
+  const handleToggleBroadcast = async () => {
+    if (!userId || !selectedArticle || isUpdatingBroadcast || userMetadata === null) {
+        debugLogger.warn("handleToggleBroadcast skipped: Missing userId, selectedArticle, updating, or metadata not loaded.");
+        if (userMetadata === null) setError("Настройки пользователя еще не загружены.");
+        return;
+    }
+     if (sections.length === 0 && !broadcastEnabled) {
+        webApp?.showPopup({title: "Нет разделов", message: "В этой статье нет разделов для рассылки.", buttons: [{type: 'ok'}]});
+        setError("В этой статье нет секций для рассылки.");
+        return;
     }
 
-    if (!isAuthenticated) {
-        // This should ideally be caught by a higher-level auth guard
-        return (
-            <div className="p-6 pt-32 text-center text-brand-pink">
-                <FontAwesomeIcon icon={faTriangleExclamation} size="2x" className="mb-2" />
-                <p className="font-semibold text-xl">Ошибка Авторизации</p>
-                <p className="text-gray-400">{error || "Не удалось подтвердить пользователя. Попробуйте перезапустить приложение."}</p>
-            </div>
-        );
+    setIsUpdatingBroadcast(true);
+    setError(null);
+    let newMetadata: UserMetadata;
+    let successMessage: string;
+    const currentlyEnabled = broadcastEnabled;
+    debugLogger.log(`Toggling broadcast. Currently enabled (state): ${currentlyEnabled}`);
+
+    if (currentlyEnabled) {
+      // Disable
+      const { advice_broadcast, ...restMetadata } = userMetadata;
+      newMetadata = restMetadata;
+      successMessage = "Рассылка советов отключена.";
+      debugLogger.log(`Disabling broadcast for article ${selectedArticle.id}`);
+    } else {
+      // Enable
+      const sortedSectionIds = sections.map(s => s.id);
+      if (sortedSectionIds.length === 0) {
+          setError("В этой статье нет секций для рассылки.");
+          setIsUpdatingBroadcast(false);
+          return;
+      }
+      newMetadata = {
+        ...userMetadata,
+        advice_broadcast: {
+          enabled: true,
+          article_id: selectedArticle.id,
+          remaining_section_ids: sortedSectionIds,
+        },
+      };
+      successMessage = "Рассылка советов включена! Ожидайте первый выпуск.";
+      debugLogger.log(`Enabling broadcast for article ${selectedArticle.id} with sections:`, sortedSectionIds);
     }
 
-    // Show error related to article loading only if in list view and loading is finished
-    if (error && !selectedArticle && !isLoadingArticles) {
-        return (
-            <div className="p-6 pt-32 text-center text-brand-pink bg-black/50 rounded-lg shadow-lg border border-brand-pink/30 mx-4">
-                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-2 text-2xl" />
-                <p className="font-semibold text-xl mt-2">Ошибка загрузки данных</p>
-                <p className="text-gray-400 mt-1">{error}</p>
-            </div>
-        );
+    // Update DB
+    const { success, error: updateError, data: updatedUserData } = await updateUserMetadata(userId, newMetadata);
+    if (success && updatedUserData) {
+      setUserMetadata(updatedUserData.metadata as UserMetadata | null ?? {});
+      setBroadcastEnabled(!currentlyEnabled);
+      webApp?.showPopup({title: "Успех", message: successMessage, buttons: [{type: 'ok'}]});
+      debugLogger.log("Metadata update successful.");
+    } else {
+      logger.error("Failed to update user metadata for broadcast:", updateError);
+      const actionText = currentlyEnabled ? 'отключить' : 'включить';
+      const errorMsg = `Не удалось ${actionText} рассылку: ${updateError?.message || 'Неизвестная ошибка'}`;
+      setError(errorMsg);
+      webApp?.showPopup({title: "Ошибка", message: errorMsg, buttons: [{type: 'ok'}]});
     }
+    setIsUpdatingBroadcast(false);
+  };
 
+  // --- Navigation & UI ---
+  const handleGoBack = useCallback(() => {
+    setSelectedArticle(null);
+    setSections([]);
+    setError(null);
+    setBroadcastEnabled(false);
+  }, []);
+
+  useEffect(() => {
+    if (!webApp) return;
+    const backButtonClickHandler = () => { handleGoBack(); };
+    if (selectedArticle) {
+      webApp.BackButton?.show();
+      webApp.BackButton?.onClick(backButtonClickHandler);
+    } else {
+      webApp.BackButton?.offClick(backButtonClickHandler);
+      webApp.BackButton?.hide();
+    }
+    return () => {
+      if (webApp.BackButton?.isVisible) {
+          webApp.BackButton?.offClick(backButtonClickHandler);
+          webApp.BackButton?.hide();
+      }
+    };
+  }, [webApp, selectedArticle, handleGoBack]);
+
+  // --- Render Logic ---
+  const showGlobalLoading = isAuthLoading || userMetadata === null;
+
+  if (showGlobalLoading) {
     return (
-        <div className={cn(
-            "min-h-screen pt-36 pb-10 font-mono",
-            "bg-gradient-to-br from-gray-900 via-black to-gray-800 text-gray-200"
-        )}>
-            <div className="relative z-10 container mx-auto px-4 max-w-4xl">
-                {!selectedArticle ? (
-                    // --- Articles List View ---
-                    <div className="space-y-6">
-                        <h1 className="text-3xl md:text-4xl font-bold text-center text-brand-green cyber-text glitch" data-text="Мудрые Советы">
-                            Мудрые Советы
-                        </h1>
-                        {/* Display loading spinner specifically for articles if needed */}
-                        {isLoadingArticles ? (
-                             <div className="flex justify-center items-center pt-16">
-                                 <FontAwesomeIcon icon={faSpinner} spin size="2x" className="text-brand-blue" />
-                             </div>
-                         ) : articles.length === 0 ? (
-                            <p className="text-center text-gray-500 dark:text-gray-400 mt-10 text-lg">Пока нет доступных статей.</p>
-                        ) : (
-                            <ul className="space-y-4">
-                                {articles.map((article) => (
-                                    <li key={article.id}>
-                                        <button
-                                            onClick={() => handleSelectArticle(article)}
-                                            className={cn(
-                                                "w-full text-left p-4 md:p-5 rounded-lg transition duration-300 ease-in-out",
-                                                "bg-black/60 backdrop-blur-sm border border-brand-blue/30 hover:border-brand-blue/70",
-                                                "shadow-md hover:shadow-lg hover:shadow-brand-blue/30 focus:outline-none focus:ring-2 focus:ring-brand-blue focus:ring-opacity-50"
-                                            )}
-                                        >
-                                            <h2 className="text-lg md:text-xl font-semibold text-brand-blue flex items-center">
-                                                <FontAwesomeIcon icon={faBookOpen} className="mr-3 text-brand-blue/70 w-5 h-5" />
-                                                {article.title}
-                                            </h2>
-                                            {article.description && (
-                                                <p className="text-sm md:text-base text-gray-400 mt-1 ml-8">{article.description}</p>
-                                            )}
-                                        </button>
-                                    </li>
-                                ))}
-                            </ul>
-                        )}
-                    </div>
-                ) : (
-                    // --- Single Article View ---
-                    <div>
-                        <h1 className="text-3xl md:text-4xl font-bold mb-3 text-brand-green cyber-text">{selectedArticle.title}</h1>
-                        {selectedArticle.description && (
-                            <p className="text-base md:text-lg text-gray-400 mb-6 italic">{selectedArticle.description}</p>
-                        )}
-
-                        {isLoadingSections ? (
-                            <div className="flex justify-center items-center py-16">
-                                <FontAwesomeIcon icon={faSpinner} spin size="3x" className="text-brand-blue" />
-                            </div>
-                        ) : error && sections.length === 0 ? ( // Show section-specific error
-                            <div className="p-4 my-6 text-brand-pink bg-pink-900/20 border border-brand-pink/40 rounded-lg shadow-md text-center">
-                                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-2 text-xl" />
-                                <p className="mt-1">{error}</p>
-                            </div>
-                        ) : (
-                            // --- Sections Loaded ---
-                            <div>
-                                {/* "Entertain Me" Button Area */}
-                                {userId && sections.length > 0 && (
-                                    <div className="my-8 p-5 bg-gradient-to-r from-blue-900/30 via-purple-900/20 to-blue-900/30 border border-brand-purple/40 rounded-lg shadow-lg text-center">
-                                        <h3 className="text-xl font-semibold mb-3 flex items-center justify-center text-brand-purple">
-                                            <FontAwesomeIcon icon={faTelegram} className="mr-2 text-brand-blue" />
-                                            Часовая Рассылка
-                                        </h3>
-                                        <p className="text-sm text-gray-300 mb-4">
-                                            {broadcastEnabled
-                                                ? "Получайте по одному разделу этой статьи каждый час прямо в Telegram!"
-                                                : "Хотите получать эту мудрость порционно? Включите часовую рассылку!"}
-                                        </p>
-                                        <button
-                                            onClick={handleToggleBroadcast}
-                                            disabled={isUpdatingBroadcast}
-                                            className={cn(
-                                                "w-full sm:w-auto inline-flex items-center justify-center px-6 py-3 rounded-md font-semibold transition duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black space-x-2 shadow-md",
-                                                isUpdatingBroadcast
-                                                    ? 'bg-gray-600 cursor-not-allowed text-gray-400'
-                                                    : broadcastEnabled
-                                                        ? 'bg-red-600 hover:bg-red-700 text-white focus:ring-red-500 shadow-red-500/30 hover:shadow-red-500/50'
-                                                        : 'bg-green-600 hover:bg-green-700 text-white focus:ring-green-500 shadow-green-500/30 hover:shadow-green-500/50'
-                                            )}
-                                        >
-                                            {isUpdatingBroadcast ? (<FontAwesomeIcon icon={faSpinner} spin />)
-                                                : broadcastEnabled ? (<FontAwesomeIcon icon={faStopCircle} />)
-                                                    : (<FontAwesomeIcon icon={faPaperPlane} />)}
-                                            <span>
-                                                {isUpdatingBroadcast ? 'Обновление...' : broadcastEnabled ? 'Отключить рассылку' : 'Развлеки меня'}
-                                            </span>
-                                        </button>
-                                        {broadcastEnabled && !isUpdatingBroadcast && (
-                                            <p className="text-xs text-brand-green mt-3 flex items-center justify-center">
-                                                <FontAwesomeIcon icon={faCheckCircle} className="mr-1" /> Рассылка активна для этой статьи.
-                                            </p>
-                                        )}
-                                        {error && !isUpdatingBroadcast && !isLoadingSections && ( // Show error only if NOT updating/loading
-                                            <p className="text-xs text-brand-pink mt-2">{error}</p>
-                                        )}
-                                    </div>
-                                )}
-
-                                {/* Sections Content */}
-                                <h2 className="text-2xl font-semibold mt-8 mb-4 border-b border-brand-blue/30 pb-2 text-brand-blue">Содержание:</h2>
-                                {sections.length === 0 && !isLoadingSections ? (
-                                    <p className="text-gray-500">В этой статье пока нет секций.</p>
-                                ) : (
-                                    <div className="space-y-6">
-                                        {sections.map((section) => (
-                                            <div key={section.id} className={cn(
-                                                "p-5 border rounded-lg transition-shadow duration-300",
-                                                "bg-black/50 border-gray-700/50 hover:border-brand-green/50 hover:shadow-md hover:shadow-brand-green/20"
-                                            )}>
-                                                {section.title && (
-                                                    <h3 className="text-lg font-semibold mb-2 text-brand-green flex items-baseline">
-                                                        <span className="text-brand-blue mr-2">{section.section_order}.</span> {section.title}
-                                                    </h3>
-                                                )}
-                                                <ReactMarkdown
-                                                    // <-- Add remarkBreaks plugin here
-                                                    remarkPlugins={[remarkGfm, remarkBreaks]}
-                                                    className="prose prose-invert prose-sm md:prose-base max-w-none text-gray-300 prose-headings:text-brand-cyan prose-strong:text-brand-lime prose-a:text-brand-blue hover:prose-a:text-brand-purple prose-code:text-brand-pink prose-code:before:content-none prose-code:after:content-none prose-blockquote:border-brand-purple prose-li:marker:text-brand-blue" // Added list item marker color
-                                                    components={{
-                                                        a: ({ node, ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" className="hover:underline" />,
-                                                        // .. Ensure lists are styled correctly by prose or add specific list styling if needed
-                                                        ul: ({node, ...props}) => <ul {...props} className="list-disc list-outside ml-4" />,
-                                                        ol: ({node, ...props}) => <ol {...props} className="list-decimal list-outside ml-4" />,
-                                                        li: ({node, ...props}) => <li {...props} className="my-1" />, // Minor spacing for list items
-                                                    }}
-                                                >
-                                                    {section.content ?? ''}
-                                                    {/* Use empty string fallback */}
-                                                </ReactMarkdown>
-                                            </div>
-                                        ))}
-                                    </div>
-                                )}
-                            </div>
-                        )}
-                    </div>
-                )}
-            </div>
-        </div>
+      <div className="flex justify-center items-center h-screen pt-36 bg-black">
+        <FontAwesomeIcon icon={faSpinner} spin size="3x" className="text-brand-green" />
+      </div>
     );
+  }
+
+   if (!isAuthenticated) {
+     return (
+       <div className="p-6 pt-32 text-center text-brand-pink">
+         <FontAwesomeIcon icon={faTriangleExclamation} size="2x" className="mb-2" />
+         <p className="font-semibold text-xl">Ошибка Авторизации</p>
+         <p className="text-gray-400">{error || "Не удалось подтвердить пользователя. Попробуйте перезапустить приложение."}</p>
+       </div>
+     );
+  }
+
+  if (error && !selectedArticle && !isLoadingArticles) {
+    return (
+       <div className="p-6 pt-32 text-center text-brand-pink bg-black/50 rounded-lg shadow-lg border border-brand-pink/30 mx-4">
+         <FontAwesomeIcon icon={faTriangleExclamation} className="mr-2 text-2xl" />
+         <p className="font-semibold text-xl mt-2">Ошибка загрузки данных</p>
+         <p className="text-gray-400 mt-1">{error}</p>
+       </div>
+     );
+  }
+
+  return (
+    <div className={cn(
+        "min-h-screen pt-36 pb-10 font-mono",
+        "bg-gradient-to-br from-gray-900 via-black to-gray-800 text-gray-200"
+    )}>
+      <div className="relative z-10 container mx-auto px-4 max-w-4xl">
+        {!selectedArticle ? (
+          // Articles List View
+          <div className="space-y-6">
+            <h1 className="text-3xl md:text-4xl font-bold text-center text-brand-green cyber-text glitch" data-text="Мудрые Советы">
+                Мудрые Советы
+            </h1>
+            {isLoadingArticles ? (
+                 <div className="flex justify-center items-center pt-16">
+                     <FontAwesomeIcon icon={faSpinner} spin size="2x" className="text-brand-blue" />
+                 </div>
+             ) : articles.length === 0 ? (
+               <p className="text-center text-gray-500 dark:text-gray-400 mt-10 text-lg">Пока нет доступных статей.</p>
+            ) : (
+              <ul className="space-y-4">
+                {articles.map((article) => (
+                  <li key={article.id}>
+                    <button
+                      onClick={() => handleSelectArticle(article)}
+                      className={cn(
+                          "w-full text-left p-4 md:p-5 rounded-lg transition duration-300 ease-in-out",
+                          "bg-black/60 backdrop-blur-sm border border-brand-blue/30 hover:border-brand-blue/70",
+                          "shadow-md hover:shadow-lg hover:shadow-brand-blue/30 focus:outline-none focus:ring-2 focus:ring-brand-blue focus:ring-opacity-50"
+                      )}
+                    >
+                      <h2 className="text-lg md:text-xl font-semibold text-brand-blue flex items-center">
+                         <FontAwesomeIcon icon={faBookOpen} className="mr-3 text-brand-blue/70 w-5 h-5" />
+                         {article.title}
+                      </h2>
+                      {article.description && (
+                        <p className="text-sm md:text-base text-gray-400 mt-1 ml-8">{article.description}</p>
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ) : (
+          // Single Article View
+          <div>
+             <h1 className="text-3xl md:text-4xl font-bold mb-3 text-brand-green cyber-text">{selectedArticle.title}</h1>
+            {selectedArticle.description && (
+              <p className="text-base md:text-lg text-gray-400 mb-6 italic">{selectedArticle.description}</p>
+            )}
+
+            {isLoadingSections ? (
+               <div className="flex justify-center items-center py-16">
+                 <FontAwesomeIcon icon={faSpinner} spin size="3x" className="text-brand-blue"/>
+               </div>
+            ) : error && sections.length === 0 ? (
+               <div className="p-4 my-6 text-brand-pink bg-pink-900/20 border border-brand-pink/40 rounded-lg shadow-md text-center">
+                  <FontAwesomeIcon icon={faTriangleExclamation} className="mr-2 text-xl" />
+                  <p className="mt-1">{error}</p>
+               </div>
+            ) : (
+              <div>
+                 {userId && sections.length > 0 && (
+                  <div className="my-8 p-5 bg-gradient-to-r from-blue-900/30 via-purple-900/20 to-blue-900/30 border border-brand-purple/40 rounded-lg shadow-lg text-center">
+                    <h3 className="text-xl font-semibold mb-3 flex items-center justify-center text-brand-purple">
+                        <FontAwesomeIcon icon={faTelegram} className="mr-2 text-brand-blue" />
+                        Часовая Рассылка
+                    </h3>
+                     <p className="text-sm text-gray-300 mb-4">
+                         {broadcastEnabled
+                           ? "Получайте по одному разделу этой статьи каждый час прямо в Telegram!"
+                           : "Хотите получать эту мудрость порционно? Включите часовую рассылку!"}
+                     </p>
+                    <button
+                      onClick={handleToggleBroadcast}
+                      disabled={isUpdatingBroadcast}
+                      className={cn(
+                          "w-full sm:w-auto inline-flex items-center justify-center px-6 py-3 rounded-md font-semibold transition duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black space-x-2 shadow-md",
+                          isUpdatingBroadcast
+                            ? 'bg-gray-600 cursor-not-allowed text-gray-400'
+                            : broadcastEnabled
+                              ? 'bg-red-600 hover:bg-red-700 text-white focus:ring-red-500 shadow-red-500/30 hover:shadow-red-500/50'
+                              : 'bg-green-600 hover:bg-green-700 text-white focus:ring-green-500 shadow-green-500/30 hover:shadow-green-500/50'
+                      )}
+                    >
+                      {isUpdatingBroadcast ? (<FontAwesomeIcon icon={faSpinner} spin />)
+                       : broadcastEnabled ? (<FontAwesomeIcon icon={faStopCircle} />)
+                       : (<FontAwesomeIcon icon={faPaperPlane} />)}
+                      <span>
+                        {isUpdatingBroadcast ? 'Обновление...' : broadcastEnabled ? 'Отключить рассылку' : 'Развлеки меня'}
+                      </span>
+                    </button>
+                    {broadcastEnabled && !isUpdatingBroadcast && (
+                       <p className="text-xs text-brand-green mt-3 flex items-center justify-center">
+                         <FontAwesomeIcon icon={faCheckCircle} className="mr-1" /> Рассылка активна для этой статьи.
+                       </p>
+                     )}
+                     {error && !isUpdatingBroadcast && !isLoadingSections && (
+                          <p className="text-xs text-brand-pink mt-2">{error}</p>
+                      )}
+                   </div>
+                 )}
+
+                {/* Sections Content */}
+                <h2 className="text-2xl font-semibold mt-8 mb-4 border-b border-brand-blue/30 pb-2 text-brand-blue">Содержание:</h2>
+                {sections.length === 0 && !isLoadingSections && !error ? (
+                  <p className="text-gray-500">В этой статье пока нет секций.</p>
+                ) : (
+                  <div className="space-y-6">
+                    {sections.map((section) => (
+                      <div key={section.id} className={cn(
+                          "p-5 border rounded-lg transition-shadow duration-300",
+                          "bg-black/50 border-gray-700/50 hover:border-brand-green/50 hover:shadow-md hover:shadow-brand-green/20"
+                      )}>
+                        {section.title && (
+                          <h3 className="text-lg font-semibold mb-2 text-brand-green flex items-baseline">
+                             <span className="text-brand-blue mr-2">{section.section_order}.</span> {section.title}
+                          </h3>
+                        )}
+                         {/* --- Use ReactMarkdown with CSS for newlines --- */}
+                         <ReactMarkdown
+                              remarkPlugins={[remarkGfm]} // GFM handles most things, including basic lists
+                              // Apply Tailwind Typography AND white-space: pre-line
+                              // Updated Prose classes for better list styling
+                              className={cn(
+                                  "prose prose-invert prose-sm md:prose-base max-w-none text-gray-300",
+                                  "prose-headings:text-brand-cyan prose-strong:text-brand-lime",
+                                  "prose-a:text-brand-blue hover:prose-a:text-brand-purple prose-a:transition-colors",
+                                  "prose-code:text-brand-pink prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:bg-gray-700/50 prose-code:px-1 prose-code:py-0.5 prose-code:rounded",
+                                  "prose-blockquote:border-brand-purple prose-blockquote:text-gray-400",
+                                  "prose-ul:list-disc prose-ol:list-decimal prose-li:marker:text-brand-blue", // Ensure list style type
+                                  "prose-ul:pl-5 prose-ol:pl-5 prose-li:my-1.5", // Indentation and spacing for lists
+                                  "whitespace-pre-line" // <-- Add this class to handle \n as line breaks
+                              )}
+                              components={{
+                                  a: ({node, ...props}) => <a {...props} target="_blank" rel="noopener noreferrer" className="hover:underline" />,
+                                  // Custom component for list items if needed for extra styling/logic
+                                  // li: ({node, ordered, ...props}) => <li className="my-1" {...props} />,
+                              }}
+                          >
+                             {section.content ?? ''}
+                          </ReactMarkdown>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/app/advice/page.tsx
+++ b/app/advice/page.tsx
@@ -1,18 +1,18 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
-import { useAppContext } from "@/contexts/AppContext"; // Use AppContext
+import { useAppContext } from "@/contexts/AppContext";
 import { fetchArticles, fetchArticleSections, updateUserMetadata, fetchUserData } from "@/hooks/supabase";
 import type { Database } from "@/types/database.types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBookOpen, faArrowLeft, faSpinner, faCheckCircle, faStopCircle, faPaperPlane, faTriangleExclamation } from "@fortawesome/free-solid-svg-icons"; // fa6 solid icons
-import { faTelegram } from "@fortawesome/free-brands-svg-icons"; // fa6 Brand icon
+import { faBookOpen, faArrowLeft, faSpinner, faCheckCircle, faStopCircle, faPaperPlane, faTriangleExclamation } from "@fortawesome/free-solid-svg-icons";
+import { faTelegram } from "@fortawesome/free-brands-svg-icons";
 import { logger } from "@/lib/logger";
 import { debugLogger } from "@/lib/debugLogger";
-import { cn } from "@/lib/utils"; // For class names
-import ReactMarkdown from 'react-markdown'; // <-- Import react-markdown
-import remarkGfm from 'remark-gfm'; // <-- Import remark-gfm for GitHub Flavored Markdown support (tables, etc.)
-
+import { cn } from "@/lib/utils";
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks'; // <-- Import remark-breaks
 // Define types based on your database schema
 type Article = Database["public"]["Tables"]["articles"]["Row"];
 type ArticleSection = Database["public"]["Tables"]["article_sections"]["Row"];
@@ -28,374 +28,374 @@ type UserMetadata = {
   // Potentially other metadata fields unrelated to advice
 };
 
+
 export default function AdvicePage() {
-  const { user: tgUser, tg: webApp, dbUser, isLoading: isAuthLoading, isAuthenticated } = useAppContext();
-  const [articles, setArticles] = useState<Article[]>([]);
-  const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
-  const [sections, setSections] = useState<ArticleSection[]>([]);
-  const [isLoadingArticles, setIsLoadingArticles] = useState(true); // Loading state for articles specifically
-  const [isLoadingSections, setIsLoadingSections] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [broadcastEnabled, setBroadcastEnabled] = useState(false); // Is broadcast active *for the selected article*?
-  const [isUpdatingBroadcast, setIsUpdatingBroadcast] = useState(false);
-  const [userMetadata, setUserMetadata] = useState<UserMetadata | null>(null); // Store the entire user metadata
+    const { user: tgUser, tg: webApp, dbUser, isLoading: isAuthLoading, isAuthenticated } = useAppContext();
+    const [articles, setArticles] = useState<Article[]>([]);
+    const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
+    const [sections, setSections] = useState<ArticleSection[]>([]);
+    const [isLoadingArticles, setIsLoadingArticles] = useState(true);
+    const [isLoadingSections, setIsLoadingSections] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [broadcastEnabled, setBroadcastEnabled] = useState(false);
+    const [isUpdatingBroadcast, setIsUpdatingBroadcast] = useState(false);
+    const [userMetadata, setUserMetadata] = useState<UserMetadata | null>(null);
 
-  const userId = dbUser?.user_id || tgUser?.id?.toString();
+    const userId = dbUser?.user_id || tgUser?.id?.toString();
 
-  // --- Data Fetching ---
-  useEffect(() => {
-    const loadInitialMetadata = async () => {
-      if (!userId) {
-        debugLogger.log("loadInitialMetadata skipped: no userId");
-        setUserMetadata({});
-        return;
-      };
-      try {
-        debugLogger.log(`loadInitialMetadata fetching for userId: ${userId}`);
-        const userData = await fetchUserData(userId);
-        const metadata = userData?.metadata as UserMetadata | null;
-        setUserMetadata(metadata ?? {});
-        debugLogger.log("Initial user metadata loaded:", metadata);
-      } catch (err) {
-        logger.error("Failed to load initial user metadata:", err);
-        setError("Не удалось загрузить настройки пользователя.");
-        setIsLoadingArticles(false); // Ensure loading stops on error
-      }
+    // --- Data Fetching ---
+    useEffect(() => {
+        const loadInitialMetadata = async () => {
+            if (!userId) {
+                debugLogger.log("loadInitialMetadata skipped: no userId");
+                setUserMetadata({}); // Set to empty object if no user ID
+                return;
+            };
+            // No need to set loading state here, handled by userMetadata === null check
+            try {
+                debugLogger.log(`loadInitialMetadata fetching for userId: ${userId}`);
+                const userData = await fetchUserData(userId);
+                const metadata = userData?.metadata as UserMetadata | null;
+                setUserMetadata(metadata ?? {}); // Use loaded metadata or empty object
+                debugLogger.log("Initial user metadata loaded:", metadata);
+            } catch (err) {
+                logger.error("Failed to load initial user metadata:", err);
+                setError("Не удалось загрузить настройки пользователя.");
+                setUserMetadata({}); // Set empty object on error to allow article loading attempt
+            }
+        };
+        if (!isAuthLoading) { // Only run after auth check is complete
+           loadInitialMetadata();
+        }
+    }, [userId, isAuthLoading]);
+
+    useEffect(() => {
+        const loadArticles = async () => {
+            setIsLoadingArticles(true);
+            setError(null);
+            debugLogger.log("Starting to load articles...");
+            const { data, error: fetchError } = await fetchArticles();
+            if (fetchError) {
+                logger.error("Failed to fetch articles:", fetchError);
+                setError("Не удалось загрузить список статей.");
+            } else {
+                setArticles(data || []);
+                debugLogger.log(`Loaded ${data?.length || 0} articles.`);
+            }
+            setIsLoadingArticles(false);
+        };
+        // Load articles only when metadata loading is done (userMetadata is not null)
+        if (userMetadata !== null) {
+            loadArticles();
+        } else if (!isAuthLoading && userMetadata === null) {
+            // This case might indicate an error during metadata load or just initial state
+            // Let the global loading spinner handle this until metadata is resolved or errors out
+             debugLogger.log("Waiting for userMetadata before loading articles...");
+        }
+    }, [userMetadata, isAuthLoading]); // Depend on metadata and auth loading status
+
+    const handleSelectArticle = useCallback(async (article: Article) => {
+        setSelectedArticle(article);
+        setIsLoadingSections(true);
+        setSections([]);
+        setError(null);
+        setBroadcastEnabled(false);
+        debugLogger.log(`Article selected: ${article.title} (${article.id})`);
+
+        if (!userMetadata) {
+             debugLogger.warn(`Cannot check broadcast status for ${article.id}: userMetadata not loaded yet.`);
+             // Optionally set an error or just wait? Let's wait for metadata.
+        }
+
+        const { data, error: fetchError } = await fetchArticleSections(article.id);
+        if (fetchError) {
+            logger.error(`Failed to fetch sections for article ${article.id}:`, fetchError);
+            setError("Не удалось загрузить секции статьи.");
+        } else {
+            const sortedSections = (data || []).sort((a, b) => a.section_order - b.section_order);
+            setSections(sortedSections);
+            debugLogger.log(`Loaded ${sortedSections.length || 0} sections for article ${article.id}.`);
+            // Check broadcast status *after* sections are loaded, using the most recent metadata
+            if (userMetadata?.advice_broadcast?.enabled && userMetadata.advice_broadcast.article_id === article.id) {
+                setBroadcastEnabled(true);
+                debugLogger.log(`Broadcast is currently ACTIVE for selected article ${article.id}`);
+            } else {
+                setBroadcastEnabled(false);
+                debugLogger.log(`Broadcast is currently INACTIVE for selected article ${article.id}`);
+            }
+        }
+        setIsLoadingSections(false);
+    }, [userMetadata]); // Added userMetadata dependency
+
+    // --- Broadcast Logic ---
+    const handleToggleBroadcast = async () => {
+        if (!userId || !selectedArticle || isUpdatingBroadcast || userMetadata === null) { // Also check if metadata is loaded
+            debugLogger.warn("handleToggleBroadcast skipped: Missing userId, selectedArticle, updating, or metadata not loaded.");
+            if (userMetadata === null) setError("Настройки пользователя еще не загружены.");
+            return;
+        }
+         if (sections.length === 0 && !broadcastEnabled) {
+            webApp?.showPopup({title: "Нет разделов", message: "В этой статье нет разделов для рассылки.", buttons: [{type: 'ok'}]});
+            setError("В этой статье нет секций для рассылки.");
+            return;
+        }
+
+        setIsUpdatingBroadcast(true);
+        setError(null);
+        let newMetadata: UserMetadata;
+        let successMessage: string;
+        const currentlyEnabled = broadcastEnabled; // Use component state derived from metadata
+        debugLogger.log(`Toggling broadcast. Currently enabled (state): ${currentlyEnabled}`);
+
+        if (currentlyEnabled) {
+            // --- Disable ---
+            const { advice_broadcast, ...restMetadata } = userMetadata; // Destructure from loaded metadata
+            newMetadata = restMetadata;
+            successMessage = "Рассылка советов отключена.";
+            debugLogger.log(`Disabling broadcast for article ${selectedArticle.id}`);
+        } else {
+            // --- Enable ---
+            const sortedSectionIds = sections.map(s => s.id);
+            if (sortedSectionIds.length === 0) {
+                setError("В этой статье нет секций для рассылки.");
+                setIsUpdatingBroadcast(false);
+                return;
+            }
+            newMetadata = {
+                ...userMetadata, // Spread current metadata first
+                advice_broadcast: {
+                    enabled: true,
+                    article_id: selectedArticle.id,
+                    remaining_section_ids: sortedSectionIds,
+                },
+            };
+            successMessage = "Рассылка советов включена! Ожидайте первый выпуск.";
+            debugLogger.log(`Enabling broadcast for article ${selectedArticle.id} with sections:`, sortedSectionIds);
+        }
+
+        // --- Update DB ---
+        const { success, error: updateError, data: updatedUserData } = await updateUserMetadata(userId, newMetadata);
+        if (success && updatedUserData) {
+            setUserMetadata(updatedUserData.metadata as UserMetadata | null ?? {});
+            setBroadcastEnabled(!currentlyEnabled);
+            webApp?.showPopup({title: "Успех", message: successMessage, buttons: [{type: 'ok'}]});
+            debugLogger.log("Metadata update successful.");
+        } else {
+            logger.error("Failed to update user metadata for broadcast:", updateError);
+            const actionText = currentlyEnabled ? 'отключить' : 'включить';
+            const errorMsg = `Не удалось ${actionText} рассылку: ${updateError?.message || 'Неизвестная ошибка'}`; // Include error message
+            setError(errorMsg);
+            webApp?.showPopup({title: "Ошибка", message: errorMsg, buttons: [{type: 'ok'}]});
+        }
+        setIsUpdatingBroadcast(false);
     };
-    if (!isAuthLoading && userId) { // Trigger only when auth is done and userId is available
-      loadInitialMetadata();
-    } else if (!isAuthLoading && !userId) {
-      // Handle case where user is authenticated but ID is missing (unlikely with AppContext logic)
-      setUserMetadata({});
-      debugLogger.warn("loadInitialMetadata skipped: Auth done but no userId found.");
-    }
-  }, [userId, isAuthLoading]);
 
-  useEffect(() => {
-    const loadArticles = async () => {
-      setIsLoadingArticles(true);
-      setError(null);
-      const { data, error: fetchError } = await fetchArticles();
-      if (fetchError) {
-        logger.error("Failed to fetch articles:", fetchError);
-        setError("Не удалось загрузить список статей.");
-      } else {
-        setArticles(data || []);
-        debugLogger.log(`Loaded ${data?.length || 0} articles.`);
-      }
-      setIsLoadingArticles(false);
-    };
-    // .. Load articles only after metadata is loaded (or determined to be empty)
-    if (userMetadata !== null) {
-        loadArticles();
-    } else if (!isAuthLoading && userMetadata === null) {
-        // This condition means metadata loading failed before
-        setIsLoadingArticles(false);
-        setError("Не удалось загрузить статьи из-за ошибки загрузки настроек.");
-        debugLogger.error("Article loading skipped due to previous metadata loading error.");
-    }
-  }, [userMetadata, isAuthLoading]); // Depend on metadata and auth loading status
+    // --- Navigation & UI ---
+    const handleGoBack = useCallback(() => {
+        setSelectedArticle(null);
+        setSections([]);
+        setError(null);
+        setBroadcastEnabled(false);
+    }, []);
 
-  const handleSelectArticle = useCallback(async (article: Article) => {
-    setSelectedArticle(article);
-    setIsLoadingSections(true);
-    setSections([]);
-    setError(null); // Clear previous section errors
-    setBroadcastEnabled(false); // Reset broadcast status for the new article
-    debugLogger.log(`Article selected: ${article.title} (${article.id})`);
-    const { data, error: fetchError } = await fetchArticleSections(article.id);
-    if (fetchError) {
-      logger.error(`Failed to fetch sections for article ${article.id}:`, fetchError);
-      setError("Не удалось загрузить секции статьи."); // Set error for section loading
-    } else {
-      const sortedSections = (data || []).sort((a, b) => a.section_order - b.section_order);
-      setSections(sortedSections);
-      debugLogger.log(`Loaded ${sortedSections.length || 0} sections for article ${article.id}.`);
-      // .. Check broadcast status *against the loaded userMetadata*
-      if (userMetadata?.advice_broadcast?.enabled && userMetadata.advice_broadcast.article_id === article.id) {
-          setBroadcastEnabled(true);
-          debugLogger.log(`Broadcast is currently ACTIVE for selected article ${article.id}`);
-      } else {
-          setBroadcastEnabled(false);
-          debugLogger.log(`Broadcast is currently INACTIVE for selected article ${article.id}`);
-      }
-    }
-    setIsLoadingSections(false);
-  }, [userMetadata]); // Depend on userMetadata to correctly check broadcast status
+    useEffect(() => {
+        if (!webApp) return;
+        const backButtonClickHandler = () => { handleGoBack(); };
+        if (selectedArticle) {
+            webApp.BackButton?.show();
+            webApp.BackButton?.onClick(backButtonClickHandler);
+        } else {
+            webApp.BackButton?.offClick(backButtonClickHandler);
+            webApp.BackButton?.hide();
+        }
+        return () => {
+            if (webApp.BackButton?.isVisible) {
+                webApp.BackButton?.offClick(backButtonClickHandler);
+                webApp.BackButton?.hide();
+            }
+        };
+    }, [webApp, selectedArticle, handleGoBack]);
 
+    // --- Render Logic ---
+    // .. Simplify global loading check: show if auth isn't done or metadata isn't loaded
+    const showGlobalLoading = isAuthLoading || userMetadata === null;
 
-  // --- Broadcast Logic ---
-  const handleToggleBroadcast = async () => {
-    if (!userId || !selectedArticle || isUpdatingBroadcast) {
-        debugLogger.warn("handleToggleBroadcast skipped: Missing userId, selectedArticle, or already updating.");
-        return;
-    }
-     // .. Check sections *before* toggling state
-    if (sections.length === 0 && !broadcastEnabled) { // Prevent enabling if no sections
-        webApp?.showPopup({title: "Нет разделов", message: "В этой статье нет разделов для рассылки.", buttons: [{type: 'ok'}]});
-        setError("В этой статье нет секций для рассылки."); // Also show error locally
-        return;
+    if (showGlobalLoading) {
+        return (
+            <div className="flex justify-center items-center h-screen pt-36 bg-black">
+                <FontAwesomeIcon icon={faSpinner} spin size="3x" className="text-brand-green" />
+            </div>
+        );
     }
 
-    setIsUpdatingBroadcast(true);
-    setError(null); // Clear previous errors
-    let newMetadata: UserMetadata;
-    let successMessage: string;
-    // .. Read current broadcast state directly from component state (updated by handleSelectArticle)
-    const currentlyEnabled = broadcastEnabled;
-    debugLogger.log(`Toggling broadcast. Currently enabled (state): ${currentlyEnabled}`);
-
-    if (currentlyEnabled) {
-      // --- Disable ---
-      // .. Create new metadata object excluding the advice_broadcast part
-      const { advice_broadcast, ...restMetadata } = userMetadata || {}; // Use loaded metadata as base
-      newMetadata = restMetadata;
-      successMessage = "Рассылка советов отключена.";
-      debugLogger.log(`Disabling broadcast for article ${selectedArticle.id}`);
-    } else {
-      // --- Enable ---
-      const sortedSectionIds = sections.map(s => s.id);
-      if (sortedSectionIds.length === 0) {
-          // This check is technically redundant due to the check at the beginning, but safe to keep
-          setError("В этой статье нет секций для рассылки.");
-          setIsUpdatingBroadcast(false);
-          return;
-      }
-      newMetadata = {
-        ...userMetadata, // Use loaded metadata as base
-        advice_broadcast: {
-          enabled: true,
-          article_id: selectedArticle.id,
-          remaining_section_ids: sortedSectionIds,
-          // last_sent_at: undefined, // Optionally clear last sent time if needed by backend logic
-        },
-      };
-      successMessage = "Рассылка советов включена! Ожидайте первый выпуск.";
-      debugLogger.log(`Enabling broadcast for article ${selectedArticle.id} with sections:`, sortedSectionIds);
+    if (!isAuthenticated) {
+        // This should ideally be caught by a higher-level auth guard
+        return (
+            <div className="p-6 pt-32 text-center text-brand-pink">
+                <FontAwesomeIcon icon={faTriangleExclamation} size="2x" className="mb-2" />
+                <p className="font-semibold text-xl">Ошибка Авторизации</p>
+                <p className="text-gray-400">{error || "Не удалось подтвердить пользователя. Попробуйте перезапустить приложение."}</p>
+            </div>
+        );
     }
 
-    // --- Update DB ---
-    const { success, error: updateError, data: updatedUserData } = await updateUserMetadata(userId, newMetadata);
-    if (success && updatedUserData) {
-      setUserMetadata(updatedUserData.metadata as UserMetadata | null ?? {}); // Update local metadata state
-      setBroadcastEnabled(!currentlyEnabled); // Update local broadcast state *after* successful DB update
-      webApp?.showPopup({title: "Успех", message: successMessage, buttons: [{type: 'ok'}]});
-      debugLogger.log("Metadata update successful.");
-    } else {
-      logger.error("Failed to update user metadata for broadcast:", updateError);
-      const actionText = currentlyEnabled ? 'отключить' : 'включить';
-      const errorMsg = `Не удалось ${actionText} рассылку: ${updateError || 'Неизвестная ошибка'}`;
-      setError(errorMsg);
-      webApp?.showPopup({title: "Ошибка", message: `Не удалось ${actionText} рассылку.`, buttons: [{type: 'ok'}]});
+    // Show error related to article loading only if in list view and loading is finished
+    if (error && !selectedArticle && !isLoadingArticles) {
+        return (
+            <div className="p-6 pt-32 text-center text-brand-pink bg-black/50 rounded-lg shadow-lg border border-brand-pink/30 mx-4">
+                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-2 text-2xl" />
+                <p className="font-semibold text-xl mt-2">Ошибка загрузки данных</p>
+                <p className="text-gray-400 mt-1">{error}</p>
+            </div>
+        );
     }
-    setIsUpdatingBroadcast(false);
-  };
 
-  // --- Navigation & UI ---
-  const handleGoBack = useCallback(() => {
-    setSelectedArticle(null);
-    setSections([]);
-    setError(null);
-    setBroadcastEnabled(false);
-  }, []);
-
-  useEffect(() => {
-    if (!webApp) return;
-    const backButtonClickHandler = () => { handleGoBack(); };
-    if (selectedArticle) {
-      webApp.BackButton?.show();
-      webApp.BackButton?.onClick(backButtonClickHandler);
-    } else {
-      webApp.BackButton?.offClick(backButtonClickHandler);
-      webApp.BackButton?.hide();
-    }
-    // .. Cleanup function to remove listener and hide button when component unmounts or article changes
-    return () => {
-      if (webApp.BackButton?.isVisible) {
-          webApp.BackButton?.offClick(backButtonClickHandler);
-          webApp.BackButton?.hide();
-      }
-    };
-  }, [webApp, selectedArticle, handleGoBack]);
-
-  // --- Render Logic ---
-  // .. Show loading spinner if auth is loading OR metadata hasn't loaded yet OR articles are loading
-  const showGlobalLoading = isAuthLoading || userMetadata === null || (isLoadingArticles && articles.length === 0 && !selectedArticle);
-  if (showGlobalLoading) {
     return (
-      <div className="flex justify-center items-center h-screen pt-36 bg-black">
-        <FontAwesomeIcon icon={faSpinner} spin size="3x" className="text-brand-green" />
-      </div>
-    );
-  }
-
-   // .. Show auth error if not authenticated after loading
-   if (!isAuthenticated) {
-     return (
-       <div className="p-6 pt-32 text-center text-brand-pink">
-         <FontAwesomeIcon icon={faTriangleExclamation} size="2x" className="mb-2" />
-         <p className="font-semibold text-xl">Ошибка Авторизации</p>
-         <p className="text-gray-400">{error || "Не удалось подтвердить пользователя. Попробуйте перезапустить приложение."}</p>
-       </div>
-     );
-  }
-
-  // .. Show error loading articles list (if it happened and we are in list view)
-  if (error && !selectedArticle && !isLoadingArticles) {
-    return (
-       <div className="p-6 pt-32 text-center text-brand-pink bg-black/50 rounded-lg shadow-lg border border-brand-pink/30 mx-4">
-         <FontAwesomeIcon icon={faTriangleExclamation} className="mr-2 text-2xl" />
-         <p className="font-semibold text-xl mt-2">Ошибка загрузки статей</p>
-         <p className="text-gray-400 mt-1">{error}</p>
-       </div>
-     );
-  }
-
-  return (
-    <div className={cn(
-        "min-h-screen pt-36 pb-10 font-mono",
-        "bg-gradient-to-br from-gray-900 via-black to-gray-800 text-gray-200"
-    )}>
-      <div className="relative z-10 container mx-auto px-4 max-w-4xl">
-        {!selectedArticle ? (
-          // --- Articles List View ---
-          <div className="space-y-6">
-            <h1 className="text-3xl md:text-4xl font-bold text-center text-brand-green cyber-text glitch" data-text="Мудрые Советы">
-                Мудрые Советы
-            </h1>
-            {isLoadingArticles ? (
-                 <div className="flex justify-center items-center pt-16">
-                     <FontAwesomeIcon icon={faSpinner} spin size="2x" className="text-brand-blue" />
-                 </div>
-             ) : articles.length === 0 ? (
-               <p className="text-center text-gray-500 dark:text-gray-400 mt-10 text-lg">Пока нет доступных статей.</p>
-            ) : (
-              <ul className="space-y-4">
-                {articles.map((article) => (
-                  <li key={article.id}>
-                    <button
-                      onClick={() => handleSelectArticle(article)}
-                      className={cn(
-                          "w-full text-left p-4 md:p-5 rounded-lg transition duration-300 ease-in-out",
-                          "bg-black/60 backdrop-blur-sm border border-brand-blue/30 hover:border-brand-blue/70",
-                          "shadow-md hover:shadow-lg hover:shadow-brand-blue/30 focus:outline-none focus:ring-2 focus:ring-brand-blue focus:ring-opacity-50"
-                      )}
-                    >
-                      <h2 className="text-lg md:text-xl font-semibold text-brand-blue flex items-center">
-                         <FontAwesomeIcon icon={faBookOpen} className="mr-3 text-brand-blue/70 w-5 h-5" />
-                         {article.title}
-                      </h2>
-                      {article.description && (
-                        <p className="text-sm md:text-base text-gray-400 mt-1 ml-8">{article.description}</p>
-                      )}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        ) : (
-          // --- Single Article View ---
-          <div>
-             <h1 className="text-3xl md:text-4xl font-bold mb-3 text-brand-green cyber-text">{selectedArticle.title}</h1>
-            {selectedArticle.description && (
-              <p className="text-base md:text-lg text-gray-400 mb-6 italic">{selectedArticle.description}</p>
-            )}
-
-            {/* Loading Sections State */}
-            {isLoadingSections ? (
-               <div className="flex justify-center items-center py-16">
-                 <FontAwesomeIcon icon={faSpinner} spin size="3x" className="text-brand-blue"/>
-               </div>
-            ) : error && sections.length === 0 ? ( // Error loading sections specific view
-               <div className="p-4 my-6 text-brand-pink bg-pink-900/20 border border-brand-pink/40 rounded-lg shadow-md text-center">
-                  <FontAwesomeIcon icon={faTriangleExclamation} className="mr-2 text-xl" />
-                  <p className="mt-1">{error}</p> {/* Display the specific error */}
-               </div>
-            ) : (
-              // --- Sections Loaded ---
-              <div>
-                 {/* "Entertain Me" Button Area */}
-                 {userId && sections.length > 0 && ( // Only show if sections exist
-                  <div className="my-8 p-5 bg-gradient-to-r from-blue-900/30 via-purple-900/20 to-blue-900/30 border border-brand-purple/40 rounded-lg shadow-lg text-center">
-                    <h3 className="text-xl font-semibold mb-3 flex items-center justify-center text-brand-purple">
-                        <FontAwesomeIcon icon={faTelegram} className="mr-2 text-brand-blue" />
-                        Часовая Рассылка
-                    </h3>
-                     <p className="text-sm text-gray-300 mb-4">
-                         {broadcastEnabled
-                           ? "Получайте по одному разделу этой статьи каждый час прямо в Telegram!"
-                           : "Хотите получать эту мудрость порционно? Включите часовую рассылку!"}
-                     </p>
-                    <button
-                      onClick={handleToggleBroadcast}
-                      disabled={isUpdatingBroadcast}
-                      className={cn(
-                          "w-full sm:w-auto inline-flex items-center justify-center px-6 py-3 rounded-md font-semibold transition duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black space-x-2 shadow-md",
-                          isUpdatingBroadcast
-                            ? 'bg-gray-600 cursor-not-allowed text-gray-400'
-                            : broadcastEnabled
-                              ? 'bg-red-600 hover:bg-red-700 text-white focus:ring-red-500 shadow-red-500/30 hover:shadow-red-500/50'
-                              : 'bg-green-600 hover:bg-green-700 text-white focus:ring-green-500 shadow-green-500/30 hover:shadow-green-500/50'
-                      )}
-                    >
-                      {isUpdatingBroadcast ? (<FontAwesomeIcon icon={faSpinner} spin />)
-                       : broadcastEnabled ? (<FontAwesomeIcon icon={faStopCircle} />)
-                       : (<FontAwesomeIcon icon={faPaperPlane} />)}
-                      <span>
-                        {isUpdatingBroadcast ? 'Обновление...' : broadcastEnabled ? 'Отключить рассылку' : 'Развлеки меня'}
-                      </span>
-                    </button>
-                    {/* Status Indicator */}
-                    {broadcastEnabled && !isUpdatingBroadcast && (
-                       <p className="text-xs text-brand-green mt-3 flex items-center justify-center">
-                         <FontAwesomeIcon icon={faCheckCircle} className="mr-1" /> Рассылка активна для этой статьи.
-                       </p>
-                     )}
-                     {/* Display error specific to broadcast update */}
-                     {error && isUpdatingBroadcast === false && !isLoadingSections && ( // Show error only if NOT currently updating
-                          <p className="text-xs text-brand-pink mt-2">{error}</p>
-                      )}
-                   </div>
-                 )}
-
-                {/* Sections Content */}
-                <h2 className="text-2xl font-semibold mt-8 mb-4 border-b border-brand-blue/30 pb-2 text-brand-blue">Содержание:</h2>
-                {sections.length === 0 && !isLoadingSections && !error ? ( // Handle case where article has 0 sections successfully loaded
-                  <p className="text-gray-500">В этой статье пока нет секций.</p>
-                ) : (
-                  <div className="space-y-6">
-                    {sections.map((section) => (
-                      <div key={section.id} className={cn(
-                          "p-5 border rounded-lg transition-shadow duration-300",
-                          "bg-black/50 border-gray-700/50 hover:border-brand-green/50 hover:shadow-md hover:shadow-brand-green/20"
-                      )}>
-                        {section.title && (
-                          <h3 className="text-lg font-semibold mb-2 text-brand-green flex items-baseline">
-                             <span className="text-brand-blue mr-2">{section.section_order}.</span> {section.title}
-                          </h3>
+        <div className={cn(
+            "min-h-screen pt-36 pb-10 font-mono",
+            "bg-gradient-to-br from-gray-900 via-black to-gray-800 text-gray-200"
+        )}>
+            <div className="relative z-10 container mx-auto px-4 max-w-4xl">
+                {!selectedArticle ? (
+                    // --- Articles List View ---
+                    <div className="space-y-6">
+                        <h1 className="text-3xl md:text-4xl font-bold text-center text-brand-green cyber-text glitch" data-text="Мудрые Советы">
+                            Мудрые Советы
+                        </h1>
+                        {/* Display loading spinner specifically for articles if needed */}
+                        {isLoadingArticles ? (
+                             <div className="flex justify-center items-center pt-16">
+                                 <FontAwesomeIcon icon={faSpinner} spin size="2x" className="text-brand-blue" />
+                             </div>
+                         ) : articles.length === 0 ? (
+                            <p className="text-center text-gray-500 dark:text-gray-400 mt-10 text-lg">Пока нет доступных статей.</p>
+                        ) : (
+                            <ul className="space-y-4">
+                                {articles.map((article) => (
+                                    <li key={article.id}>
+                                        <button
+                                            onClick={() => handleSelectArticle(article)}
+                                            className={cn(
+                                                "w-full text-left p-4 md:p-5 rounded-lg transition duration-300 ease-in-out",
+                                                "bg-black/60 backdrop-blur-sm border border-brand-blue/30 hover:border-brand-blue/70",
+                                                "shadow-md hover:shadow-lg hover:shadow-brand-blue/30 focus:outline-none focus:ring-2 focus:ring-brand-blue focus:ring-opacity-50"
+                                            )}
+                                        >
+                                            <h2 className="text-lg md:text-xl font-semibold text-brand-blue flex items-center">
+                                                <FontAwesomeIcon icon={faBookOpen} className="mr-3 text-brand-blue/70 w-5 h-5" />
+                                                {article.title}
+                                            </h2>
+                                            {article.description && (
+                                                <p className="text-sm md:text-base text-gray-400 mt-1 ml-8">{article.description}</p>
+                                            )}
+                                        </button>
+                                    </li>
+                                ))}
+                            </ul>
                         )}
-                         {/* --- Use ReactMarkdown to render content --- */}
-                         <ReactMarkdown
-                             remarkPlugins={[remarkGfm]} // Enable GitHub Flavored Markdown (tables, strikethrough, etc.)
-                             className="prose prose-invert prose-sm md:prose-base max-w-none text-gray-300 prose-headings:text-brand-cyan prose-strong:text-brand-lime prose-a:text-brand-blue hover:prose-a:text-brand-purple prose-code:text-brand-pink prose-code:before:content-none prose-code:after:content-none prose-blockquote:border-brand-purple"
-                             // .. You can customize components if needed, e.g., for links:
-                              components={{
-                                 a: ({node, ...props}) => <a {...props} target="_blank" rel="noopener noreferrer" className="hover:underline" />,
-                                // .. Add other custom components if necessary
-                             }}
-                         >
-                            {section.content}
-                         </ReactMarkdown>
-                      </div>
-                    ))}
-                  </div>
+                    </div>
+                ) : (
+                    // --- Single Article View ---
+                    <div>
+                        <h1 className="text-3xl md:text-4xl font-bold mb-3 text-brand-green cyber-text">{selectedArticle.title}</h1>
+                        {selectedArticle.description && (
+                            <p className="text-base md:text-lg text-gray-400 mb-6 italic">{selectedArticle.description}</p>
+                        )}
+
+                        {isLoadingSections ? (
+                            <div className="flex justify-center items-center py-16">
+                                <FontAwesomeIcon icon={faSpinner} spin size="3x" className="text-brand-blue" />
+                            </div>
+                        ) : error && sections.length === 0 ? ( // Show section-specific error
+                            <div className="p-4 my-6 text-brand-pink bg-pink-900/20 border border-brand-pink/40 rounded-lg shadow-md text-center">
+                                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-2 text-xl" />
+                                <p className="mt-1">{error}</p>
+                            </div>
+                        ) : (
+                            // --- Sections Loaded ---
+                            <div>
+                                {/* "Entertain Me" Button Area */}
+                                {userId && sections.length > 0 && (
+                                    <div className="my-8 p-5 bg-gradient-to-r from-blue-900/30 via-purple-900/20 to-blue-900/30 border border-brand-purple/40 rounded-lg shadow-lg text-center">
+                                        <h3 className="text-xl font-semibold mb-3 flex items-center justify-center text-brand-purple">
+                                            <FontAwesomeIcon icon={faTelegram} className="mr-2 text-brand-blue" />
+                                            Часовая Рассылка
+                                        </h3>
+                                        <p className="text-sm text-gray-300 mb-4">
+                                            {broadcastEnabled
+                                                ? "Получайте по одному разделу этой статьи каждый час прямо в Telegram!"
+                                                : "Хотите получать эту мудрость порционно? Включите часовую рассылку!"}
+                                        </p>
+                                        <button
+                                            onClick={handleToggleBroadcast}
+                                            disabled={isUpdatingBroadcast}
+                                            className={cn(
+                                                "w-full sm:w-auto inline-flex items-center justify-center px-6 py-3 rounded-md font-semibold transition duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black space-x-2 shadow-md",
+                                                isUpdatingBroadcast
+                                                    ? 'bg-gray-600 cursor-not-allowed text-gray-400'
+                                                    : broadcastEnabled
+                                                        ? 'bg-red-600 hover:bg-red-700 text-white focus:ring-red-500 shadow-red-500/30 hover:shadow-red-500/50'
+                                                        : 'bg-green-600 hover:bg-green-700 text-white focus:ring-green-500 shadow-green-500/30 hover:shadow-green-500/50'
+                                            )}
+                                        >
+                                            {isUpdatingBroadcast ? (<FontAwesomeIcon icon={faSpinner} spin />)
+                                                : broadcastEnabled ? (<FontAwesomeIcon icon={faStopCircle} />)
+                                                    : (<FontAwesomeIcon icon={faPaperPlane} />)}
+                                            <span>
+                                                {isUpdatingBroadcast ? 'Обновление...' : broadcastEnabled ? 'Отключить рассылку' : 'Развлеки меня'}
+                                            </span>
+                                        </button>
+                                        {broadcastEnabled && !isUpdatingBroadcast && (
+                                            <p className="text-xs text-brand-green mt-3 flex items-center justify-center">
+                                                <FontAwesomeIcon icon={faCheckCircle} className="mr-1" /> Рассылка активна для этой статьи.
+                                            </p>
+                                        )}
+                                        {error && !isUpdatingBroadcast && !isLoadingSections && ( // Show error only if NOT updating/loading
+                                            <p className="text-xs text-brand-pink mt-2">{error}</p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Sections Content */}
+                                <h2 className="text-2xl font-semibold mt-8 mb-4 border-b border-brand-blue/30 pb-2 text-brand-blue">Содержание:</h2>
+                                {sections.length === 0 && !isLoadingSections ? (
+                                    <p className="text-gray-500">В этой статье пока нет секций.</p>
+                                ) : (
+                                    <div className="space-y-6">
+                                        {sections.map((section) => (
+                                            <div key={section.id} className={cn(
+                                                "p-5 border rounded-lg transition-shadow duration-300",
+                                                "bg-black/50 border-gray-700/50 hover:border-brand-green/50 hover:shadow-md hover:shadow-brand-green/20"
+                                            )}>
+                                                {section.title && (
+                                                    <h3 className="text-lg font-semibold mb-2 text-brand-green flex items-baseline">
+                                                        <span className="text-brand-blue mr-2">{section.section_order}.</span> {section.title}
+                                                    </h3>
+                                                )}
+                                                <ReactMarkdown
+                                                    // <-- Add remarkBreaks plugin here
+                                                    remarkPlugins={[remarkGfm, remarkBreaks]}
+                                                    className="prose prose-invert prose-sm md:prose-base max-w-none text-gray-300 prose-headings:text-brand-cyan prose-strong:text-brand-lime prose-a:text-brand-blue hover:prose-a:text-brand-purple prose-code:text-brand-pink prose-code:before:content-none prose-code:after:content-none prose-blockquote:border-brand-purple prose-li:marker:text-brand-blue" // Added list item marker color
+                                                    components={{
+                                                        a: ({ node, ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" className="hover:underline" />,
+                                                        // .. Ensure lists are styled correctly by prose or add specific list styling if needed
+                                                        ul: ({node, ...props}) => <ul {...props} className="list-disc list-outside ml-4" />,
+                                                        ol: ({node, ...props}) => <ol {...props} className="list-decimal list-outside ml-4" />,
+                                                        li: ({node, ...props}) => <li {...props} className="my-1" />, // Minor spacing for list items
+                                                    }}
+                                                >
+                                                    {section.content ?? ''}
+                                                    {/* Use empty string fallback */}
+                                                </ReactMarkdown>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </div>
                 )}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+            </div>
+        </div>
+    );
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react-hook-form": "^7.54.1",
     "react-markdown": "latest",
     "remark-gfm": "latest",
+    "remark-breaks": "latest",
     "react-resizable-panels": "^2.1.7",
     "react-syntax-highlighter": "^15.6.1",
     "react-hot-toast": "latest",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-folder-tree": "latest",
     "react-hook-form": "^7.54.1",
     "react-markdown": "latest",
+    "remark-gfm": "latest",
     "react-resizable-panels": "^2.1.7",
     "react-syntax-highlighter": "^15.6.1",
     "react-hot-toast": "latest",


### PR DESCRIPTION
Ок, понял задачу. Нужно отобразить контент секций (`section_content`), который сохранен в базе с Markdown-разметкой, как отформатированный текст, а не просто как обычный текст.

Для этого отлично подойдет библиотека `react-markdown`. Добавим ее и используем для рендеринга `section.content`.

**Изменения:**

1.  **Импорт `ReactMarkdown`**: Добавлен импорт компонента `ReactMarkdown` из `react-markdown` и плагина `remark-gfm` для поддержки расширенного синтаксиса (например, таблиц).
2.  **Замена `dangerouslySetInnerHTML`**: Вместо использования `dangerouslySetInnerHTML`, теперь контент секции (`section.content`) передается как дочерний элемент компоненту `<ReactMarkdown>`.
3.  **Добавление `remarkPlugins={[remarkGfm]}`**: Включен плагин `remark-gfm`, чтобы корректно отображать таблицы, зачеркнутый текст и другие элементы GitHub Flavored Markdown.
4.  **Стилизация через `prose`**: Оставлены классы Tailwind Typography (`prose prose-invert...`) для базовой стилизации Markdown-элементов. Добавлены некоторые уточнения стилей для ссылок (`prose-a`), жирного текста (`prose-strong`), заголовков (`prose-headings`), кода (`prose-code`) и цитат (`prose-blockquote`), чтобы они лучше сочетались с киберпанк-темой.
5.  **Безопасность**: `react-markdown` по умолчанию выполняет базовую очистку HTML, что делает его безопаснее, чем `dangerouslySetInnerHTML`.
6.  **Улучшена логика загрузки/ошибок**: Немного переработана логика `useEffect` и условного рендеринга для более четкого отображения состояний загрузки и ошибок на разных этапах (загрузка метаданных, загрузка статей, загрузка секций).

Теперь контент секций должен отображаться с правильным форматированием Markdown. Не забудьте установить зависимости, если еще не установлены:

**Файлы (1):**
- `app/advice/page.tsx`