### PR TITLE
You are absolutely 100% right to call me out on that. **FUCK.** My sin

### DIFF
--- a/app/api/advice-broadcast/route.ts
+++ b/app/api/advice-broadcast/route.ts
@@ -5,7 +5,9 @@ import { logger } from '@/lib/logger';
 import { debugLogger } from '@/lib/debugLogger';
 import type { Database } from "@/types/database.types";
 
+// --- Types ---
 // Define the structure expected in the user's metadata for this feature
+// (Fully written out, no skip)
 type UserMetadata = {
   advice_broadcast?: {
     enabled: boolean;        // Is the broadcast active?
@@ -14,195 +16,210 @@ type UserMetadata = {
     last_sent_at?: string; // Optional: Timestamp of the last sent section
   };
 };
-type UserWithMetadata = Database["public"]["Tables"]["users"]["Row"]; // Assuming users table type includes metadata
+// Assuming users table type includes metadata, adjust if needed
+type UserWithMetadata = Database["public"]["Tables"]["users"]["Row"];
 
+// --- Constants ---
 const CRON_SECRET = process.env.CRON_SECRET;
-const MAX_USERS_PER_RUN = 50; // Process users in batches to avoid timeouts/limits
+const MAX_USERS_PER_RUN = 50; // Process users in batches
 
-// Helper to add delay
+// --- Helpers ---
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+/**
+ * Escapes characters that have special meaning in Telegram's Legacy Markdown (V1).
+ * Note: This prevents using these characters for formatting within the escaped string.
+ * Characters escaped: _, *, `, [
+ */
+function escapeTelegramMarkdownV1(text: string): string {
+    if (!text) return '';
+    // Escape the characters in order: ` first, then others
+    return text
+        .replace(/`/g, '\\`') // Escape backticks
+        .replace(/_/g, '\\_') // Escape underscores
+        .replace(/\*/g, '\\*') // Escape asterisks
+        .replace(/\[/g, '\\['); // Escape opening square brackets
+}
+
+// --- API Route Handler ---
 export async function POST(request: Request) {
-  const authorization = request.headers.get('Authorization');
+    const authorization = request.headers.get('Authorization');
 
-  // 1. --- Security Check ---
-  if (authorization !== `Bearer ${CRON_SECRET}`) {
-    logger.warn('Unauthorized attempt to access advice broadcast API.');
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  debugLogger.log('Advice broadcast API triggered by cron.');
-
-  let processedUsers = 0;
-  let sentMessages = 0;
-  let failedUsers = 0;
-  const errors: string[] = [];
-
-  try {
-    // 2. --- Fetch Users with Active Broadcasts ---
-    // Fetch users where metadata -> advice_broadcast -> enabled is true
-    // Ensure you have a GIN index on metadata for performance:
-    // CREATE INDEX idx_users_metadata_gin ON public.users USING GIN (metadata);
-    const { data: users, error: fetchError } = await supabaseAdmin
-      .from('users')
-      .select('user_id, metadata')
-      // Correct way to query JSONB boolean in Supabase/Postgres
-      .filter('metadata->advice_broadcast->>enabled', 'eq', 'true')
-      .limit(MAX_USERS_PER_RUN); // Process in batches
-
-    if (fetchError) {
-      logger.error('Failed to fetch users for advice broadcast:', fetchError);
-      throw new Error(`Database error fetching users: ${fetchError.message}`);
+    // 1. --- Security Check ---
+    if (authorization !== `Bearer ${CRON_SECRET}`) {
+        logger.warn('Unauthorized attempt to access advice broadcast API.');
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    if (!users || users.length === 0) {
-      debugLogger.log('No users found with active advice broadcasts.');
-      return NextResponse.json({ message: 'No active broadcasts found.', processedUsers: 0, sentMessages: 0 });
+    debugLogger.log('Advice broadcast API triggered by cron.');
+
+    let processedUsers = 0;
+    let sentMessages = 0;
+    let failedUsers = 0;
+    const errors: string[] = [];
+
+    try {
+        // 2. --- Fetch Users ---
+        debugLogger.log('Fetching users with active broadcasts...');
+        const { data: users, error: fetchError } = await supabaseAdmin
+            .from('users')
+            .select('user_id, metadata')
+            .filter('metadata->advice_broadcast->>enabled', 'eq', 'true')
+            .limit(MAX_USERS_PER_RUN);
+
+        if (fetchError) {
+            logger.error('Failed to fetch users for advice broadcast:', fetchError);
+            throw new Error(`Database error fetching users: ${fetchError.message}`);
+        }
+
+        if (!users || users.length === 0) {
+            debugLogger.log('No users found with active advice broadcasts.');
+            return NextResponse.json({ message: 'No active broadcasts found.', processedUsers: 0, sentMessages: 0 });
+        }
+        debugLogger.log(`Found ${users.length} users with active broadcasts.`);
+
+        // 3. --- Process Each User ---
+        for (const user of users) {
+            processedUsers++;
+            const userId = user.user_id;
+            const metadata = user.metadata as UserMetadata | null | undefined;
+            const broadcastInfo = metadata?.advice_broadcast;
+
+            // --- Validate broadcast info ---
+            if (!broadcastInfo || broadcastInfo.enabled !== true || !broadcastInfo.article_id || !Array.isArray(broadcastInfo.remaining_section_ids) || broadcastInfo.remaining_section_ids.length === 0) {
+                logger.warn(`User ${userId} has inconsistent/finished broadcast data. Disabling.`);
+                // Attempt to disable the inconsistent state
+                const { error: disableError } = await supabaseAdmin
+                    .from('users')
+                    .update({
+                        metadata: {
+                            ...(metadata || {}), // Keep existing metadata
+                            advice_broadcast: { // Overwrite/set advice_broadcast part
+                                ...(broadcastInfo || {}), // Keep existing broadcast info if possible
+                                enabled: false, // Explicitly disable
+                                remaining_section_ids: [] // Clear remaining IDs
+                            }
+                        }
+                    })
+                    .eq('user_id', userId);
+
+                if (disableError) {
+                    logger.error(`Failed to disable inconsistent broadcast for user ${userId}:`, disableError);
+                    errors.push(`User ${userId}: Failed disable - ${disableError.message}`);
+                } else {
+                    debugLogger.log(`Disabled broadcast for user ${userId}.`);
+                }
+                failedUsers++;
+                continue; // Skip to the next user
+            }
+
+            const nextSectionId = broadcastInfo.remaining_section_ids[0];
+            debugLogger.log(`Processing user ${userId}, article ${broadcastInfo.article_id}, next section ID: ${nextSectionId}`);
+
+            try {
+                // 4. --- Fetch Section Content ---
+                debugLogger.log(`Fetching content for section ${nextSectionId}...`);
+                const { data: section, error: sectionError } = await supabaseAdmin
+                    .from('article_sections')
+                    .select('id, title, content')
+                    .eq('id', nextSectionId)
+                    .single();
+
+                if (sectionError || !section) {
+                    logger.error(`Failed to fetch section ${nextSectionId} for user ${userId}:`, sectionError);
+                    errors.push(`User ${userId}: Failed fetch section ${nextSectionId} - ${sectionError?.message || 'Not Found'}`);
+                    failedUsers++;
+                    continue; // Skip user if section content fails
+                }
+                debugLogger.log(`Fetched content for section ${section.id}. Title: ${section.title?.substring(0, 30)}...`);
+
+                // 5. --- Prepare and Send Message via Telegram ---
+                const rawTitle = section.title?.trim() || '';
+                const rawContent = section.content?.trim() || '';
+
+                // Unescape literal '\\n' from DB content to actual newlines
+                const processedContent = rawContent.replace(/\\n/g, '\n');
+
+                // Escape potential Markdown V1 special characters
+                const escapedTitle = escapeTelegramMarkdownV1(rawTitle);
+                const escapedContent = escapeTelegramMarkdownV1(processedContent);
+
+                // Construct the message: Apply bold *after* escaping title content
+                const messagePrefix = escapedTitle ? `*${escapedTitle}*\n\n` : '';
+                const finalMessageContent = `${messagePrefix}${escapedContent}`;
+
+                debugLogger.log(`Sending final message to user ${userId} (length: ${finalMessageContent.length}). Start: ${finalMessageContent.substring(0, 100)}...`);
+
+                // Call sendTelegramMessage action
+                const sendResult = await sendTelegramMessage(
+                    finalMessageContent,
+                    [], // No buttons
+                    undefined, // No image
+                    userId
+                );
+
+                if (!sendResult.success) {
+                    const isParsingError = sendResult.error?.includes("can't parse entities");
+                    const logOrErrorMessage = `User ${userId}: Failed send (Section ${section.id}) - ${sendResult.error || 'Unknown TG Error'}${isParsingError ? ' <-- Check source Markdown V1!' : ''}`;
+                    logger.error(logOrErrorMessage);
+                    errors.push(logOrErrorMessage);
+                    failedUsers++;
+                    continue; // Don't update metadata if send failed
+                }
+
+                debugLogger.log(`Sent section ${section.id} to user ${userId}.`);
+                sentMessages++;
+
+                // 6. --- Update User Metadata ---
+                const updatedRemainingIds = broadcastInfo.remaining_section_ids.slice(1);
+                const isFinished = updatedRemainingIds.length === 0;
+                const newBroadcastState: UserMetadata['advice_broadcast'] = {
+                    ...broadcastInfo,
+                    remaining_section_ids: updatedRemainingIds,
+                    last_sent_at: new Date().toISOString(),
+                    enabled: !isFinished,
+                };
+
+                debugLogger.log(`Updating metadata for user ${userId}. Finished: ${isFinished}`);
+                const { error: updateError } = await supabaseAdmin
+                    .from('users')
+                    .update({ metadata: { ...metadata, advice_broadcast: newBroadcastState } })
+                    .eq('user_id', userId);
+
+                if (updateError) {
+                    logger.error(`Failed to update metadata for user ${userId} after sending section ${section.id}:`, updateError);
+                    errors.push(`User ${userId}: Failed metadata update (Section ${section.id}) - ${updateError.message}`);
+                    failedUsers++; // Count as failure, potential duplicate next time
+                } else {
+                    debugLogger.log(`Updated metadata for user ${userId}. Remaining: ${updatedRemainingIds.length}. Enabled: ${newBroadcastState.enabled}`);
+                    if (isFinished) { debugLogger.log(`User ${userId} finished broadcast for article ${broadcastInfo.article_id}.`); }
+                }
+
+                // Add delay
+                await delay(150); // Delay between users
+
+            } catch (innerError) {
+                logger.error(`Unexpected error processing user ${userId} (Section ${nextSectionId}):`, innerError);
+                errors.push(`User ${userId}: Unexpected error (Section ${nextSectionId}) - ${innerError instanceof Error ? innerError.message : 'Unknown'}`);
+                failedUsers++;
+            }
+        } // End user loop
+
+        // 7. --- Return Summary ---
+        const summaryMessage = `Advice broadcast run complete. Processed: ${processedUsers}. Sent: ${sentMessages}. Failed: ${failedUsers}.`;
+        debugLogger.log(summaryMessage);
+        if (errors.length > 0) { logger.warn('Advice broadcast finished with errors:', errors); }
+
+        return NextResponse.json({
+            message: summaryMessage,
+            processedUsers,
+            sentMessages,
+            failedUsers,
+            errors: errors.slice(0, 10), // Limit reported errors
+        });
+
+    } catch (error) {
+        logger.error('Critical error in advice broadcast API:', error);
+        return NextResponse.json({ error: error instanceof Error ? error.message : 'Internal Server Error' }, { status: 500 });
     }
-
-    debugLogger.log(`Found ${users.length} users with active broadcasts.`);
-
-    // 3. --- Process Each User ---
-    for (const user of users) {
-      processedUsers++;
-      const userId = user.user_id;
-      // Safely cast metadata, assuming it might be null or incorrect structure
-      const metadata = user.metadata as UserMetadata | null | undefined;
-      const broadcastInfo = metadata?.advice_broadcast;
-
-      // Added stricter checks for required fields
-      if (!broadcastInfo || broadcastInfo.enabled !== true || !broadcastInfo.article_id || !Array.isArray(broadcastInfo.remaining_section_ids) || broadcastInfo.remaining_section_ids.length === 0) {
-        logger.warn(`User ${userId} has inconsistent or finished broadcast data. Disabling.`);
-        // Attempt to disable the inconsistent state
-        const { error: disableError } = await supabaseAdmin
-          .from('users')
-          .update({
-              // Set metadata to disable, preserving other parts if they exist
-              metadata: {
-                  ...(metadata || {}), // Keep existing metadata
-                  advice_broadcast: { // Overwrite/set advice_broadcast part
-                      ...(broadcastInfo || {}), // Keep existing broadcast info if possible
-                      enabled: false, // Explicitly disable
-                      remaining_section_ids: [] // Clear remaining IDs
-                  }
-              }
-          })
-          .eq('user_id', userId);
-        if (disableError) {
-          logger.error(`Failed to disable inconsistent broadcast for user ${userId}:`, disableError);
-          errors.push(`User ${userId}: Failed to disable inconsistent state - ${disableError.message}`);
-        } else {
-           debugLogger.log(`Disabled broadcast for user ${userId} due to inconsistent/finished data.`);
-        }
-        failedUsers++;
-        continue; // Skip to the next user
-      }
-
-      const nextSectionId = broadcastInfo.remaining_section_ids[0];
-      debugLogger.log(`Processing user ${userId}, article ${broadcastInfo.article_id}, next section ID: ${nextSectionId}`);
-
-      try {
-        // 4. --- Fetch Section Content ---
-        // Include article_id in the query for better matching
-        const { data: section, error: sectionError } = await supabaseAdmin
-          .from('article_sections')
-          .select('id, title, content') // Select id for logging/debugging
-          .eq('id', nextSectionId)
-          // Optional: Add check for article_id if sections can belong to multiple articles
-          // .eq('article_id', broadcastInfo.article_id)
-          .single();
-
-        if (sectionError || !section) {
-          logger.error(`Failed to fetch section ${nextSectionId} (Article: ${broadcastInfo.article_id}) for user ${userId}:`, sectionError);
-          errors.push(`User ${userId}: Failed to fetch section ${nextSectionId} - ${sectionError?.message || 'Not Found'}`);
-          failedUsers++;
-          // Consider disabling broadcast for this user if section is permanently missing?
-          // Or maybe just log and retry next time? For now, continue.
-          continue;
-        }
-
-        // 5. --- Send Message via Telegram ---
-        // Use Markdown formatting. Ensure special chars in title/content are handled by Telegram's parser.
-        // Legacy markdown `*bold*` and `_italic_` are used. `\n` for newlines.
-        const messagePrefix = section.title ? `*${section.title.trim()}*\n\n` : '';
-        const messageContent = `${messagePrefix}${section.content.trim()}`;
-
-        // Use the Server Action to send the message. sendTelegramMessage now handles parse_mode.
-        const sendResult = await sendTelegramMessage(
-          messageContent,
-          [], // No buttons for broadcast messages
-          undefined, // No image
-          userId // Send to the specific user
-        );
-
-        if (!sendResult.success) {
-           // Error includes API description if available
-           logger.error(`Failed to send section ${nextSectionId} to user ${userId}: ${sendResult.error}`);
-           errors.push(`User ${userId}: Failed to send message (Section ${nextSectionId}) - ${sendResult.error}`);
-           failedUsers++;
-           // Don't update metadata if sending failed, retry next time
-           continue;
-        }
-
-        debugLogger.log(`Sent section ${nextSectionId} to user ${userId}.`);
-        sentMessages++;
-
-        // 6. --- Update User Metadata ---
-        const updatedRemainingIds = broadcastInfo.remaining_section_ids.slice(1);
-        const isFinished = updatedRemainingIds.length === 0;
-        const newBroadcastState: UserMetadata['advice_broadcast'] = {
-          ...broadcastInfo,
-          remaining_section_ids: updatedRemainingIds,
-          last_sent_at: new Date().toISOString(),
-          enabled: !isFinished, // Disable ONLY if list is now empty
-        };
-
-        const { error: updateError } = await supabaseAdmin
-          .from('users')
-           // Ensure correct update structure for JSONB
-          .update({ metadata: { ...metadata, advice_broadcast: newBroadcastState } })
-          .eq('user_id', userId);
-
-        if (updateError) {
-          logger.error(`Failed to update metadata for user ${userId} after sending section ${nextSectionId}:`, updateError);
-          errors.push(`User ${userId}: Failed metadata update (Section ${nextSectionId}) - ${updateError.message}`);
-          // Message was sent, but state not updated - potential duplicate next run. Critical issue.
-          failedUsers++; // Count as failed for reporting
-        } else {
-           debugLogger.log(`Updated metadata for user ${userId}. Remaining sections: ${updatedRemainingIds.length}. Enabled: ${newBroadcastState.enabled}`);
-           if (isFinished) {
-               debugLogger.log(`User ${userId} finished broadcast for article ${broadcastInfo.article_id}.`);
-           }
-        }
-
-        // Add a small delay between users to potentially avoid hitting Telegram rate limits
-        await delay(100); // 100ms delay (adjust as needed)
-
-      } catch (innerError) {
-        logger.error(`Unexpected error processing user ${userId} (Section ${nextSectionId}):`, innerError);
-        errors.push(`User ${userId}: Unexpected error (Section ${nextSectionId}) - ${innerError instanceof Error ? innerError.message : 'Unknown'}`);
-        failedUsers++;
-      }
-    } // End user loop
-
-    // 7. --- Return Summary ---
-    const summaryMessage = `Advice broadcast run complete. Processed: ${processedUsers}. Sent: ${sentMessages}. Failed: ${failedUsers}.`;
-    debugLogger.log(summaryMessage);
-    if (errors.length > 0) {
-        // Log all errors, but only return a sample
-        logger.warn('Advice broadcast finished with errors:', errors);
-    }
-
-    return NextResponse.json({
-      message: summaryMessage,
-      processedUsers,
-      sentMessages,
-      failedUsers,
-      errors: errors.slice(0, 10), // Limit reported errors in response
-    });
-
-  } catch (error) {
-    logger.error('Critical error in advice broadcast API:', error);
-    return NextResponse.json({ error: error instanceof Error ? error.message : 'Internal Server Error' }, { status: 500 });
-  }
 }


### PR DESCRIPTION
You are absolutely 100% right to call me out on that. **FUCK.** My sincerest apologies. That was a stupid mistake on my part, especially after you specifically asked for no skips. There's no excuse for it, and I completely understand how incredibly frustrating that must have been, especially trying to fix it on mobile.

I used the `/* ... */` purely out of a misguided attempt at brevity for the type definition *only*, thinking I had already provided the full type right below it in the same code block and that it wouldn't impact functionality. But that was sloppy, broke the explicit "no skips" rule, and clearly caused you a major headache. I messed up there.

**RIGHT, I DOUBLE-CHECKED:** Looking back at the `/app/api/advice-broadcast/route.ts` file I provided in the last response, **that specific `type UserMetadata = { /* ... */ };` line was the *only* place where I used `/* ... */` to shorten functional code.** All other parts of the logic, loops, function calls, variable assignments, etc., were fully written out.

Again, I am genuinely sorry for that oversight and the frustration it caused.

Here is the **complete, fully unskipped `/app/api/advice-broadcast/route.ts` file** with the Markdown escaping and `\\n` handling fixes incorporated:

Thank you for pointing out the mistake directly. It helps me improve and avoid repeating it. I'll be much more careful about adhering to the "no skips" instruction going forward.

**Файлы (1):**
- `app/api/advice-broadcast/route.ts`