### PR TITLE
Feat: Внедрена валидация Telegram Auth (SHA-256) и добавлен новый "пер

### DIFF
--- a/app/api/validate-telegram-auth/route.ts
+++ b/app/api/validate-telegram-auth/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { webcrypto } from 'crypto'; // Using Node.js crypto module for server-side
+
+const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+
+async function validateTelegramHash(initDataString: string): Promise<{ isValid: boolean; user?: any; error?: string }> {
+  if (!BOT_TOKEN) {
+    console.error("SERVER ERROR: TELEGRAM_BOT_TOKEN environment variable is not set.");
+    return { isValid: false, error: "Bot token not configured on server." };
+  }
+
+  const params = new URLSearchParams(initDataString);
+  const hash = params.get("hash");
+  if (!hash) {
+    return { isValid: false, error: "Hash not found in initData." };
+  }
+
+  params.delete("hash"); // Remove hash from params for data-check-string
+  const dataToCheck: string[] = [];
+  // URLSearchParams.entries() returns an iterator. Convert to array and sort.
+  // Keys must be sorted alphabetically.
+  const sortedParams = Array.from(params.entries()).sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+  
+  for (const [key, value] of sortedParams) {
+    dataToCheck.push(`${key}=${value}`);
+  }
+
+  const dataCheckString = dataToCheck.join("\n");
+
+  try {
+    const secretKey = await webcrypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode("WebAppData"), // "WebAppData" is the salt for the first HMAC
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+
+    const botTokenKey = await webcrypto.subtle.sign( // This produces the key for the second HMAC
+      "HMAC",
+      secretKey,
+      new TextEncoder().encode(BOT_TOKEN)
+    );
+    
+    // Now use this derived key to sign the data_check_string
+     const finalKeyForSigning = await webcrypto.subtle.importKey(
+      "raw",
+      botTokenKey, // This is the result of HMAC_SHA256(BOT_TOKEN, "WebAppData")
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+
+    const signatureBuffer = await webcrypto.subtle.sign(
+      "HMAC",
+      finalKeyForSigning, 
+      new TextEncoder().encode(dataCheckString)
+    );
+
+    const signatureHex = Array.from(new Uint8Array(signatureBuffer))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    if (signatureHex === hash) {
+      const userParam = params.get("user"); // Use original params to get user, as it was part of dataCheckString
+      if (userParam) {
+        try {
+          const user = JSON.parse(decodeURIComponent(userParam));
+          return { isValid: true, user };
+        } catch (e) {
+          console.error("Error parsing user data from initData:", e);
+          return { isValid: false, error: "Failed to parse user data." };
+        }
+      }
+      return { isValid: true }; 
+    } else {
+      console.warn("Hash validation failed. Generated:", signatureHex, "Received:", hash, "DataChecked:", dataCheckString);
+      return { isValid: false, error: "Hash mismatch." };
+    }
+  } catch (e: any) {
+    console.error("Error during crypto operations:", e);
+    return { isValid: false, error: `Crypto error: ${e.message}` };
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { initData } = body;
+
+    if (typeof initData !== "string") {
+      return NextResponse.json({ error: "initData must be a string." }, { status: 400 });
+    }
+
+    if (!BOT_TOKEN) {
+        console.error("FATAL API ERROR: TELEGRAM_BOT_TOKEN is not set on the server.");
+        return NextResponse.json({ error: "Server configuration error: Bot token missing." }, { status: 500 });
+    }
+    
+    const validationResult = await validateTelegramHash(initData);
+    
+    return NextResponse.json(validationResult, { 
+        status: validationResult.isValid ? 200 : 401 
+    });
+
+  } catch (e: any) {
+    console.error("Error processing POST request in /api/validate-telegram-auth:", e);
+    return NextResponse.json({ error: `Server error: ${e.message}` }, { status: 500 });
+  }
+}

--- a/hooks/useTelegram.ts
+++ b/hooks/useTelegram.ts
@@ -2,9 +2,9 @@
 
 import { useCallback, useEffect, useState, useMemo } from "react";
 import { debugLogger } from "@/lib/debugLogger";
-import { logger as globalLogger } from "@/lib/logger"; // Renamed to avoid conflict with local logger alias
+import { logger as globalLogger } from "@/lib/logger"; 
 import { createOrUpdateUser as dbCreateOrUpdateUser, fetchUserData as dbFetchUserData } from "@/hooks/supabase";
-import type { TelegramWebApp, WebAppUser } from "@/types/telegram";
+import type { TelegramWebApp, WebAppUser, WebAppInitData } from "@/types/telegram";
 import type { Database } from "@/types/database.types";
 
 type DatabaseUser = Database["public"]["Tables"]["users"]["Row"] | null;
@@ -13,9 +13,14 @@ interface AuthResult {
     dbUserToSet: DatabaseUser;
     isAuthenticatedToSet: boolean;
 }
+interface ValidatedUserData extends WebAppUser {
+  // Placeholder for any additional fields backend might return or parse
+}
 
+
+const MOCK_USER_ID_STR = process.env.NEXT_PUBLIC_MOCK_USER_ID || "413553377";
 const MOCK_USER: WebAppUser | null = process.env.NEXT_PUBLIC_USE_MOCK_USER === 'true' ? {
-  id: parseInt(process.env.NEXT_PUBLIC_MOCK_USER_ID || "413553377"),
+  id: parseInt(MOCK_USER_ID_STR, 10),
   first_name: process.env.NEXT_PUBLIC_MOCK_USER_FIRST_NAME || "Mock",
   last_name: process.env.NEXT_PUBLIC_MOCK_USER_LAST_NAME || "User",
   username: process.env.NEXT_PUBLIC_MOCK_USER_USERNAME || "mockuser",
@@ -26,6 +31,57 @@ const MOCK_USER: WebAppUser | null = process.env.NEXT_PUBLIC_USE_MOCK_USER === '
 if (MOCK_USER) {
     globalLogger.warn("Using mock Telegram user for development. Ensure NEXT_PUBLIC_USE_MOCK_USER is 'false' or unset in production.");
 }
+
+async function validateTelegramAuth(initDataString: string): Promise<ValidatedUserData | null> {
+  if (!initDataString) {
+    debugLogger.warn("[validateTelegramAuth] initDataString is empty.");
+    return null;
+  }
+  try {
+    debugLogger.log("[validateTelegramAuth] Calling Supabase Edge Function 'validate-telegram-auth'");
+    const response = await fetch('/functions/v1/validate-telegram-auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ initData: initDataString }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      globalLogger.error(`[validateTelegramAuth] Validation failed. Status: ${response.status}`, errorBody);
+      throw new Error(`Telegram data validation failed: ${errorBody || response.statusText}`);
+    }
+
+    const result = await response.json();
+    if (result.isValid && result.user) {
+      debugLogger.log("[validateTelegramAuth] Telegram data successfully validated. User:", result.user);
+      // Ensure the user object has the 'id' field, potentially converting from user.id if that's how TG sends it
+      const tgUser = result.user as WebAppInitData['user'];
+      if (!tgUser || typeof tgUser.id !== 'number') {
+          globalLogger.error("[validateTelegramAuth] Validated user data is missing id or id is not a number.", tgUser);
+          throw new Error("Validated user data is malformed (missing or invalid id).");
+      }
+      return { // Ensure it conforms to WebAppUser
+          id: tgUser.id,
+          first_name: tgUser.first_name,
+          last_name: tgUser.last_name,
+          username: tgUser.username,
+          language_code: tgUser.language_code,
+          photo_url: tgUser.photo_url,
+          is_premium: tgUser.is_premium,
+          is_bot: tgUser.is_bot,
+          added_to_attachment_menu: tgUser.added_to_attachment_menu,
+          allows_write_to_pm: tgUser.allows_write_to_pm,
+      };
+    } else {
+      globalLogger.warn("[validateTelegramAuth] Validation unsuccessful or no user data returned from backend.", result);
+      return null;
+    }
+  } catch (error) {
+    globalLogger.error("[validateTelegramAuth] Error during validation call:", error);
+    return null;
+  }
+}
+
 
 export function useTelegram() {
   const [tgWebApp, setTgWebApp] = useState<TelegramWebApp | null>(null);
@@ -38,55 +94,56 @@ export function useTelegram() {
   const [isAuthenticated, setIsAuthenticated] = useState(false); 
 
   const handleAuthentication = useCallback(
-    async (telegramUserToAuth: WebAppUser): Promise<AuthResult> => {
-      debugLogger.log("[handleAuthentication] Started for:", telegramUserToAuth?.id);
+    async (userToAuth: WebAppUser): Promise<AuthResult> => {
+      debugLogger.log("[handleAuthentication] Started for user ID:", userToAuth?.id);
       
-      if (!telegramUserToAuth?.id) {
-         globalLogger.error("[handleAuthentication] Invalid Telegram user data received.");
-         throw new Error("Invalid Telegram user data received.");
+      if (!userToAuth?.id) {
+         globalLogger.error("[handleAuthentication] Invalid user data: missing id.");
+         throw new Error("Invalid user data: missing id.");
       }
-      const userIdStr = telegramUserToAuth.id.toString();
+      const userIdStr = userToAuth.id.toString();
 
       try {
          let userFromDb = await dbFetchUserData(userIdStr);
+         debugLogger.log(`[handleAuthentication] Fetched user ${userIdStr} from DB. Exists: ${!!userFromDb}`);
 
          if (!userFromDb) {
             debugLogger.log(`[handleAuthentication] User ${userIdStr} not found in DB, creating...`);
-            userFromDb = await dbCreateOrUpdateUser(userIdStr, telegramUserToAuth);
-             if (!userFromDb) { // Explicitly check if creation failed
-                 globalLogger.error(`[handleAuthentication] Failed to create user ${userIdStr} in database.`);
+            userFromDb = await dbCreateOrUpdateUser(userIdStr, userToAuth);
+             if (!userFromDb) { 
+                 globalLogger.error(`[handleAuthentication] Failed to create user ${userIdStr} in DB (returned null).`);
                  throw new Error(`Failed to create user ${userIdStr} in database.`);
              }
-             globalLogger.info(`[handleAuthentication] New user ${userIdStr} (${telegramUserToAuth.username || ''}) created.`);
+             globalLogger.info(`[handleAuthentication] New user ${userIdStr} (${userToAuth.username || ''}) created in DB.`);
          } else {
             debugLogger.log(`[handleAuthentication] User ${userIdStr} found in DB. Checking for updates...`);
             const needsUpdate = (
-                userFromDb.username !== telegramUserToAuth.username ||
-                userFromDb.full_name !== `${telegramUserToAuth.first_name || ""} ${telegramUserToAuth.last_name || ""}`.trim() ||
-                userFromDb.avatar_url !== telegramUserToAuth.photo_url
+                userFromDb.username !== userToAuth.username ||
+                userFromDb.full_name !== `${userToAuth.first_name || ""} ${userToAuth.last_name || ""}`.trim() ||
+                userFromDb.avatar_url !== userToAuth.photo_url ||
+                userFromDb.language_code !== userToAuth.language_code
             );
             if(needsUpdate) {
                 debugLogger.log(`[handleAuthentication] User ${userIdStr} data differs, updating...`);
-                userFromDb = await dbCreateOrUpdateUser(userIdStr, telegramUserToAuth);
-                 if (!userFromDb) { // Explicitly check if update failed
-                     globalLogger.error(`[handleAuthentication] Failed to update user ${userIdStr} in database.`);
+                userFromDb = await dbCreateOrUpdateUser(userIdStr, userToAuth);
+                 if (!userFromDb) { 
+                     globalLogger.error(`[handleAuthentication] Failed to update user ${userIdStr} in DB (returned null).`);
                      throw new Error(`Failed to update user ${userIdStr} in database.`);
                  }
-                 globalLogger.info(`[handleAuthentication] User ${userIdStr} (${telegramUserToAuth.username || ''}) updated.`);
+                 globalLogger.info(`[handleAuthentication] User ${userIdStr} (${userToAuth.username || ''}) updated in DB.`);
             } else {
                  debugLogger.log(`[handleAuthentication] User ${userIdStr} data is up-to-date.`);
             }
          }
-         // At this point, userFromDb MUST be a valid user object if no error was thrown
-         debugLogger.log(`[handleAuthentication] Successful for user ${userIdStr}. dbUser.id: ${userFromDb.id}, username: ${userFromDb.username}`);
+         debugLogger.log(`[handleAuthentication] Successful for user ${userIdStr}. dbUser.user_id: ${userFromDb.user_id}, username: ${userFromDb.username}`);
          return { 
-            tgUserToSet: telegramUserToAuth, 
+            tgUserToSet: userToAuth, 
             dbUserToSet: userFromDb, 
             isAuthenticatedToSet: true 
         };
 
       } catch (err) {
-         globalLogger.error(`[handleAuthentication] Auth FAILED for user ${telegramUserToAuth.id}:`, err);
+         globalLogger.error(`[handleAuthentication] Auth FAILED for user ${userToAuth.id}:`, err);
          const authError = err instanceof Error ? err : new Error("Authentication failed due to an unknown error in handleAuthentication.");
          throw authError; 
       }
@@ -96,100 +153,100 @@ export function useTelegram() {
 
   useEffect(() => {
     let isMounted = true;
-    debugLogger.log("[useTelegram Effect] Running, isMounted:", isMounted);
+    debugLogger.log("[useTelegram Effect Main Init] Running, isMounted:", isMounted);
 
     const initialize = async () => {
-      debugLogger.log("[useTelegram Initialize] Started");
+      debugLogger.log("[useTelegram initialize async fn] Started");
       if (!isMounted) {
-          debugLogger.log("[useTelegram Initialize] Aborted: component unmounted");
+          debugLogger.log("[useTelegram initialize async fn] Aborted: component unmounted");
           return;
       }
 
-      // Initial state before any async work
       setIsLoading(true); 
       setIsAuthenticating(true);
       setError(null);
-      setIsAuthenticated(false);
+      setIsAuthenticated(false); 
       setDbUser(null); 
       setTgUser(null);
-      setTgWebApp(null);
-      setIsInTelegramContext(false); 
-
+      
       let authCandidate: WebAppUser | null = null;
       let inTgContextReal = false;
       let tempTgWebApp: TelegramWebApp | null = null;
 
-      // Determine authCandidate and context (sync part)
       if (typeof window !== "undefined" && (window as any).Telegram?.WebApp) {
         const telegram = (window as any).Telegram.WebApp;
-        tempTgWebApp = telegram; 
-        debugLogger.log("[useTelegram Initialize] Telegram WebApp context detected", {
-            initDataUnsafeUserExists: !!telegram.initDataUnsafe?.user,
-            initDataUnsafeUser: telegram.initDataUnsafe?.user, // Log the actual user object
-            initData: telegram.initData // Log the raw initData string
-        });
+        tempTgWebApp = telegram;
+        inTgContextReal = !!telegram.initData; // Presence of initData implies Telegram context
         
-        if (telegram.initDataUnsafe?.user && telegram.initDataUnsafe.user.id) { // Check for user and user.id
-          inTgContextReal = true;
-          authCandidate = telegram.initDataUnsafe.user;
-          telegram.ready(); 
-          debugLogger.log("[useTelegram Initialize] Auth candidate from Telegram:", authCandidate);
-        } else {
-           debugLogger.warn("[useTelegram Initialize] Telegram context found, but no valid user data in initDataUnsafe. Mock user check next.");
-           if (MOCK_USER) {
-               globalLogger.warn("[useTelegram Initialize] No user data in Telegram context, WILL use MOCK_USER.");
-               authCandidate = MOCK_USER;
-               inTgContextReal = false; 
-               debugLogger.log("[useTelegram Initialize] Auth candidate from MOCK_USER:", authCandidate);
-           }
-        }
-      } else {
-        debugLogger.log("[useTelegram Initialize] Not running inside Telegram WebApp context. Mock user check next.");
-        inTgContextReal = false;
-        if (MOCK_USER) {
-           globalLogger.warn("[useTelegram Initialize] Not in Telegram context, WILL use MOCK_USER.");
-           authCandidate = MOCK_USER;
-           debugLogger.log("[useTelegram Initialize] Auth candidate from MOCK_USER:", authCandidate);
+        debugLogger.log("[useTelegram initialize] Telegram WebApp context detected.", {
+            initDataExists: !!telegram.initData,
+            initDataUnsafeUserExists: !!telegram.initDataUnsafe?.user,
+            initDataUnsafeUserId: telegram.initDataUnsafe?.user?.id,
+        });
+        telegram.ready(); // Call ready() early
+
+        if (telegram.initData && inTgContextReal) {
+            debugLogger.log("[useTelegram initialize] Validating Telegram initData...");
+            const validatedUser = await validateTelegramAuth(telegram.initData);
+            if (validatedUser) {
+                authCandidate = validatedUser;
+                globalLogger.info("[useTelegram initialize] Telegram auth validated successfully. Candidate from validated initData:", authCandidate.id);
+            } else {
+                globalLogger.warn("[useTelegram initialize] Telegram initData validation FAILED.");
+                // Decide fallback: error or mock user? For now, error if in TG context but validation fails.
+                 if (isMounted) setError(new Error("Telegram data validation failed. User data might be compromised."));
+            }
+        } else if (telegram.initDataUnsafe?.user && telegram.initDataUnsafe.user.id && !inTgContextReal /* Should not happen if initData exists */) {
+           // This case is less likely if initData validation is primary. Retained for robustness.
+           globalLogger.warn("[useTelegram initialize] Using initDataUnsafe as fallback (initData not present/validated). THIS IS LESS SECURE.");
+           authCandidate = telegram.initDataUnsafe.user;
         }
       }
+
+      // Fallback to MOCK_USER if no authCandidate from Telegram and MOCK_USER is enabled
+      if (!authCandidate && MOCK_USER) {
+          globalLogger.warn(`[useTelegram initialize] No auth candidate from Telegram (or validation failed). ${inTgContextReal ? "Falling back to" : "Using"} MOCK_USER.`);
+          authCandidate = MOCK_USER;
+          inTgContextReal = false; // If we use mock, it's not a real TG context for auth purposes
+      }
       
-      if (isMounted) { // Set non-auth-critical states early
+      if (isMounted) { 
         setTgWebApp(tempTgWebApp);
         setIsInTelegramContext(inTgContextReal);
       }
       
-      // Async authentication part
       if (authCandidate) {
         try {
-          debugLogger.log(`[useTelegram Initialize] Calling handleAuthentication for user: ${authCandidate.id}`);
+          debugLogger.log(`[useTelegram initialize] Calling handleAuthentication for user: ${authCandidate.id}`);
           const authData = await handleAuthentication(authCandidate);
           if (isMounted) {
-            const oldDbUser = dbUser;
             setTgUser(authData.tgUserToSet);
             setDbUser(authData.dbUserToSet); 
             setIsAuthenticated(authData.isAuthenticatedToSet);
-            setError(null);
-            globalLogger.log(`[useTelegram Initialize] States set after successful auth. Prev dbUser.id: ${oldDbUser?.id}, New dbUser.id: ${authData.dbUserToSet?.id}, isAuthenticated: ${authData.isAuthenticatedToSet}`);
+            setError(null); // Clear previous errors on success
+            globalLogger.info(`[useTelegram initialize] States set after successful auth. dbUser.user_id: ${authData.dbUserToSet?.user_id}, isAuthenticated: ${authData.isAuthenticatedToSet}`);
           }
         } catch (authProcessError: any) {
-          debugLogger.error("[useTelegram Initialize] Error during handleAuthentication or state setting:", authProcessError.message);
+          debugLogger.error("[useTelegram initialize] Error during handleAuthentication or state setting:", authProcessError);
           if (isMounted) {
             setError(authProcessError);
-            setTgUser(authCandidate); // Keep original TG user if available, even if DB ops failed
+            setTgUser(authCandidate); 
             setDbUser(null);          
             setIsAuthenticated(false); 
           }
         } finally {
           if (isMounted) {
             setIsAuthenticating(false); 
-            debugLogger.log("[useTelegram Initialize] Auth process finished (setIsAuthenticating(false)). isMounted:", isMounted);
+            debugLogger.log("[useTelegram initialize] Auth process finished (setIsAuthenticating(false)).");
           }
         }
       } else { 
         if (isMounted) {
-          const noAuthError = new Error("No authentication candidate: Not in Telegram, MOCK_USER disabled, or Telegram.WebApp.initDataUnsafe.user is missing/invalid.");
-          setError(noAuthError);
-          globalLogger.warn(`[useTelegram Initialize] ${noAuthError.message}`);
+           if (!error) { // Set error only if not already set by validation failure
+             const noAuthError = new Error("No authentication candidate: Not in Telegram or MOCK_USER disabled, or Telegram data missing/invalid.");
+             setError(noAuthError);
+             globalLogger.warn(`[useTelegram Initialize] ${noAuthError.message}`);
+           }
           setTgUser(null);
           setDbUser(null);
           setIsAuthenticated(false);
@@ -201,17 +258,17 @@ export function useTelegram() {
     initialize();
 
     return () => {
-      debugLogger.log("[useTelegram Effect Cleanup] Setting isMounted=false");
+      debugLogger.log("[useTelegram Effect Main Init Cleanup] Setting isMounted=false");
       isMounted = false;
     };
-  }, [handleAuthentication]); 
+  }, [handleAuthentication]); // handleAuthentication's own dependencies are dbCreateOrUpdateUser, dbFetchUserData
 
   useEffect(() => {
     if (!isAuthenticating) { 
       setIsLoading(false);
-      globalLogger.log(`[useTelegram Effect dbUser/isAuth] isAuthenticating is false. Setting isLoading to false. dbUser ID: ${dbUser?.id}, isAuthenticated: ${isAuthenticated}`);
+      globalLogger.log(`[useTelegram Effect isLoading] isAuthenticating is false. Setting isLoading to false. dbUser.user_id: ${dbUser?.user_id}, isAuthenticated: ${isAuthenticated}, error: ${error?.message}`);
     }
-  }, [dbUser, isAuthenticated, isAuthenticating]); // Added isAuthenticated dependency for completeness
+  }, [dbUser, isAuthenticated, isAuthenticating, error]);
 
   const isAdmin = useCallback(() => {
     if (!dbUser) return false;
@@ -250,22 +307,23 @@ export function useTelegram() {
         close: () => safeWebAppCall('close'),
         showPopup: (params: any) => safeWebAppCall('showPopup', params), 
         sendData: (data: string) => safeWebAppCall('sendData', data),
-        getInitData: () => tgWebApp?.initDataUnsafe ?? null, 
+        getInitData: () => tgWebApp?.initDataUnsafe ?? null, // For debug, validated initData should be used internally
         expand: () => safeWebAppCall('expand'),
         setHeaderColor: (color: string) => safeWebAppCall('setHeaderColor', color),
         setBackgroundColor: (color: string) => safeWebAppCall('setBackgroundColor', color),
         platform: tgWebApp?.platform ?? 'unknown',
         themeParams: tgWebApp?.themeParams ?? { bg_color: '#000000', text_color: '#ffffff', hint_color: '#888888', link_color: '#007aff', button_color: '#007aff', button_text_color: '#ffffff', secondary_bg_color: '#1c1c1d', header_bg_color: '#000000', accent_text_color: '#007aff', section_bg_color: '#1c1c1d', section_header_text_color: '#8e8e93', subtitle_text_color: '#8e8e93', destructive_text_color: '#ff3b30' },
-        initData: tgWebApp?.initData,
-        initDataUnsafe: tgWebApp?.initDataUnsafe,
+        initData: tgWebApp?.initData, // Raw initData string
+        initDataUnsafe: tgWebApp?.initDataUnsafe, // Unsafe data (potentially for non-critical UI)
         colorScheme: tgWebApp?.colorScheme ?? 'dark',
     };
     debugLogger.log("[useTelegram useMemo] Creating baseData.", {
         isLoading: baseData.isLoading,
         isAuthenticating: baseData.isAuthenticating,
-        dbUserId: baseData.dbUser?.id,
+        dbUserId: baseData.dbUser?.user_id,
         isAuthenticated: baseData.isAuthenticated,
         tgUserId: baseData.user?.id,
+        error: baseData.error?.message
     });
     return baseData;
   }, [

--- a/supabase/functions/validate-telegram-auth/index.ts
+++ b/supabase/functions/validate-telegram-auth/index.ts
@@ -1,0 +1,130 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { crypto } from "https://deno.land/std@0.177.0/crypto/mod.ts";
+
+const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
+
+if (!BOT_TOKEN) {
+  console.error("FATAL: TELEGRAM_BOT_TOKEN environment variable is not set.");
+  // In a real scenario, you might want to prevent the function from serving
+  // or return a specific error, but for now, it will proceed and fail hash validation.
+}
+
+async function validateHash(initDataString: string): Promise<{ isValid: boolean; user?: any; error?: string }> {
+  if (!BOT_TOKEN) {
+    return { isValid: false, error: "Bot token not configured on server." };
+  }
+
+  const params = new URLSearchParams(initDataString);
+  const hash = params.get("hash");
+  if (!hash) {
+    return { isValid: false, error: "Hash not found in initData." };
+  }
+
+  const dataToCheck: string[] = [];
+  params.forEach((value, key) => {
+    if (key !== "hash") {
+      dataToCheck.push(`${key}=${value}`);
+    }
+  });
+
+  dataToCheck.sort(); // Sort alphabetically
+  const dataCheckString = dataToCheck.join("\n");
+
+  try {
+    const secretKeyData = new TextEncoder().encode("WebAppData");
+    const secretKey = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(BOT_TOKEN),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+    
+    const intermediateHashBuffer = await crypto.subtle.sign(
+      "HMAC",
+      secretKey,
+      secretKeyData
+    );
+    
+    const finalSecretKey = await crypto.subtle.importKey(
+      "raw",
+      intermediateHashBuffer,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+
+    const signatureBuffer = await crypto.subtle.sign(
+      "HMAC",
+      finalSecretKey,
+      new TextEncoder().encode(dataCheckString)
+    );
+
+    const signatureHex = Array.from(new Uint8Array(signatureBuffer))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    if (signatureHex === hash) {
+      const userParam = params.get("user");
+      if (userParam) {
+        try {
+          const user = JSON.parse(decodeURIComponent(userParam));
+          return { isValid: true, user };
+        } catch (e) {
+          console.error("Error parsing user data from initData:", e);
+          return { isValid: false, error: "Failed to parse user data." };
+        }
+      }
+      return { isValid: true }; // Valid hash but no user data found (should not happen with WebApp)
+    } else {
+      console.warn("Hash validation failed. Generated:", signatureHex, "Received:", hash);
+      return { isValid: false, error: "Hash mismatch." };
+    }
+  } catch (e) {
+    console.error("Error during crypto operations:", e);
+    return { isValid: false, error: `Crypto error: ${e.message}` };
+  }
+}
+
+serve(async (req: Request) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  try {
+    const { initData } = await req.json();
+    if (typeof initData !== "string") {
+      return new Response(JSON.stringify({ error: "initData must be a string." }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const validationResult = await validateHash(initData);
+    
+    return new Response(JSON.stringify(validationResult), {
+      status: validationResult.isValid ? 200 : 401, // Unauthorized if not valid
+      headers: { "Content-Type": "application/json" },
+    });
+
+  } catch (e) {
+    console.error("Error processing request in Edge Function:", e);
+    return new Response(JSON.stringify({ error: `Server error: ${e.message}` }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});
+
+/*
+Test with curl:
+curl -X POST 'http://localhost:54321/functions/v1/validate-telegram-auth' \
+-H "Authorization: Bearer YOUR_SUPABASE_ANON_KEY" \
+-H "Content-Type: application/json" \
+-d '{
+  "initData": "user=%7B%22id%22%3A413553377%2C%22first_name%22%3A%22Sergey%22%2C%22last_name%22%3A%22%F0%9F%AA%A6%22%2C%22username%22%3A%22SALAVEY%22%2C%22language_code%22%3A%22en%22%2C%22is_premium%22%3Atrue%2C%22allows_write_to_pm%22%3Atrue%7D&chat_instance=8177329295040631650&chat_type=sender&auth_date=1715551981&hash=YOUR_ACTUAL_HASH_FROM_TELEGRAM"
+}'
+
+Replace YOUR_SUPABASE_ANON_KEY and YOUR_ACTUAL_HASH_FROM_TELEGRAM.
+The initData string should be URL encoded as Telegram sends it.
+*/


### PR DESCRIPTION
Feat: Внедрена валидация Telegram Auth (SHA-256) и добавлен новый "перк"

Привет, вайб-компаньон! Поймал несколько важных моментов:

1.  **Исправлена проблема "Guest Mode" на странице Профиля (`/app/profile/page.tsx`):**
    *   **Ключевая ошибка:** В коде страницы Профиля для проверки пользователя использовалось `dbUser?.id`. Однако, в нашей схеме базы данных (таблица `users`) поле идентификатора называется `user_id`. Соответственно, `dbUser?.id` всегда было `undefined`, что приводило к отображению "Guest Mode" даже для аутентифицированных пользователей.
    *   **Исправление:** Заменил все обращения `dbUser?.id` на `dbUser?.user_id`. Теперь профиль должен корректно определять пользователя. Нулевая статистика, которую ты видел, была связана с тем, что для твоего реального пользователя в Supabase в поле `metadata` отсутствовал ключ `cyberFitness`. После первого же действия, логируемого `CyberFitness` (например, открытие StickyChat, которое ты делал), это поле должно было создаться с начальными значениями и любыми заработанными ачивками.

2.  **Безопасность: Валидация Telegram `initData` (Анти-спуфинг):**
    *   **Проблема:** Ранее мы доверяли данным из `window.Telegram.WebApp.initDataUnsafe.user`. Это небезопасно, так как эти данные можно подделать.
    *   **Решение:** Внедрена проверка подлинности данных от Telegram.
        *   **Новая Supabase Edge Function (`/supabase/functions/validate-telegram-auth/index.ts`):** Эта функция принимает строку `initData` от Telegram. На сервере она проверяет хеш (`hash`), используя твой `BOT_TOKEN` (который нужно будет установить как секрет в Supabase). Если хеш валиден, функция возвращает данные пользователя.
        *   **Обновлен `useTelegram.ts`:**
            *   Теперь хук получает `window.Telegram.WebApp.initData`.
            *   Отправляет эту строку в новую Edge Function для валидации.
            *   Только после успешной валидации данные пользователя используются для аутентификации в приложении и создания/обновления записи в БД.
            *   Если валидация не удалась или `initData` отсутствует, будет установлена ошибка (или использован MOCK_USER, если включен).
    *   **ВАЖНО:** Тебе нужно будет создать эту Edge Function в своем проекте Supabase и **установить переменную окружения `TELEGRAM_BOT_TOKEN`** для этой функции со значением твоего токена бота Telegram.

3.  **Новый Перк/Ачивка: "Кунг-фу Двух Пальцев" (<FaMobileScreenButton />):**
    *   Как ты и просил, добавил новую ачивку в `cyberFitnessSupabase.ts` за мастерство мобильного ввода!
    *   **ID:** `two_finger_fu`
    *   **Название:** `Кунг-фу Двух Пальцев`
    *   **Описание:** `Продемонстрировал мастерство молниеносного мобильного ввода и навигации в стиле Mortal Kombat.`
    *   **Иконка:** `<FaMobileScreenButton />`
    *   **Награда:** 75 KiloVibes.
    *   **Условие:** Пока что `checkCondition: () => false`. Это означает, что ачивка не будет выдаваться автоматически по какому-то условию в профиле, а задумана как квестовая – ее можно будет выдать через `completeQuestAndUpdateProfile` (например, админом или по выполнению какого-то специфического действия в будущем, которое мы сможем отследить).

**Что дальше:**
*   Проверь, что `dbUser.user_id` теперь корректно используется в `ProfilePage`.
*   Разверни Edge Function `validate-telegram-auth` в Supabase и настрой `TELEGRAM_BOT_TOKEN`.
*   После этих изменений реальный пользователь, заходящий через Telegram, должен видеть свой настоящий профиль (не "Guest Mode") и корректное создание/обновление статистики CyberFitness в его `metadata`.

Let's get this vibe train rolling! 🚀

**Файлы (4):**
- `hooks/useTelegram.ts`
- `supabase/functions/validate-telegram-auth/index.ts`
- `hooks/cyberFitnessSupabase.ts`
- `app/profile/page.tsx`