### PR TITLE
Fix: Поменял местами кнопку "Тайлы" и "ЮзерИнфо" в хедере

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -28,7 +28,6 @@ interface PageInfo {
   color?: 'purple' | 'blue' | 'yellow' | 'lime' | 'green' | 'pink' | 'cyan' | 'red';
 }
 
-
 const allPages: PageInfo[] = [
   // --- Важные ссылки ---
   { path: "/", name: "Fix13min", icon: FaDumbbell, isImportant: true, color: "cyan" },
@@ -275,9 +274,6 @@ export default function Header() {
                 {currentLang === 'en' ? 'RU' : 'EN'}
               </button>
 
-              {/* User Info */}
-              <UserInfo />
-
               {/* Navigation Toggle Button (Only shows when nav is closed) */}
               {!isNavOpen && (
                 <button
@@ -288,6 +284,9 @@ export default function Header() {
                   <LayoutGrid className="h-6 w-6" />
                 </button>
               )}
+
+              {/* User Info */}
+              <UserInfo />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fix: Поменял местами кнопку "Тайлы" и "ЮзерИнфо" в хедере

Пользователь попросил переместить кнопку открытия навигации (иконка `LayoutGrid`, "тайлы") левее информации о пользователе (`UserInfo`), так как в текущем расположении она перекрывается другим элементом интерфейса и её сложно нажать.

Изменения:
*   В компоненте `Header.tsx` изменен порядок следования элементов в правом блоке управления:
    *   Кнопка открытия навигации (`LayoutGrid`) теперь отображается **перед** компонентом `UserInfo`.
    *   Компонент `UserInfo` теперь отображается **после** кнопки `LayoutGrid`.
    *   Кнопка переключения языка остается на своем месте, самой левой в этой группе.

Это должно решить проблему с перекрытием кнопки "тайлов".

**Файлы (1):**
- `components/Header.tsx`