### PR TITLE
Okay, I dig the "half-ass more" vibe! 😂 Let's break down this upgrade

### DIFF
--- a/app/tools/remuxer/page.tsx
+++ b/app/tools/remuxer/page.tsx
@@ -1,0 +1,305 @@
+"use client";
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { FFmpeg } from '@ffmpeg/ffmpeg';
+import { fetchFile, toBlobURL } from '@ffmpeg/util';
+import { debugLogger as logger } from '@/lib/debugLogger';
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress"; // Assuming you have this Shadcn component
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { FaVideo, FaVolumeUp, FaSpinner, FaDownload as FaDownloadIcon, FaRocket } from "react-icons/fa6"; // Alias FaDownload
+import Link from 'next/link';
+
+// --- Constants ---
+// !!! ЗАМЕНИ НА СВОИ URL ИЗ SUPABASE STORAGE !!!
+const FFMPEG_BASE_URL = 'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/ffmpeg-assets'; // Пример
+const CORE_URL = `${FFMPEG_BASE_URL}/ffmpeg-core.js`;
+const WASM_URL = `${FFMPEG_BASE_URL}/ffmpeg-core.wasm`;
+// const WORKER_URL = `${FFMPEG_BASE_URL}/ffmpeg-core.worker.js`; // Раскомментируй, если используешь worker
+
+type ProcessingStatus = "idle" | "loadingEngine" | "reading" | "remuxing" | "done" | "error";
+
+function VideoRemuxerPage() {
+    const [videoFile, setVideoFile] = useState<File | null>(null);
+    const [audioFile, setAudioFile] = useState<File | null>(null);
+    const [status, setStatus] = useState<ProcessingStatus>("loadingEngine");
+    const [progress, setProgress] = useState(0); // 0-100
+    const [outputUrl, setOutputUrl] = useState<string | null>(null);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const ffmpegRef = useRef(new FFmpeg());
+    const outputFilename = useRef<string>("remuxed_output.mkv"); // Store filename
+
+    // --- Load FFmpeg Engine ---
+    useEffect(() => {
+        const loadEngine = async () => {
+            const ffmpeg = ffmpegRef.current;
+            setStatus("loadingEngine");
+            setProgress(0); // Show initial loading state
+            logger.info("Remuxer: Loading FFmpeg engine...");
+
+            ffmpeg.on('log', ({ message }) => {
+                // Avoid flooding logs, maybe log only specific messages if needed
+                // logger.debug(`FFmpeg Log: ${message}`);
+            });
+
+            // Progress handler - maps FFmpeg's 0-1 progress to 0-100
+            ffmpeg.on('progress', ({ progress: p }) => {
+                 if (status === 'remuxing') { // Only update during the remux phase
+                    const currentProgress = Math.min(100, Math.max(0, Math.round(p * 100)));
+                    logger.debug(`Remuxer FFmpeg Progress: ${currentProgress}%`);
+                    setProgress(currentProgress);
+                 }
+            });
+
+            try {
+                // Dynamically create Blob URLs for loading to potentially help with CORS/caching
+                 const coreBlobUrl = await toBlobURL(CORE_URL, 'text/javascript');
+                 const wasmBlobUrl = await toBlobURL(WASM_URL, 'application/wasm');
+                 // const workerBlobUrl = await toBlobURL(WORKER_URL, 'text/javascript'); // If using worker
+
+                await ffmpeg.load({
+                    coreURL: coreBlobUrl,
+                    wasmURL: wasmBlobUrl,
+                    // workerURL: workerBlobUrl, // Uncomment if using worker
+                });
+                logger.info("Remuxer: FFmpeg engine loaded successfully.");
+                setStatus("idle");
+                setProgress(0);
+            } catch (err: any) {
+                logger.error("Remuxer: Failed to load FFmpeg engine:", err);
+                setErrorMessage(`Ошибка загрузки FFmpeg движка: ${err?.message || 'Unknown error'}. Проверь URL и CORS.`);
+                setStatus("error");
+                setProgress(0);
+            }
+        };
+        loadEngine();
+
+        // Cleanup function to potentially terminate FFmpeg if component unmounts
+        // return () => {
+        //     try {
+        //         if (ffmpegRef.current.loaded) {
+        //              // ffmpegRef.current.terminate(); // Be careful with terminate
+        //         }
+        //     } catch (e) {
+        //         logger.warn("Remuxer: Error during FFmpeg cleanup:", e);
+        //     }
+        // };
+    }, []); // Run only once on mount
+
+    // --- Reset Output URL ---
+    useEffect(() => {
+        // Revoke old Object URL when component unmounts or outputUrl changes
+        let currentUrl = outputUrl;
+        return () => {
+            if (currentUrl) {
+                logger.debug("Remuxer: Revoking previous object URL:", currentUrl.substring(0, 50));
+                URL.revokeObjectURL(currentUrl);
+            }
+        };
+    }, [outputUrl]);
+
+    // --- Main Remuxing Logic ---
+    const handleRemux = useCallback(async () => {
+        if (!videoFile || !audioFile || status !== "idle") {
+            logger.warn("Remuxer: Remux skipped, invalid state or files.", { status, videoFile, audioFile });
+            return;
+        }
+        if (!ffmpegRef.current.loaded) {
+            setErrorMessage("Движок FFmpeg еще не загружен.");
+            setStatus("error");
+            return;
+        }
+
+        setStatus("reading");
+        setProgress(0);
+        setOutputUrl(null);
+        setErrorMessage(null);
+        const ffmpeg = ffmpegRef.current;
+        const videoName = 'inputVideo' + videoFile.name.substring(videoFile.name.lastIndexOf('.')); // Use original extension
+        const audioName = 'inputAudio' + audioFile.name.substring(audioFile.name.lastIndexOf('.'));
+        outputFilename.current = `remuxed_${videoFile.name}`; // Use original video name
+
+        logger.info("Remuxer: Starting remux process...", { video: videoName, audio: audioName, output: outputFilename.current });
+
+        try {
+            logger.debug("Remuxer: Reading files into memory...");
+            // Add size checks here if desired
+            const videoData = await fetchFile(videoFile);
+            const audioData = await fetchFile(audioFile);
+            logger.debug("Remuxer: Files read. Writing to virtual FS...");
+
+            // Check if files already exist from a previous run and delete them
+            try { await ffmpeg.deleteFile(videoName); } catch (e) {}
+            try { await ffmpeg.deleteFile(audioName); } catch (e) {}
+            try { await ffmpeg.deleteFile(outputFilename.current); } catch (e) {}
+
+
+            await ffmpeg.writeFile(videoName, videoData);
+            await ffmpeg.writeFile(audioName, audioData);
+            logger.debug("Remuxer: Files written to FS.");
+
+            setStatus("remuxing");
+            setProgress(0); // Reset progress for FFmpeg command
+            logger.info("Remuxer: Executing FFmpeg remux command...");
+
+            await ffmpeg.exec([
+                '-i', videoName,
+                '-i', audioName,
+                '-map', '0:v', // Map video from first input
+                '-map', '1:a', // Map audio from second input
+                '-c', 'copy',  // CRITICAL: Copy streams without re-encoding
+                '-shortest',   // Finish when the shortest input ends (optional, but good practice)
+                outputFilename.current
+            ]);
+            logger.info("Remuxer: FFmpeg command finished.");
+
+            logger.debug("Remuxer: Reading output file from FS...");
+            setStatus("reading"); // Indicate reading output
+            setProgress(0); // Reset progress for read operation
+            const outputData = await ffmpeg.readFile(outputFilename.current);
+            logger.debug("Remuxer: Output file read.", { size: outputData.byteLength });
+
+            const mimeType = videoFile.type.startsWith('video/') ? videoFile.type : 'video/mkv'; // Use original video MIME or default
+            const blob = new Blob([outputData], { type: mimeType });
+            const url = URL.createObjectURL(blob);
+            setOutputUrl(url);
+            setStatus("done");
+            setProgress(100);
+            logger.info("Remuxer: Output file ready for download.", { url: url.substring(0, 50) });
+
+            // Clean up files from virtual FS after successful processing
+             try {
+                 logger.debug("Remuxer: Cleaning up virtual FS...");
+                 await ffmpeg.deleteFile(videoName);
+                 await ffmpeg.deleteFile(audioName);
+                 await ffmpeg.deleteFile(outputFilename.current);
+                 logger.debug("Remuxer: Virtual FS cleaned.");
+             } catch (cleanupError) {
+                 logger.warn("Remuxer: Error during virtual FS cleanup:", cleanupError);
+             }
+
+
+        } catch (err: any) {
+            logger.error("Remuxer: Error during remuxing:", err);
+            setErrorMessage(`Ошибка обработки: ${err?.message || 'Неизвестная проблема'}. Проверьте консоль браузера (F12) для деталей.`);
+            setStatus("error");
+            setOutputUrl(null);
+            setProgress(0);
+        }
+        // No finally block for setStatus("idle") here, keep it in "done" or "error" state
+
+    }, [videoFile, audioFile, status]); // Dependencies
+
+    const getStatusMessage = () => {
+        switch (status) {
+            case "idle": return "Готов к работе.";
+            case "loadingEngine": return "Загрузка движка FFmpeg...";
+            case "reading": return "Чтение файлов / Подготовка результата...";
+            case "remuxing": return `Склейка... ${progress}%`;
+            case "done": return "Готово! Можно скачивать.";
+            case "error": return `Ошибка: ${errorMessage || 'Неизвестно'}`;
+            default: return "";
+        }
+    };
+
+    const isBusy = status === 'loadingEngine' || status === 'reading' || status === 'remuxing';
+
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-950 to-black p-4 sm:p-8 pt-24 flex justify-center items-start">
+            <Card className="w-full max-w-2xl bg-dark-card border-brand-purple/30 shadow-glow-md glitch-border-animate">
+                <CardHeader>
+                    <CardTitle className="text-2xl font-bold text-brand-green cyber-text flex items-center gap-2">
+                        <FaRocket /> Локальный Видео Ремиксер
+                    </CardTitle>
+                    <CardDescription className="text-muted-foreground">
+                        Склейка видео и аудио прямо в браузере (Level 1: Remux). <br/>
+                        Файлы не загружаются на сервер. Ограничение по памяти ~500MB.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        {/* Video Input */}
+                        <div className="space-y-2">
+                            <Label htmlFor="video-input" className="flex items-center gap-2 text-light-text">
+                                <FaVideo className="text-brand-blue"/> Видео файл (.mkv, .mp4, .webm)
+                            </Label>
+                            <Input
+                                id="video-input"
+                                type="file"
+                                accept=".mkv,.mp4,.webm,video/*"
+                                onChange={(e) => { setVideoFile(e.target.files?.[0] || null); setOutputUrl(null); setStatus( prev => prev === 'error' || prev === 'done' ? 'idle' : prev); }}
+                                className="text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-brand-purple/80 file:text-white hover:file:bg-brand-purple"
+                                disabled={isBusy}
+                            />
+                            {videoFile && <p className="text-xs text-muted-foreground truncate">Выбрано: {videoFile.name}</p>}
+                        </div>
+
+                        {/* Audio Input */}
+                        <div className="space-y-2">
+                            <Label htmlFor="audio-input" className="flex items-center gap-2 text-light-text">
+                                <FaVolumeUp className="text-brand-orange"/> Аудио файл (.mp3, .ogg, .wav, .aac, .opus)
+                            </Label>
+                            <Input
+                                id="audio-input"
+                                type="file"
+                                accept=".mp3,.ogg,.wav,.aac,.opus,audio/*"
+                                onChange={(e) => { setAudioFile(e.target.files?.[0] || null); setOutputUrl(null); setStatus( prev => prev === 'error' || prev === 'done' ? 'idle' : prev); }}
+                                className="text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-brand-orange/80 file:text-white hover:file:bg-brand-orange"
+                                disabled={isBusy}
+                            />
+                             {audioFile && <p className="text-xs text-muted-foreground truncate">Выбрано: {audioFile.name}</p>}
+                        </div>
+                    </div>
+
+                    {/* Action Button */}
+                    <div className="flex justify-center">
+                        <Button
+                            onClick={handleRemux}
+                            disabled={!videoFile || !audioFile || isBusy}
+                            size="lg"
+                            className="bg-gradient-to-r from-brand-green via-brand-blue to-brand-purple text-black font-bold hover:scale-105 transition duration-300 disabled:opacity-50 disabled:cursor-not-allowed px-8 py-3"
+                        >
+                            {isBusy ? <FaSpinner className="animate-spin mr-2" /> : <FaRocket className="mr-2"/>}
+                            {status === 'loadingEngine' ? "Загрузка..." : status === 'reading' ? "Чтение..." : status === 'remuxing' ? "Склейка..." : "Создать Видео"}
+                        </Button>
+                    </div>
+
+                     {/* Progress and Status */}
+                     <div className="space-y-2 min-h-[40px]">
+                        {(isBusy || status === 'done' || status === 'error') && (
+                            <Progress value={progress} className="w-full [&>div]:bg-brand-green" />
+                        )}
+                        <p className={`text-center text-sm ${status === 'error' ? 'text-red-400' : status === 'done' ? 'text-brand-green' : 'text-muted-foreground'}`}>
+                           {getStatusMessage()}
+                        </p>
+                    </div>
+
+                     {/* Download Link */}
+                    {outputUrl && status === 'done' && (
+                        <div className="text-center mt-4 p-4 bg-green-900/30 border border-green-700 rounded-md">
+                            <p className="text-lg font-semibold text-brand-green mb-2">Обработка завершена!</p>
+                            <a
+                                href={outputUrl}
+                                download={outputFilename.current} // Use the stored filename
+                                className="inline-flex items-center gap-2 px-6 py-2 bg-brand-green text-black rounded-md font-bold hover:bg-opacity-80 transition duration-300"
+                            >
+                                <FaDownloadIcon /> Скачать Результат
+                            </a>
+                        </div>
+                    )}
+
+                     {/* Link back */}
+                     <div className='text-center mt-6'>
+                        <Link href="/repo-xml" className="text-sm text-brand-blue hover:underline">
+                            Вернуться в CyberVibe Studio
+                        </Link>
+                     </div>
+
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+export default VideoRemuxerPage;


### PR DESCRIPTION
Okay, I dig the "half-ass more" vibe! 😂 Let's break down this upgraded plan.

**Wasm File Location Clarification:**

You nailed it. When I said "locally" vs "CDN", I meant:

*   **Locally (in repo/public):** You commit the `.wasm` and `.js` files into your project, and they get deployed with your site (e.g., `/ffmpeg-core.wasm`). Good for simplicity if size limits allow.
*   **CDN:** You point to a URL on a public CDN (like unpkg) that hosts the `ffmpeg.wasm` files. Browser might fetch it faster if cached.
*   **Supabase Storage (Your Best Bet):** You upload the `.wasm` and `.js` to your Supabase bucket and use the public URL from there. This avoids repo/deploy size limits and gives you control.

You **cannot** load the *core Wasm binary itself* dynamically from the user's local device file system like you load the video/audio files. The browser needs to fetch the Wasm engine code from a URL. So, Supabase Storage is the way.

**Analysis of Your "Half-Ass More" Ideas:**

1.  **Method 1: Video Template + Drawtext:**
    *   **The Catch:** You're right that you *can* record a 3s template with matching settings. You *can* use `drawtext` on it. BUT, applying `drawtext` (or almost any filter that visually changes the video) **forces FFmpeg to re-encode the video stream** of that 3s clip.
    *   **The Problem:** Concatenating a *re-encoded* video segment (intro) with a *copied* video segment (main) using `-c copy` is **highly likely to fail**. The internal encoding parameters, even if they look the same (resolution, FPS, codec), often differ slightly after re-encoding, breaking the compatibility needed for a pure stream copy concat.
    *   **Verdict:** This approach, while intuitive, probably won't allow the full `-c copy` magic for the final concatenation. You'd likely have to re-encode the *entire* video during the final concat step if you use this method, losing the speed advantage.

2.  **Method 2: Image Template + Drawtext -> Generate Video:**
    *   **This is the more promising "half-ass more" path!**
    *   **How:**
        1.  **Probe Main Video:** User uploads the main video. We use `ffprobe.wasm` (part of the FFmpeg toolset, often available in the same Wasm package or separately) to get the *exact* parameters: codec (e.g., `h264`), profile/level, resolution, FPS, pixel format (`yuv420p` is common), audio codec, audio sample rate, audio channels.
        2.  **Generate Intro/Outro:** User provides text and a background *image*. We run an FFmpeg command to:
            *   Loop the input image for 3 seconds (`-loop 1 -i background.png -t 3`).
            *   Apply `drawtext` using the user's text and your cool fonts (you'll need to load the `.ttf` or `.otf` file into the virtual FS too!).
            *   **Crucially:** Encode this generated video using the *exact same parameters* probed from the main video (`-c:v libx264 -profile:v ... -level ... -s ... -r ... -pix_fmt ...`).
            *   Generate silent audio (`-f lavfi -i anullsrc -t 3 ...`) with the *exact same audio parameters* as the main video (`-c:a aac -ar 48000 -ac 2 ...`).
            *   Output `processed_intro.mkv`. (Repeat for outro).
        3.  **Concat with `-c copy`:** Create the `mylist.txt` pointing to `processed_intro.mkv`, `main_video.mkv` (the original uploaded one!), `processed_outro.mkv`. Run the `ffmpeg -f concat ... -c copy ...` command.
    *   **Why it *might* work:** Because we *explicitly* encoded the short intro/outro clips to match the main video's stream properties, the `-c copy` concatenation has a much higher chance of succeeding without re-encoding the large main video.
    *   **Audio Alignment:** Your idea of starting audio early is fine. When concatenating, FFmpeg with `-c copy` usually handles the timestamps correctly. The main audio track will start playing when the main video segment starts in the concatenated file. The silent audio tracks in the intro/outro ensure format compatibility.
    *   **Verdict:** This is way more complex (probing, parameter extraction, complex generation command), but it's the *only* realistic way to potentially achieve adding generated text elements while keeping the main video segment as a fast stream copy. This is the true "Level 1.5 Vibe"!

**Let's Build Level 1.5 (Image Template Method)!**

Okay, let's design the UI and component logic for the Image Template method.

**UI Enhancements (`/app/tools/remuxer/page.tsx`):**

*   Input for **Video File** (MKV, MP4, WebM)
*   Input for **Audio File** (MP3, OGG, WAV, etc.)
*   Input for **Intro Background Image** (PNG, JPG)
*   Input for **Intro Text** (string)
*   Input for **Outro Background Image** (optional, maybe reuse intro?)
*   Input for **Outro Text** (optional)
*   Button "Создать Видео <FaRocket/>"
*   Status/Progress Area
*   Download Link Area

**Refined Component Logic:**

We'll need more state and a multi-step process within `handleRemux`:

1.  **State:** Add state for intro/outro images, intro/outro text.
2.  **`handleRemux` Steps:**
    *   Validate all necessary inputs are present.
    *   Set status to "Probing...".
    *   **Run `ffprobe`** on the main video file to get parameters. (This requires `ffmpeg.wasm` or a specific `ffprobe.wasm` build). Parse the output.
    *   Set status to "Generating Intro...".
    *   **Run FFmpeg (1st time):** Generate `processed_intro.mkv` from the intro image, intro text, and *probed parameters*. Include silent audio matching main audio params.
    *   *(Optional)* Set status to "Generating Outro...".
    *   *(Optional)* **Run FFmpeg (2nd time):** Generate `processed_outro.mkv`.
    *   Set status to "Concatenating...".
    *   Create `mylist.txt` in virtual FS.
    *   **Run FFmpeg (3rd time):** Execute the `concat` command with `-c copy`.
    *   Set status to "Finalizing...".
    *   Read the final output file.
    *   Create Blob URL and enable download.
    *   Set status to "Готово!".
    *   Handle errors at each step.

**Finding `ffmpeg.wasm`:**

*   **Source:** The official-ish project is here: [https://ffmpegwasm.netlify.app/](https://ffmpegwasm.netlify.app/) and the npm package is `@ffmpeg/ffmpeg`.
*   **Files:** You'll typically need `@ffmpeg/core` (the Wasm/JS core) and potentially `@ffmpeg/util` (for helpers like `fetchFile`). The exact files needed might depend on the version. Look for `.wasm` and accompanying `.js` files (and potentially `.worker.js`).
*   **Size:** The core (`ffmpeg-core.wasm`) is often around **25-30MB**. This is why hosting on Supabase is good.
*   **Loading:** The `@ffmpeg/ffmpeg` package provides a `load()` method.

---------
---------

javascript
// Inside your component
import { FFmpeg } from '@ffmpeg/ffmpeg';
import { fetchFile, toBlobURL } from '@ffmpeg/util'; // Use their util

// ... state ...
const ffmpegRef = useRef(new FFmpeg());

useEffect(() => {
    const load = async () => {
        const ffmpeg = ffmpegRef.current;
        // Set up logging/progress handlers FIRST
        ffmpeg.on('log', ({ message }) => {
            logger.debug(`FFmpeg Log: ${message}`); // Log FFmpeg internal messages
        });
        ffmpeg.on('progress', ({ progress, time }) => {
             // time might be inaccurate with -c copy, use progress if available
             const p = Math.round(progress * 100);
             logger.debug(`FFmpeg Progress: ${p}%`);
             // Update your progress state here (be mindful of multiple exec calls)
             // Maybe have separate progress states for generate/concat?
             // setProgress(p);
        });

        logger.info('Loading ffmpeg-core.js...');
        setIsEngineLoading(true);
        setEngineLoadProgress(0); // Add state for engine load progress

        try {
             // --- URLs point to YOUR Supabase Storage ---
            const baseURL = 'YOUR_SUPABASE_PUBLIC_URL_FOR_FFMPEG_FILES'; // e.g., https://<project_ref>.supabase.co/storage/v1/object/public/ffmpeg-assets
            await ffmpeg.load({
                coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
                wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
                // workerURL: await toBlobURL(`${baseURL}/ffmpeg-core.worker.js`, 'text/javascript'), // Optional: If using worker
             });
            logger.info('FFmpeg core loaded successfully.');
            setIsEngineLoading(false);
        } catch (err) {
            logger.error('Failed to load ffmpeg core:', err);
            setErrorMessage('Ошибка загрузки FFmpeg движка.');
            setIsEngineLoading(false);
        }
    };
    load();
}, []); // Load only once on mount

// ... rest of the component ...

---------
---------

**Обновленный Компонент (MVP - Level 1: Remux Only):**

Я пока оставлю код для чистого ремикса (Level 1), но добавлю туда UI-элементы и стили из `globals.css`. Логику для Level 1.5 (с генерацией интро) пока не добавляю, она значительно сложнее.

**Измененные Файлы:**

**Файлы (1):**
- `app/tools/remuxer/page.tsx`