### PR TITLE
Refactor: Centralize URL parameters in RepoXmlPageContext to reduce pr

### DIFF
--- a/app/api/validate-telegram-auth/route.ts
+++ b/app/api/validate-telegram-auth/route.ts
@@ -1,4 +1,3 @@
-// /app/api/validate-telegram-auth/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { webcrypto } from 'crypto'; 
 import { logger } from '@/lib/logger'; 
@@ -29,7 +28,7 @@ async function validateTelegramHash(initDataString: string): Promise<{ isValid: 
   logger.log(`[API_VALIDATE_HASH_FN_INFO] Client hash: ${hashFromClient}`);
 
   const keys = Array.from(params.keys())
-    .filter(key => key !== "hash")
+    .filter(key => key !== "hash" && key !== "signature")
     .sort();
 
   const dataCheckString = keys.map(key => `${key}=${params.get(key)}`).join('\n');

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,3 @@
-// /app/layout.tsx
 import type React from "react";
 import Script from "next/script";
 import "./globals.css";

--- a/components/AutomationBuddy.tsx
+++ b/components/AutomationBuddy.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/contexts/RepoXmlPageContext";
 import { debugLogger as logger } from '@/lib/debugLogger';
 import { useAppToast } from "@/hooks/useAppToast";
-import useInactivityTimer from "@/hooks/useInactivityTimer"; // Import the new hook
+import useInactivityTimer from "@/hooks/useInactivityTimer"; 
 
 // --- Constants & Types ---
 const INACTIVITY_TIMEOUT_MS = 60000; // 1 minute
@@ -45,7 +45,6 @@ interface Suggestion {
 // --- Animation Variants ---
 const containerVariants = { hidden: { opacity: 0, x: 300 }, visible: { opacity: 1, x: 0, transition: { type: "spring", stiffness: 120, damping: 15, when: "beforeChildren", staggerChildren: 0.08, }, }, exit: { opacity: 0, x: 300, transition: { duration: 0.3 } }, };
 const childVariants = { hidden: { opacity: 0, y: 20 }, visible: { opacity: 1, y: 0, transition: { type: "spring", bounce: 0.4 } }, exit: { opacity: 0, transition: { duration: 0.2 } }, };
-// Simplified FAB animation
 const fabVariants = {
     hidden: { scale: 0, opacity: 0, rotate: 45 },
     visible: {
@@ -61,19 +60,16 @@ const notificationVariants = { hidden: { scale: 0, opacity: 0 }, visible: { scal
 // --- Main Component ---
 const AutomationBuddy: React.FC = () => {
     logger.log("[AutomationBuddy] START Render");
-    // --- State ---
     const [isMounted, setIsMounted] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
-    const hasOpenedDueToInactivityRef = useRef(false); // Tracks if opened by inactivity this session
+    const hasOpenedDueToInactivityRef = useRef(false); 
     const [hasNewSuggestions, setHasNewSuggestions] = useState(false);
     const previousSuggestionIds = useRef<Set<string>>(new Set());
     const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
 
-    // --- Hooks ---
     const searchParams = useSearchParams(); 
     const { error: toastError } = useAppToast();
 
-    // --- Context ---
     const context = useRepoXmlPageContext();
     const {
         currentStep, fetchStatus, repoUrlEntered, filesFetched,
@@ -90,25 +86,22 @@ const AutomationBuddy: React.FC = () => {
     } = context;
     logger.debug(`[AutomationBuddy] Context State Read: currentStep=${currentStep}, fetchStatus=${fetchStatus}, imageTask=${!!imageReplaceTask}, showComponents=${showComponents}`);
 
-    // --- Effects ---
     useEffect(() => { setIsMounted(true); logger.debug("[AutomationBuddy Effect] Mounted"); }, []);
 
-    // --- Inactivity Timer ---
     useInactivityTimer(
         INACTIVITY_TIMEOUT_MS,
-        () => { // onInactive
+        () => { 
             if (isMounted && !isOpen && !hasOpenedDueToInactivityRef.current) {
                 logger.log("[AutomationBuddy] Inactivity detected, auto-opening.");
                 setIsOpen(true);
                 hasOpenedDueToInactivityRef.current = true;
-                setHasNewSuggestions(false); // Clear notification when auto-opening
+                setHasNewSuggestions(false); 
             }
         },
-        undefined, // onActive (optional)
+        undefined, 
         "AutomationBuddy"
     );
     
-    // --- Get Active Message ---
     const activeMessage = useMemo(() => {
         logger.debug(`[AutomationBuddy Memo] Calculating activeMessage.`);
         if (!isMounted) return "Загрузка Бадди...";
@@ -121,7 +114,6 @@ const AutomationBuddy: React.FC = () => {
         return "Ошибка получения статуса...";
     }, [isMounted, getXuinityMessage]);
 
-    // --- Calculate Suggestions ---
     useEffect(() => {
         logger.debug("[AutomationBuddy Effect] Calculating suggestions START");
         if (!isMounted || typeof triggerFetch !== 'function') {
@@ -249,7 +241,7 @@ const AutomationBuddy: React.FC = () => {
 
     }, [ 
         isMounted, currentStep, fetchStatus, repoUrlEntered, filesFetched,
-        selectedFetcherFiles, kworkInputHasContent, kworkInputValue,
+        selectedFetcherFiles, kworkInputHasContent, kworkInputValue, // kworkInputValue added
         aiResponseHasContent, filesParsed, selectedAssistantFiles,
         assistantLoading, aiActionLoading, loadingPrs, targetBranchName, manualBranchName,
         isSettingsModalOpen, isParsing, currentAiRequestId, imageReplaceTask, allFetchedFiles,
@@ -257,10 +249,9 @@ const AutomationBuddy: React.FC = () => {
         triggerFetch, triggerSelectHighlighted, triggerAddSelectedToKwork, triggerCopyKwork,
         triggerAskAi, triggerParseResponse, triggerSelectAllParsed, triggerCreateOrUpdatePR,
         triggerToggleSettingsModal, scrollToSection, triggerClearKworkInput,
-        logger
+        logger // Removed context setters as they should be stable
     ]);
 
-    // --- Suggestion Change Detection ---
     useEffect(() => {
         if (!isMounted || isOpen) { if (isOpen) logger.debug("[AutomationBuddy Effect] Suggestion Change - Resetting notification (buddy open)"); setHasNewSuggestions(false); return; }
         const currentIds = new Set(suggestions.map(s => s.id)); const prevIds = previousSuggestionIds.current;
@@ -269,13 +260,9 @@ const AutomationBuddy: React.FC = () => {
         previousSuggestionIds.current = currentIds;
     }, [isMounted, suggestions, isOpen, logger]);
 
-    // Removed old auto-open timer logic, now handled by useInactivityTimer
-
-    // --- Handle Escape Key ---
     const handleEscKey = useCallback((e:KeyboardEvent) => { if(e.key==='Escape'&&isOpen) { logger.debug("[AutomationBuddy CB] Escape key pressed, closing."); setIsOpen(false);} }, [isOpen, logger]);
     useEffect(() => { document.addEventListener('keydown',handleEscKey); return()=>{document.removeEventListener('keydown',handleEscKey);}; }, [handleEscKey]);
 
-    // --- Event Handlers ---
     const handleSuggestionClick = (suggestion: Suggestion) => {
         if(suggestion.disabled){ logger.debug(`[Buddy Click] Suggestion ${suggestion.id} clicked but disabled.`); return; }
         logger.info(`[Buddy Click] Suggestion clicked: ${suggestion.id}`);
@@ -293,15 +280,14 @@ const AutomationBuddy: React.FC = () => {
         logger.info(`[Buddy Click] FAB clicked. Current state: ${isOpen ? 'Open' : 'Closed'}`);
         const newIsOpenState = !isOpen;
         setIsOpen(newIsOpenState);
-        if (newIsOpenState) { // If opening
-            hasOpenedDueToInactivityRef.current = true; // Manual open should prevent inactivity open for this session
+        if (newIsOpenState) { 
+            hasOpenedDueToInactivityRef.current = true; 
             setHasNewSuggestions(false);
-        } else { // If closing
+        } else { 
             requestAnimationFrame(() => document.body.focus());
         }
     };
 
-    // --- Render Logic ---
     if (!isMounted) return null;
 
     logger.debug(`[AutomationBuddy Render] Final render. isOpen=${isOpen}, hasNewSuggestions=${hasNewSuggestions}`);
@@ -320,7 +306,6 @@ const AutomationBuddy: React.FC = () => {
                         </motion.div>
                     </motion.div>
                 ) : (
-                    // Adjusted FAB position: more bottom padding
                     <div className="fixed bottom-12 right-4 z-50">
                         <motion.div variants={fabVariants} initial="hidden" animate="visible" exit="exit" className="relative">
                              <FloatingActionButton onClick={handleFabClick} icon={<FaAngrycreative className="text-xl" />} className="bg-gradient-to-br from-purple-600 to-indigo-700 hover:from-purple-700 hover:to-indigo-800 text-white shadow-lg hover:shadow-xl rounded-full" aria-label="Open Automation Buddy" />

--- a/components/CharacterForm.tsx
+++ b/components/CharacterForm.tsx
@@ -42,7 +42,7 @@ export function CharacterForm({ character }: CharacterFormProps) {
       }
     };
     checkAndInsertDefaults();
-  }, []);
+  }, []); // Removed defaultCharacters from dependency array as it's constant
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,7 +51,7 @@ export function CharacterForm({ character }: CharacterFormProps) {
     try {
       let imageUrl = formData.image_url;
       if (imageFile) {
-        const bucketName = "character-images";
+        const bucketName = "character-images"; // Ensure this bucket exists and is public
         const { data: buckets, error: bucketError } = await supabaseAdmin.storage.listBuckets();
         if (bucketError) throw bucketError;
         if (!buckets.some((b) => b.name === bucketName)) {

--- a/components/DevErrorOverlay.tsx
+++ b/components/DevErrorOverlay.tsx
@@ -106,7 +106,7 @@ const getLevelColor = (level: LogLevel | ToastRecord['type']): string => {
 
 // --- Main Overlay Component ---
 const DevErrorOverlay: React.FC = () => {
-  logger.debug("[DevErrorOverlay] START Render"); // Use debug
+  logger.debug("[DevErrorOverlay] START Render"); 
 
   const [internalRenderError, setInternalRenderError] = useState<Error | null>(null);
   const [logHistory, setLogHistory] = useState<ReadonlyArray<LogRecord>>([]);
@@ -132,7 +132,7 @@ const DevErrorOverlay: React.FC = () => {
 
 
   useEffect(() => {
-      if (contextAvailable) { logger.debug("[DevErrorOverlay Effect] Context access successful."); } // Use debug
+      if (contextAvailable) { logger.debug("[DevErrorOverlay Effect] Context access successful."); } 
       else { logger.warn("[DevErrorOverlay Effect] Context access returned fallback or missing function."); }
   }, [contextAvailable]);
 
@@ -174,14 +174,12 @@ const DevErrorOverlay: React.FC = () => {
           } catch (e: any) { logger.error("[DevErrorOverlay] Error getting/formatting stack trace:", e); return `${t.stackTraceError}: ${e?.message ?? 'Unknown'}`; }
       };
 
-       // --- Helper to prepare data with TRUNCATION for GitHub URL ---
       const prepareIssueAndCopyDataSafe = (logLimit = 10, toastLimit = 5, maxLogChars = 1000, maxToastChars = 300, maxStackLines = 7) => {
           logger.debug("[DevErrorOverlay] prepareIssueAndCopyDataSafe START");
           try {
-             const safeErrorInfo = errorInfo as ErrorInfo; // Assuming errorInfo is not null here
+             const safeErrorInfo = errorInfo as ErrorInfo; 
              const errorType = safeErrorInfo.type?.toUpperCase() || 'UNKNOWN';
              const message = safeErrorInfo.message || t.unknownError;
-             // Get slightly shorter stack for body
              const shortStackForBody = getTruncatedStackTrace(safeErrorInfo.error, maxStackLines);
              const componentStackInfo = safeErrorInfo.componentStack ? `\n\n**Component Stack (truncated):**\n\`\`\`\n${safeErrorInfo.componentStack.substring(0, 300)}\n\`\`\`` : '';
              const source = safeErrorInfo.source ? `${safeErrorInfo.source}${typeof safeErrorInfo.lineno === 'number' ? ':' + safeErrorInfo.lineno : ''}` : 'N/A';
@@ -191,8 +189,6 @@ const DevErrorOverlay: React.FC = () => {
              const issueTitle = encodeURIComponent(issueTitleOptions[Math.floor(Math.random() * issueTitleOptions.length)]);
              logger.debug(`[DevErrorOverlay] Issue Details: Type=${errorType}, Source=${source}, Title=${decodeURIComponent(issueTitle)}`);
 
-
-             // --- Truncate Logs and Toasts for GitHub URL ---
              const formatHistoryForUrl = (history: any[], limit: number, maxChars: number, type: 'log' | 'toast') => {
                  logger.debug(`[DevErrorOverlay] Formatting history for URL: type=${type}, count=${history?.length ?? 0}, limit=${limit}, maxChars=${maxChars}`);
                  if (!history || history.length === 0) return type === 'log' ? t.noRecentLogs : t.noRecentToasts;
@@ -200,7 +196,6 @@ const DevErrorOverlay: React.FC = () => {
                  const limitedHistory = history.slice().reverse().slice(0, limit);
                  const formattedLines: string[] = [];
                  for (const item of limitedHistory) {
-                     // Add extra checks for item properties
                      const itemType = item?.type || (type === 'log' ? item?.level : 'unknown');
                      const itemTimestamp = item?.timestamp ? new Date(item.timestamp).toLocaleTimeString('ru-RU',{hour12:false}) : 'N/A';
                      const prefix = type === 'log' ? `[${(itemType || 'UNKNOWN').toUpperCase()}] ${itemTimestamp} |` : `[${(itemType || 'UNKNOWN').toUpperCase()}]`;
@@ -208,7 +203,7 @@ const DevErrorOverlay: React.FC = () => {
                      const line = `${prefix} ${itemMsg}`;
                      if (charCount + line.length > maxChars) { logger.debug(`[DevErrorOverlay] History URL limit reached for ${type}.`); break; }
                      formattedLines.push(`- ${line}`);
-                     charCount += line.length + 1; // +1 for newline
+                     charCount += line.length + 1; 
                  }
                   if (history.length > limit || charCount >= maxChars) {
                       formattedLines.push("- ...(еще больше записей опущено)...");
@@ -217,20 +212,16 @@ const DevErrorOverlay: React.FC = () => {
                  return formattedLines.join('\n');
               };
 
-
              const formattedLogHistoryForUrl = formatHistoryForUrl(logHistory, logLimit, maxLogChars, 'log');
              const formattedToastHistoryForUrl = formatHistoryForUrl(toastHistory, toastLimit, maxToastChars, 'toast');
-             // --- End Truncation for URL ---
 
              const issueBodyContent = `**Тип Ошибки:** ${errorType}\n**Сообщение:** ${message}\n**Источник:** ${source}\n\n**Стек (начало):**\n\`\`\`\n${shortStackForBody}\n\`\`\`${componentStackInfo}\n\n**Последние События (Логи):**\n${formattedLogHistoryForUrl}\n\n**Недавние Уведомления (Тосты):**\n${formattedToastHistoryForUrl}\n\n**Контекст/Шаги:**\n[Опиши, что ты делал(а), когда это случилось]\n`;
              const issueBody = encodeURIComponent(issueBodyContent);
              const gitHubIssueUrl = `https://github.com/${repoOrg}/${repoName}/issues/new?title=${issueTitle}&body=${issueBody}`;
 
-             // --- Prepare FULL history for Copy Prompt (less strict limits) ---
-             const fullFormattedLogHistory = formatHistoryForUrl(logHistory, 50, 8000, 'log'); // More logs for copy
-             const fullFormattedToastHistory = formatHistoryForUrl(toastHistory, 20, 2000, 'toast'); // More toasts for copy
-             const fullStackTrace = getTruncatedStackTrace(safeErrorInfo.error, 30); // More stack lines for copy
-             // --- End Full history prep ---
+             const fullFormattedLogHistory = formatHistoryForUrl(logHistory, 50, 8000, 'log'); 
+             const fullFormattedToastHistory = formatHistoryForUrl(toastHistory, 20, 2000, 'toast'); 
+             const fullStackTrace = getTruncatedStackTrace(safeErrorInfo.error, 30); 
 
              const copyPrompt = `Йоу! Поймал ошибку в ${repoName}, помоги разгрести!\n\nОшибка (${errorType}) Источник: ${source}\n${message}\n\nСтек (начало):\n\`\`\`\n${fullStackTrace}\n\`\`\`${componentStackInfo}\n\nПоследние События (Логи):\n${fullFormattedLogHistory}\n\nНедавние уведомления (Тосты):\n${fullFormattedToastHistory}\n\nЗадача: Проанализируй ошибку, стек, логи и уведомления. Предложи исправления кода или объясни причину.`;
              logger.info("[DevErrorOverlay] Prepared GitHub URL and Copy Prompt.", { ghUrlLength: gitHubIssueUrl.length, promptLength: copyPrompt.length });
@@ -262,29 +253,24 @@ const DevErrorOverlay: React.FC = () => {
          }
       };
 
-      // --- Safe Render Helper ---
       const RenderSection: React.FC<{ title: string; children: () => React.ReactNode }> = ({ title, children }) => {
           try { return <>{children()}</>; }
           catch (e: any) { logger.error(`[DevErrorOverlay] Error rendering section "${title}":`, e); setInternalRenderError(new Error(`Failed to render section "${title}": ${e.message}`)); return <div className="text-red-500 p-2 bg-red-900/30 rounded">Ошибка рендера секции: {title}</div>; }
       };
 
-      // --- JSX Return ---
       return (
         <div
           className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-md p-4 overflow-hidden"
           role="alertdialog" aria-modal="true" aria-labelledby="error-overlay-title" aria-describedby="error-overlay-description"
         >
-          {/* Main Content Container */}
           <div className="bg-gradient-to-br from-gray-900 via-indigo-950 to-black border border-cyan-500/30 rounded-lg shadow-2xl p-4 md:p-6 max-w-4xl w-full max-h-[95vh] flex flex-col text-gray-200 glitch-border-animate">
 
-            {/* Header */}
              <RenderSection title="Header">
                  {() => (
                      <div className="flex items-center justify-between mb-4 flex-shrink-0">
                        <h2 id="error-overlay-title" className="text-xl md:text-2xl font-bold text-cyan-300 flex items-center gap-2 glitch-text-shadow">
                           <FaTriangleExclamation className="text-yellow-400" /> {t.systemFailureTitle}
                        </h2>
-                       {/* Moved Close button to header for better UX */}
                        <button
                          onClick={handleClose}
                          className="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded-md text-xs font-semibold transition shadow hover:shadow-md"
@@ -296,9 +282,7 @@ const DevErrorOverlay: React.FC = () => {
                  )}
             </RenderSection>
 
-            {/* Body (Scrollable Area) */}
             <div id="error-overlay-description" className="flex-grow overflow-y-auto simple-scrollbar pr-2 space-y-3 mb-4">
-                 {/* Error Message */}
                  <RenderSection title="Message">
                       {() => {
                           let messageText = t.unknownError;
@@ -308,7 +292,6 @@ const DevErrorOverlay: React.FC = () => {
                       }}
                  </RenderSection>
 
-                 {/* Source Info */}
                  <RenderSection title="Source">
                       {() => {
                           try {
@@ -318,7 +301,6 @@ const DevErrorOverlay: React.FC = () => {
                       }}
                  </RenderSection>
 
-                 {/* --- Moved Advice/Action Section Higher --- */}
                  <RenderSection title="Advice">
                       {() => (<div className="my-4 p-4 bg-gradient-to-r from-blue-900/30 via-indigo-900/40 to-purple-900/30 border border-blue-600/50 rounded text-blue-100 text-xs md:text-sm space-y-3 shadow-md">
                            <p className="font-semibold text-lg text-blue-200">{t.adviceTitle}</p>
@@ -337,11 +319,7 @@ const DevErrorOverlay: React.FC = () => {
                            </div>
                          </div>)}
                  </RenderSection>
-                 {/* --- End Moved Advice Section --- */}
-
                  <hr className="border-gray-700/50 my-3"/>
-
-                 {/* Stack Trace (Default Collapsed) */}
                  <RenderSection title="StackTrace">
                       {() => (<details className="bg-black/30 p-3 rounded border border-gray-700/50" open={false}>
                             <summary className="cursor-pointer text-sm font-medium text-gray-400 hover:text-gray-200 transition-colors"> {t.stackTraceLabel} </summary>
@@ -350,7 +328,6 @@ const DevErrorOverlay: React.FC = () => {
                        </details>)}
                  </RenderSection>
 
-                 {/* Logs Section (Default Collapsed) */}
                  <RenderSection title="RecentLogs">
                      {() => (<details className="bg-black/40 p-3 rounded border border-gray-600/60" open={false}>
                           <summary className="cursor-pointer text-sm font-medium text-gray-300 hover:text-white transition-colors"> {t.recentLogsTitle} ({logHistory.length}) </summary>
@@ -369,8 +346,6 @@ const DevErrorOverlay: React.FC = () => {
                           ) : (<p className="mt-2 text-xs text-gray-500">{t.noRecentLogs}</p>)}
                         </details>)}
                  </RenderSection>
-
-                 {/* Toasts Section (Default Collapsed) */}
                  <RenderSection title="RecentToasts">
                      {() => (<details className="bg-black/30 p-3 rounded border border-gray-700/50" open={false}>
                           <summary className="cursor-pointer text-sm font-medium text-gray-400 hover:text-gray-200 transition-colors"> {t.recentToastsTitle} ({toastHistory.length}) </summary>
@@ -386,24 +361,17 @@ const DevErrorOverlay: React.FC = () => {
                           ) : (<p className="mt-2 text-xs text-gray-500">{t.noRecentToasts}</p>)}
                         </details>)}
                  </RenderSection>
-
-            </div> {/* End Scrollable Body */}
-
-            {/* Footer - Close button moved to header */}
-            {/* <RenderSection title="Footer"> ... </RenderSection> */}
-
-          </div> {/* End Main Content Container */}
-        </div> // End Modal Root
+            </div> 
+          </div> 
+        </div> 
       );
-      // --- End JSX Return ---
-
   } catch (renderError: any) {
       const fatalMsg = "[DevErrorOverlay] CRITICAL: Failed during main UI render execution!";
       logger.fatal(fatalMsg, renderError);
       setInternalRenderError(renderError);
-      return null; // Fallback will be rendered on next cycle
+      return null; 
   } finally {
-       logger.debug("[DevErrorOverlay] END Render"); // Use debug
+       logger.debug("[DevErrorOverlay] END Render"); 
   }
 };
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,14 +7,11 @@ import Link from "next/link";
 import { FaGithub, FaTelegram } from "react-icons/fa6"; 
 import { usePathname } from "next/navigation"; 
 
+// cn import is not used in this file based on the provided snippet, so no import { cn } from "@/lib/utils"; needed here.
+
 export default function Footer() {
   const { tg, isInTelegramContext } = useAppContext();
   const pathname = usePathname(); 
-
-  // Логика скрытия футера на '/finance-literacy-memo' УДАЛЕНА
-  // if (pathname === '/finance-literacy-memo') {
-  //   return null;
-  // }
 
   const handleShare = () => {
     const shareUrl = "https://t.me/share/url?url=" + encodeURIComponent("https://t.me/oneSitePlsBot/app") + "&text=" + encodeURIComponent("Зацени oneSitePls - твой AI-Dev ассистент в Telegram!");

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,7 +7,7 @@ import UserInfo from "@/components/user-info";
 import { motion, AnimatePresence } from "framer-motion";
 import { usePathname } from "next/navigation";
 import { useAppContext } from "@/contexts/AppContext";
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils"; // <<--- IMPORT ADDED
 import { 
   FaGears, 
   FaScrewdriverWrench 
@@ -111,7 +111,6 @@ const translations: Record<string, Record<string, string>> = {
   }
 };
 
-// Updated color mapping to use theme definitions
 const colorVarMap: Record<string, string> = {
   purple: "var(--brand-purple-rgb)",
   blue: "var(--brand-blue-rgb)",
@@ -120,9 +119,9 @@ const colorVarMap: Record<string, string> = {
   green: "var(--brand-green-rgb)",
   pink: "var(--brand-pink-rgb)",
   cyan: "var(--brand-cyan-rgb)",
-  red: "var(--red-500-rgb)", // Assuming red-500 is defined in your theme or globals
+  red: "var(--red-500-rgb)", 
   orange: "var(--brand-orange-rgb)",
-  gray: "var(--gray-500-rgb)", // Assuming gray-500 is defined in your theme or globals
+  gray: "var(--gray-500-rgb)", 
 };
 
 const tileColorClasses: Record<Required<PageInfo>['color'] | 'default', string> = {
@@ -133,10 +132,10 @@ const tileColorClasses: Record<Required<PageInfo>['color'] | 'default', string> 
   green: "border-brand-green/60 hover:border-brand-green text-brand-green",
   pink: "border-brand-pink/60 hover:border-brand-pink text-brand-pink",
   cyan: "border-brand-cyan/60 hover:border-brand-cyan text-brand-cyan",
-  red: "border-destructive/60 hover:border-destructive text-destructive", // Use destructive from theme
+  red: "border-destructive/60 hover:border-destructive text-destructive", 
   orange: "border-brand-orange/60 hover:border-brand-orange text-brand-orange",
-  gray: "border-muted/60 hover:border-muted text-muted-foreground", // Use muted from theme
-  default: "border-border hover:border-primary/80 text-muted-foreground hover:text-primary" // Use theme defaults
+  gray: "border-muted/60 hover:border-muted text-muted-foreground", 
+  default: "border-border hover:border-primary/80 text-muted-foreground hover:text-primary" 
 };
 
 export default function Header() {
@@ -147,11 +146,6 @@ export default function Header() {
   const [searchTerm, setSearchTerm] = useState("");
   const pathname = usePathname();
   
-  // Логика скрытия хедера на '/finance-literacy-memo' УДАЛЕНА
-  // if (pathname === '/finance-literacy-memo') {
-  //   return null;
-  // }
-
   const initialLang = useMemo(() => (user?.language_code === 'ru' ? 'ru' : 'en'), [user?.language_code]);
   const [currentLang, setCurrentLang] = useState<'en' | 'ru'>(initialLang);
   
@@ -202,9 +196,9 @@ export default function Header() {
       const groupName = page.group || "Misc";
       if (groups[groupName]) { 
         groups[groupName].push(page);
-      } else if (groupName === "Admin Zone" && currentIsAdminReal) { // Ensure Admin Zone is created if not pre-created by filter logic
+      } else if (groupName === "Admin Zone" && currentIsAdminReal) { 
         groups[groupName] = [page];
-      } else if (groupName !== "Admin Zone") { // Catch-all for other groups not in groupOrder, though ideally all pages should have a group from groupOrder
+      } else if (groupName !== "Admin Zone") { 
         groups[groupName] = [page];
       }
     });
@@ -330,8 +324,8 @@ export default function Header() {
                                 page.isImportant 
                                   ? "bg-gradient-to-br from-purple-800/30 via-black/50 to-blue-800/30 col-span-1 sm:col-span-2 shadow-sm" 
                                   : "bg-dark-card/60 hover:bg-dark-card/80 col-span-1",
-                                tileBaseColorClass, // Use updated color classes
-                                shadowClass, // Use updated shadow class based on colorVarMap
+                                tileBaseColorClass, 
+                                shadowClass, 
                                 isCurrentPage ? `ring-2 ring-offset-2 ring-offset-black ${page.color === 'lime' || page.color === 'yellow' || page.color === 'orange' ? 'ring-black/70' : 'ring-white/90'}` : 'ring-transparent'
                               )}
                               title={page.translatedName}

--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -26,11 +26,9 @@ function LoadingChatButtonFallback() {
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  // logger.debug(`[ClientLayout] Current pathname: ${pathname}`);
-
-  // Paths where BottomNavigation should be visible
-  const pathsToShowBottomNavForExactMatch = ["/", "/repo-xml"]; // Exact matches
-  const pathsToShowBottomNavForStartsWith = ["/selfdev/gamified", "/p-plan", "/profile"]; // StartsWith matches
+  
+  const pathsToShowBottomNavForExactMatch = ["/", "/repo-xml"]; 
+  const pathsToShowBottomNavForStartsWith = ["/selfdev/gamified", "/p-plan", "/profile"]; 
 
   const isExactMatch = pathsToShowBottomNavForExactMatch.includes(pathname);
   const isStartsWithMatch = pathsToShowBottomNavForStartsWith.some(p => pathname.startsWith(p));
@@ -38,14 +36,15 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   const showBottomNav = isExactMatch || isStartsWithMatch;
   logger.debug(`[ClientLayout] showBottomNav for "${pathname}" evaluated to: ${showBottomNav} (Exact: ${isExactMatch}, StartsWith: ${isStartsWithMatch})`);
 
-
   return (
     <ErrorOverlayProvider>
       <AppProvider>
         <TooltipProvider>
           <ErrorBoundaryForOverlay>
             <Header />
-            <main className={`flex-1 ${showBottomNav ? 'pb-20 sm:pb-0' : ''}`}> 
+            {/* Apply pb-20 (height of bottom nav) only if showBottomNav is true */}
+            {/* On sm screens and up, pb-0 because bottom nav is likely hidden or different */}
+            <main className={cn("flex-1", showBottomNav ? "pb-20 sm:pb-0" : "")}>
               {children}
             </main>
             {showBottomNav && <BottomNavigation pathname={pathname} />}

--- a/components/repo/FileList.tsx
+++ b/components/repo/FileList.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import React from 'react';
-// Added FaListCheck and FaSquareXmark for new buttons
 import { FaSquareCheck, FaRegSquare, FaPlus, FaCodeBranch, FaStar, FaHighlighter, FaKey, FaTree, FaFileLines, FaListCheck, FaSquareXmark } from 'react-icons/fa6';
-import { FileNode, ImportCategory } from '../RepoTxtFetcher';
+import { FileNode, ImportCategory } from '@/contexts/RepoXmlPageContext'; // Changed import source
 import { motion, AnimatePresence } from 'framer-motion';
 
-// Interface defining the props expected by FileList
 interface FileListProps {
     id: string;
     files: FileNode[];
@@ -21,23 +19,18 @@ interface FileListProps {
     onAddImportant: () => void;
     onAddTree: () => void;
     onSelectHighlighted: () => void;
-    // --- NEW PROPS for bulk actions ---
     onSelectAll: () => void;
     onDeselectAll: () => void;
-    // --- End NEW PROPS ---
 }
 
-// Helper to get the display name (filename) from a full path
 const getDisplayName = (path: string) => path.split("/").pop() || path;
-
-// Helper to group files by their parent folder
 const groupFilesByFolder = (files: FileNode[]) => { const g: { folder: string; files: FileNode[] }[] = []; const fm: { [key: string]: FileNode[] } = {}; files.forEach((f) => { const fo = f.path.includes('/') ? f.path.substring(0, f.path.lastIndexOf("/")) : "/"; if (!fm[fo]) fm[fo] = []; fm[fo].push(f); }); const sF = Object.keys(fm).sort((a, b) => { if (a === '/') return -1; if (b === '/') return 1; return a.localeCompare(b); }); sF.forEach(fo => { fm[fo].sort((a, b) => getDisplayName(a.path).localeCompare(getDisplayName(b.path))); g.push({ folder: fo, files: fm[fo] }); }); return g; };
 
 
-const FileList: React.FC<FileListProps> = React.memo(({ // Memoize the component
+const FileList: React.FC<FileListProps> = React.memo(({ 
     id, files, selectedFiles, primaryHighlightedPath, secondaryHighlightedPaths, importantFiles,
     isLoading, isActionDisabled, toggleFileSelection, onAddSelected, onAddImportant,
-    onAddTree, onSelectHighlighted, onSelectAll, onDeselectAll, // Destructure new props
+    onAddTree, onSelectHighlighted, onSelectAll, onDeselectAll, 
 }) => {
 
     const groupedFiles = React.useMemo(() => groupFilesByFolder(files), [files]);
@@ -63,10 +56,8 @@ const FileList: React.FC<FileListProps> = React.memo(({ // Memoize the component
                  <motion.button onClick={onAddSelected} disabled={selectedCount === 0 || isActionDisabled} className={`flex items-center justify-center gap-1 px-2.5 py-1 rounded-full font-semibold text-white bg-gradient-to-r from-indigo-600 to-purple-500 transition-all shadow-md shadow-purple-500/30 ${(selectedCount === 0 || isActionDisabled) ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-lg hover:shadow-indigo-500/40'}`} whileHover={{ scale: (selectedCount === 0 || isActionDisabled) ? 1 : 1.03 }} whileTap={{ scale: (selectedCount === 0 || isActionDisabled) ? 1 : 0.97 }}> <FaFileLines /> Добавить ({selectedCount}) </motion.button>
                  <motion.button onClick={onAddImportant} disabled={isActionDisabled} className={`flex items-center justify-center gap-1 px-2.5 py-1 rounded-full font-semibold text-white bg-gradient-to-r from-blue-600 to-cyan-500 transition-all shadow-md shadow-cyan-500/30 ${isActionDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-lg hover:shadow-teal-500/40'}`} whileHover={{ scale: isActionDisabled ? 1 : 1.03 }} whileTap={{ scale: isActionDisabled ? 1 : 0.97 }}> <FaKey /> Важные </motion.button>
                  <motion.button onClick={onAddTree} disabled={allFilesCount === 0 || isActionDisabled} className={`flex items-center justify-center gap-1 px-2.5 py-1 rounded-full font-semibold text-white bg-gradient-to-r from-red-600 to-orange-500 transition-all shadow-md shadow-orange-500/30 ${isActionDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-lg hover:shadow-red-500/40'}`} whileHover={{ scale: isActionDisabled ? 1 : 1.03 }} whileTap={{ scale: isActionDisabled ? 1 : 0.97 }}> <FaTree /> Дерево </motion.button>
-                 {/* --- NEW Buttons --- */}
                  <motion.button onClick={onSelectAll} disabled={!canSelectAll || isActionDisabled} className={`flex items-center justify-center gap-1 px-2.5 py-1 rounded-full font-semibold text-white bg-gradient-to-r from-green-600 to-emerald-500 transition-all shadow-md shadow-emerald-500/30 ${(!canSelectAll || isActionDisabled) ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-lg hover:shadow-green-500/40'}`} whileHover={{ scale: (!canSelectAll || isActionDisabled) ? 1 : 1.03 }} whileTap={{ scale: (!canSelectAll || isActionDisabled) ? 1 : 0.97 }} title="Выбрать все файлы"> <FaListCheck /> Все </motion.button>
                  <motion.button onClick={onDeselectAll} disabled={!canDeselectAll || isActionDisabled} className={`flex items-center justify-center gap-1 px-2.5 py-1 rounded-full font-semibold text-white bg-gradient-to-r from-gray-600 to-slate-500 transition-all shadow-md shadow-slate-500/30 ${(!canDeselectAll || isActionDisabled) ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-lg hover:shadow-gray-500/40'}`} whileHover={{ scale: (!canDeselectAll || isActionDisabled) ? 1 : 1.03 }} whileTap={{ scale: (!canDeselectAll || isActionDisabled) ? 1 : 0.97 }} title="Снять выбор со всех"> <FaSquareXmark /> Ничего </motion.button>
-                 {/* --- End NEW Buttons --- */}
              </div>
             {isLoading && ( <div className="flex justify-center items-center flex-grow"><p className="text-gray-400 animate-pulse text-sm">Загрузка...</p></div> )}
             {!isLoading && files.length === 0 && ( <div className="flex justify-center items-center flex-grow"><p className="text-gray-400 text-sm">Файлы не найдены.</p></div> )}

--- a/components/repo/RequestInput.tsx
+++ b/components/repo/RequestInput.tsx
@@ -1,19 +1,18 @@
 "use client";
-import React, { useCallback } from "react"; // Добавлен useCallback
+import React, { useCallback } from "react"; 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-// Добавлена FaWandMagicSparkles
 import { FaCopy, FaBroom, FaPlus, FaWandMagicSparkles } from "react-icons/fa6";
 import { TooltipProvider, Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { useAppToast } from "@/hooks/useAppToast"; // Импортируем хук для тостов
-import { ULTIMATE_VIBE_MASTER_PROMPT } from "./prompt"; // Импортируем сам промпт
-import { debugLogger as logger } from "@/lib/debugLogger"; // Импортируем логгер
+import { useAppToast } from "@/hooks/useAppToast"; 
+import { ULTIMATE_VIBE_MASTER_PROMPT } from "./prompt"; 
+import { debugLogger as logger } from "@/lib/debugLogger"; 
 
 interface RequestInputProps {
     kworkInputRef: React.RefObject<HTMLTextAreaElement>;
-    kworkInputValue: string | undefined; // Допускаем undefined
+    kworkInputValue: string | undefined; 
     onValueChange: (value: string) => void;
-    onCopyToClipboard: () => void; // Оставляем для копирования *текущего* запроса
+    onCopyToClipboard: () => void; 
     onClearAll: () => void;
     onAddSelected: () => void;
     isAddSelectedDisabled: boolean;
@@ -34,20 +33,14 @@ const RequestInput: React.FC<RequestInputProps> = ({
     isActionDisabled = false,
     filesFetched = false,
 }) => {
-    const { success: toastSuccess, error: toastError } = useAppToast(); // Получаем функции тостов
+    const { success: toastSuccess, error: toastError } = useAppToast(); 
 
-    // --- Безопасное вычисление зависимых состояний ---
-    // Используем typeof для проверки и trim(), если это строка, иначе пустая строка
     const kworkValueTrimmed = typeof kworkInputValue === 'string' ? kworkInputValue.trim() : '';
     const hasContent = kworkValueTrimmed.length > 0;
 
-    // Кнопка копирования активна, если есть контент и действия не заблокированы
     const calculatedIsCopyDisabled = !hasContent || isActionDisabled;
-    // Кнопка очистки активна, если есть контент ИЛИ выбраны файлы ИЛИ файлы были загружены (чтобы можно было очистить даже пустой инпут после загрузки), и действия не заблокированы
     const calculatedIsClearDisabled = (!hasContent && selectedFetcherFilesCount === 0 && !filesFetched) || isActionDisabled;
-    // --- Конец безопасного вычисления ---
 
-    // --- НОВЫЙ ОБРАБОТЧИК для копирования системного промпта ---
     const handleCopySystemPrompt = useCallback(() => {
         try {
             navigator.clipboard.writeText(ULTIMATE_VIBE_MASTER_PROMPT);
@@ -57,7 +50,7 @@ const RequestInput: React.FC<RequestInputProps> = ({
             logger.error("[RequestInput] System prompt clipboard write error:", e);
             toastError("Ошибка копирования системного промпта");
         }
-    }, [toastSuccess, toastError, logger]); // Зависимости только от тостов и логгера
+    }, [toastSuccess, toastError]); // Removed logger from deps as it's stable
 
     return (
         <TooltipProvider>
@@ -66,24 +59,22 @@ const RequestInput: React.FC<RequestInputProps> = ({
                     <Textarea
                         ref={kworkInputRef}
                         id="kworkInput"
-                        value={kworkInputValue ?? ''} // Гарантируем строку здесь
+                        value={kworkInputValue ?? ''} 
                         onChange={(e) => onValueChange(e.target.value)}
-                        className="textarea-cyber" // Используем стиль из globals.css
+                        className="textarea-cyber" 
                         placeholder="4. Напиши свой запрос к AI здесь ИЛИ добавь выбранные файлы как контекст ->"
                         spellCheck="false"
                         disabled={isActionDisabled}
                     />
-                    {/* --- Блок кнопок утилиты --- */}
                     <div className="absolute top-2 right-2 flex flex-col gap-1.5">
-                        {/* НОВАЯ КНОПКА: Копировать Системный Промпт */}
                         <Tooltip delayDuration={100}>
                             <TooltipTrigger asChild>
                                 <Button
                                     variant="ghost"
                                     size="icon"
                                     onClick={handleCopySystemPrompt}
-                                    disabled={isActionDisabled} // Дизейблим вместе с остальными
-                                    className="h-7 w-7 text-muted-foreground hover:text-brand-yellow hover:bg-muted disabled:opacity-50" // Theme colors
+                                    disabled={isActionDisabled} 
+                                    className="h-7 w-7 text-muted-foreground hover:text-brand-yellow hover:bg-muted disabled:opacity-50" 
                                 >
                                     <FaWandMagicSparkles />
                                 </Button>
@@ -91,38 +82,34 @@ const RequestInput: React.FC<RequestInputProps> = ({
                             <TooltipContent side="left" className="bg-popover text-popover-foreground border-border shadow-lg text-xs p-1.5 rounded max-w-[200px]">Копировать СУПЕР-ПРОМПТ (вставь его боту перед запросом)</TooltipContent>
                         </Tooltip>
 
-                        {/* Копировать ТЕКУЩИЙ Запрос */}
                         <Tooltip delayDuration={100}>
                             <TooltipTrigger asChild>
-                                <Button variant="ghost" size="icon" onClick={onCopyToClipboard} disabled={calculatedIsCopyDisabled} className="h-7 w-7 text-muted-foreground hover:text-brand-cyan hover:bg-muted disabled:opacity-50"> {/* Theme colors */}
+                                <Button variant="ghost" size="icon" onClick={onCopyToClipboard} disabled={calculatedIsCopyDisabled} className="h-7 w-7 text-muted-foreground hover:text-brand-cyan hover:bg-muted disabled:opacity-50"> 
                                     <FaCopy />
                                 </Button>
                             </TooltipTrigger>
                             <TooltipContent side="left" className="bg-popover text-popover-foreground border-border shadow-lg text-xs p-1.5 rounded">Скопировать запрос</TooltipContent>
                         </Tooltip>
 
-                        {/* Очистить Все */}
                         <Tooltip delayDuration={100}>
                             <TooltipTrigger asChild>
-                                <Button variant="ghost" size="icon" onClick={onClearAll} disabled={calculatedIsClearDisabled} className="h-7 w-7 text-muted-foreground hover:text-destructive hover:bg-muted disabled:opacity-50"> {/* Theme colors */}
+                                <Button variant="ghost" size="icon" onClick={onClearAll} disabled={calculatedIsClearDisabled} className="h-7 w-7 text-muted-foreground hover:text-destructive hover:bg-muted disabled:opacity-50"> 
                                     <FaBroom />
                                 </Button>
                             </TooltipTrigger>
                             <TooltipContent side="left" className="bg-popover text-popover-foreground border-border shadow-lg text-xs p-1.5 rounded">Очистить все</TooltipContent>
                         </Tooltip>
                     </div>
-                    {/* --- Конец блока кнопок --- */}
                 </div>
                  <div className="flex flex-wrap justify-end gap-3">
-                     {/* Добавить Выбранное */}
                      <Tooltip delayDuration={100}>
                         <TooltipTrigger asChild>
                             <Button
-                                variant="default" // Use default primary style
+                                variant="default" 
                                 size="sm"
                                 onClick={onAddSelected}
                                 disabled={isAddSelectedDisabled || isActionDisabled}
-                                className="rounded-full shadow-md hover:shadow-lg transition-all disabled:opacity-50 px-4" // Use default button styling
+                                className="rounded-full shadow-md hover:shadow-lg transition-all disabled:opacity-50 px-4" 
                             >
                                 <FaPlus className="mr-2 h-4 w-4" />
                                 Добавить Выбранное ({selectedFetcherFilesCount})

--- a/components/repo/SelectedFilesPreview.tsx
+++ b/components/repo/SelectedFilesPreview.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import { FileNode } from '../RepoTxtFetcher'; // Import FileNode interface
+import { FileNode } from '@/contexts/RepoXmlPageContext'; // Changed import source
 
 interface SelectedFilesPreviewProps {
     selectedFiles: Set<string>;
@@ -11,13 +11,11 @@ interface SelectedFilesPreviewProps {
     getLanguage: (path: string) => string;
 }
 
-// Memoize the component to prevent re-renders if props haven't changed by reference
 const SelectedFilesPreview: React.FC<SelectedFilesPreviewProps> = React.memo(({
     selectedFiles,
     allFiles,
     getLanguage,
 }) => {
-    // Create a sorted array from the Set inside the component
     const sortedSelectedPaths = React.useMemo(() => Array.from(selectedFiles).sort(), [selectedFiles]);
 
     if (selectedFiles.size === 0) {
@@ -25,16 +23,15 @@ const SelectedFilesPreview: React.FC<SelectedFilesPreviewProps> = React.memo(({
     }
 
     return (
-         <details className="mb-4 bg-gray-800/50 border border-gray-700 p-3 rounded-lg shadow-inner"> {/* Adjusted styles */}
-            <summary className="text-base font-semibold text-cyan-300 cursor-pointer hover:text-cyan-200 transition-colors"> {/* Adjusted styles */}
+         <details className="mb-4 bg-gray-800/50 border border-gray-700 p-3 rounded-lg shadow-inner"> 
+            <summary className="text-base font-semibold text-cyan-300 cursor-pointer hover:text-cyan-200 transition-colors"> 
                 Предпросмотр выбранных файлов ({selectedFiles.size})
             </summary>
-            <div className="mt-3 max-h-80 overflow-y-auto space-y-3 custom-scrollbar pr-1"> {/* Adjusted max-height, padding */}
+            <div className="mt-3 max-h-80 overflow-y-auto space-y-3 custom-scrollbar pr-1"> 
                 {sortedSelectedPaths.map((path) => {
                     const file = allFiles.find((f) => f.path === path);
                     if (!file) return null;
                     const lang = getLanguage(file.path);
-                    // More aggressive truncation for preview
                     const MAX_PREVIEW_LENGTH = 500;
                     const isTruncated = file.content.length > MAX_PREVIEW_LENGTH;
                     const displayContent = isTruncated
@@ -44,15 +41,14 @@ const SelectedFilesPreview: React.FC<SelectedFilesPreviewProps> = React.memo(({
                     return (
                         <div key={file.path} className="bg-gray-900/80 rounded-md overflow-hidden border border-gray-700/40 shadow-sm">
                             <h4 className="text-[11px] font-medium text-purple-300 px-2 py-0.5 bg-gray-700/60 truncate" title={file.path}>{file.path}</h4>
-                             <pre className="!m-0 !p-0 text-[10px]"> {/* Smaller base font for preview */}
+                             <pre className="!m-0 !p-0 text-[10px]"> 
                                 <SyntaxHighlighter
                                     language={lang}
                                     style={oneDark}
-                                    // Further optimize styles for preview
                                     customStyle={{ background: "transparent", padding: "0.5rem 0.75rem", margin: 0, maxHeight: '15rem', overflowY: 'auto' }}
                                     showLineNumbers={true}
                                     wrapLines={true}
-                                    lineNumberStyle={{ color: '#5c6370', fontSize: '0.6rem', minWidth: '2.0em', paddingRight: '0.5em' }} // Adjusted line number style
+                                    lineNumberStyle={{ color: '#5c6370', fontSize: '0.6rem', minWidth: '2.0em', paddingRight: '0.5em' }} 
                                 >
                                     {displayContent}
                                 </SyntaxHighlighter>
@@ -64,6 +60,6 @@ const SelectedFilesPreview: React.FC<SelectedFilesPreviewProps> = React.memo(({
         </details>
     );
 });
-SelectedFilesPreview.displayName = 'SelectedFilesPreview'; // Add display name
+SelectedFilesPreview.displayName = 'SelectedFilesPreview'; 
 
 export default SelectedFilesPreview;

--- a/components/repo/SettingsModal.tsx
+++ b/components/repo/SettingsModal.tsx
@@ -2,53 +2,45 @@
 
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { FaCodeBranch, FaList, FaCheck, FaSquareArrowUpRight, FaArrowsRotate } from 'react-icons/fa6'; // Updated icons
-import { SimplePullRequest } from '@/contexts/RepoXmlPageContext'; // Import type
-import { Tooltip } from '@/components/ui/tooltip';
+import { FaCodeBranch, FaList, FaCheck, FaSquareArrowUpRight, FaArrowsRotate } from 'react-icons/fa6'; 
+import { SimplePullRequest } from '@/contexts/RepoXmlPageContext'; 
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/components/ui/tooltip'; // Corrected Tooltip import
 
 interface SettingsModalProps {
     isOpen: boolean;
-    // onClose: () => void; // Removed, closure handled by context toggle
     repoUrl: string;
     setRepoUrl: (url: string) => void;
     token: string;
     setToken: (token: string) => void;
     manualBranchName: string;
     setManualBranchName: (name: string) => void;
-    currentTargetBranch: string | null; // Effective target branch from context
-    // PR Selection Props
+    currentTargetBranch: string | null; 
     openPrs: SimplePullRequest[];
     loadingPrs: boolean;
-    onSelectPrBranch: (branchName: string | null) => void; // Callback for selection
-    onLoadPrs: () => void; // Callback to trigger PR loading
-
-    loading: boolean; // General loading (fetch)
+    onSelectPrBranch: (branchName: string | null) => void; 
+    onLoadPrs: () => void; 
+    loading: boolean; 
 }
 
 const SettingsModal: React.FC<SettingsModalProps> = ({
     isOpen,
-    // onClose,
     repoUrl,
     setRepoUrl,
     token,
     setToken,
     manualBranchName,
     setManualBranchName,
-    currentTargetBranch, // This now reflects the *effective* target branch
-    // PR Props
+    currentTargetBranch, 
     openPrs,
     loadingPrs,
     onSelectPrBranch,
     onLoadPrs,
-    loading, // General loading
+    loading, 
 }) => {
 
     const getTargetBranchDisplay = () => {
-        // Display relies on the `currentTargetBranch` passed from context,
-        // which should already factor in manual input vs PR selection.
         if (currentTargetBranch) {
-            // Basic middle truncation attempt for display only
-            const maxLen = 40; // Adjust max length as needed
+            const maxLen = 40; 
             if (currentTargetBranch.length > maxLen) {
                 const start = currentTargetBranch.substring(0, maxLen / 2 - 2);
                 const end = currentTargetBranch.substring(currentTargetBranch.length - maxLen / 2 + 2);
@@ -59,18 +51,15 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
         return "Current Target: Default Branch";
     };
 
-    // Determine if the "Default" button should be marked as active
-    // Active if no PR is selected AND manual input is empty.
-    const isDefaultBranchActive = !currentTargetBranch && !manualBranchName.trim(); // Check manual input too
+    const isDefaultBranchActive = !currentTargetBranch && !manualBranchName.trim(); 
 
-    // Determine if a specific PR's branch is the active target
     const isPrBranchActive = (prBranch: string) => {
-         // Active if current target matches PR branch AND manual input is empty
          return currentTargetBranch === prBranch && !manualBranchName.trim();
     };
 
 
     return (
+      <TooltipProvider> {/* Added TooltipProvider Wrapper */}
         <AnimatePresence>
             {isOpen && (
                 <motion.div
@@ -78,13 +67,12 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                     animate={{ height: 'auto', opacity: 1, marginTop: '0.75rem' }}
                     exit={{ height: 0, opacity: 0, marginTop: 0 }}
                     transition={{ duration: 0.3 }}
-                    className="overflow-hidden mb-4 border border-purple-700 rounded-lg p-4 bg-gray-800 shadow-xl z-20 relative" // Kept rounded-lg for modal container
+                    className="overflow-hidden mb-4 border border-purple-700 rounded-lg p-4 bg-gray-800 shadow-xl z-20 relative" 
                 >
                     <h3 className="text-lg font-semibold text-purple-300 mb-4">Настройки и Выбор Ветки</h3>
 
-                    <div className="flex flex-col gap-5"> {/* Increased gap */}
+                    <div className="flex flex-col gap-5"> 
 
-                         {/* Current Target Branch Display */}
                         <div className="flex items-center gap-2 text-sm text-gray-300 bg-gray-900/50 p-2 rounded-md border border-gray-700">
                             <FaCodeBranch className="text-cyan-400 flex-shrink-0" />
                             <span className="font-semibold text-cyan-300 truncate" title={`Full Target: ${currentTargetBranch || 'Default'}`}>
@@ -92,29 +80,34 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                             </span>
                         </div>
 
-                        {/* --- PR Selection Section --- */}
-                        <div className="border border-gray-700 p-3 rounded-lg bg-gray-800/50"> {/* Kept rounded-lg */}
+                        <div className="border border-gray-700 p-3 rounded-lg bg-gray-800/50"> 
                             <div className="flex justify-between items-center mb-2">
                                 <h4 className="text-base font-semibold text-purple-300 flex items-center gap-2">
                                     Выберите PR для извлечения/обновления ветки:
                                 </h4>
                                 <div className="flex items-center gap-2">
-                                    <Tooltip text="Использовать ветку по умолчанию" >
+                                    <Tooltip delayDuration={100}>
+                                      <TooltipTrigger asChild>
                                         <button
-                                           onClick={() => { setManualBranchName(''); onSelectPrBranch(null); }} // Clear manual input when selecting default
+                                           onClick={() => { setManualBranchName(''); onSelectPrBranch(null); }} 
                                            disabled={loading || loadingPrs}
-                                           className={`text-xs px-3 py-1 rounded ${ // Kept rounded
+                                           className={`text-xs px-3 py-1 rounded ${ 
                                                isDefaultBranchActive
                                                ? 'bg-purple-600 ring-2 ring-purple-400 font-semibold'
                                                : 'bg-gray-600 hover:bg-gray-500'} transition text-white disabled:opacity-50`}
                                          >
                                            Default
                                         </button>
+                                      </TooltipTrigger>
+                                      <TooltipContent>Использовать ветку по умолчанию</TooltipContent>
                                      </Tooltip>
-                                     <Tooltip text="Обновить список PR" >
+                                     <Tooltip delayDuration={100}>
+                                      <TooltipTrigger asChild>
                                           <button onClick={onLoadPrs} disabled={loading || loadingPrs || !repoUrl.includes('github.com')} className="p-1 text-gray-400 hover:text-white disabled:opacity-50 disabled:cursor-not-allowed transition">
                                               {loadingPrs ? <FaArrowsRotate className="animate-spin"/> : <FaList />}
                                           </button>
+                                      </TooltipTrigger>
+                                      <TooltipContent>Обновить список PR</TooltipContent>
                                      </Tooltip>
                                 </div>
                             </div>
@@ -123,24 +116,22 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                                    {openPrs.map((pr) => (
                                         <li key={pr.id}>
                                             <button
-                                                onClick={() => { setManualBranchName(''); onSelectPrBranch(pr.head.ref); }} // Clear manual input when selecting PR
+                                                onClick={() => { setManualBranchName(''); onSelectPrBranch(pr.head.ref); }} 
                                                 disabled={loading || loadingPrs}
-                                                className={`w-full flex flex-wrap sm:flex-nowrap items-center justify-between gap-x-2 gap-y-1 p-2 rounded text-left text-sm transition ${ // Kept rounded, added flex-wrap
-                                                    isPrBranchActive(pr.head.ref) // Check if this PR branch is active
+                                                className={`w-full flex flex-wrap sm:flex-nowrap items-center justify-between gap-x-2 gap-y-1 p-2 rounded text-left text-sm transition ${ 
+                                                    isPrBranchActive(pr.head.ref) 
                                                     ? 'bg-purple-700/80 ring-2 ring-purple-400 shadow-md'
                                                     : 'bg-gray-700/50 hover:bg-gray-600/70 disabled:opacity-50'
                                                 }`}
                                                 title={`Select branch: ${pr.head.ref}\nPR: ${pr.title}`}
                                             >
-                                                {/* Left Side: Check, PR #, Title */}
-                                                <div className="flex items-center gap-2 flex-grow min-w-0 basis-3/5 sm:basis-auto"> {/* Allow grow/shrink */}
+                                                <div className="flex items-center gap-2 flex-grow min-w-0 basis-3/5 sm:basis-auto"> 
                                                      {isPrBranchActive(pr.head.ref) && <FaCheck className="text-green-400 flex-shrink-0" />}
                                                      <span className="text-purple-300 font-medium flex-shrink-0">#{pr.number}:</span>
                                                      <span className="text-gray-200 truncate" title={pr.title}>{pr.title}</span>
                                                 </div>
-                                                {/* Right Side: Branch Name, GitHub Link */}
-                                                <div className="flex items-center gap-2 flex-shrink-0 min-w-0 basis-2/5 sm:basis-auto justify-end w-full sm:w-auto"> {/* Allow shrink, basis for wrap */}
-                                                     <span className="text-xs text-gray-400 ml-auto truncate" title={`Branch: ${pr.head.ref}`}> {/* Added ml-auto to push right, truncate */}
+                                                <div className="flex items-center gap-2 flex-shrink-0 min-w-0 basis-2/5 sm:basis-auto justify-end w-full sm:w-auto"> 
+                                                     <span className="text-xs text-gray-400 ml-auto truncate" title={`Branch: ${pr.head.ref}`}> 
                                                          ({pr.head.ref})
                                                      </span>
                                                       <a href={pr.html_url} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()} className="text-gray-500 hover:text-blue-400 flex-shrink-0" title="Open PR on GitHub">
@@ -157,22 +148,18 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                                 </p>
                             )}
                         </div>
-                        {/* --- End PR Selection Section --- */}
 
 
-                        {/* Repo URL Input */}
                         <div>
                             <label htmlFor="settings-repo-url" className="block text-sm font-medium mb-1 text-cyan-300">URL репозитория GitHub</label>
-                            <input id="settings-repo-url" type="text" value={repoUrl} onChange={(e) => setRepoUrl(e.target.value)} className="w-full p-3 bg-gray-700 rounded-lg border border-gray-600 focus:border-cyan-500 focus:outline-none transition shadow-inner text-sm text-white placeholder-gray-400 disabled:opacity-50" placeholder="https://github.com/username/repository" disabled={loading || loadingPrs} aria-label="URL репозитория GitHub" /> {/* Kept rounded-lg */}
+                            <input id="settings-repo-url" type="text" value={repoUrl} onChange={(e) => setRepoUrl(e.target.value)} className="w-full p-3 bg-gray-700 rounded-lg border border-gray-600 focus:border-cyan-500 focus:outline-none transition shadow-inner text-sm text-white placeholder-gray-400 disabled:opacity-50" placeholder="https://github.com/username/repository" disabled={loading || loadingPrs} aria-label="URL репозитория GitHub" /> 
                         </div>
 
-                        {/* GitHub Token Input */}
                         <div>
                             <label htmlFor="settings-token" className="block text-sm font-medium mb-1 text-cyan-300">Токен GitHub <span className="text-gray-400">(опционально)</span></label>
-                            <input id="settings-token" type="password" value={token} onChange={(e) => setToken(e.target.value)} className="w-full p-3 bg-gray-700 rounded-lg border border-gray-600 focus:border-cyan-500 focus:outline-none transition shadow-inner text-sm text-white placeholder-gray-400 disabled:opacity-50" placeholder="Personal Access Token" disabled={loading || loadingPrs} aria-label="Токен GitHub" /> {/* Kept rounded-lg */}
+                            <input id="settings-token" type="password" value={token} onChange={(e) => setToken(e.target.value)} className="w-full p-3 bg-gray-700 rounded-lg border border-gray-600 focus:border-cyan-500 focus:outline-none transition shadow-inner text-sm text-white placeholder-gray-400 disabled:opacity-50" placeholder="Personal Access Token" disabled={loading || loadingPrs} aria-label="Токен GitHub" /> 
                         </div>
 
-                        {/* Manual Branch Name Input */}
                         <div>
                             <label htmlFor="settings-manual-branch" className="block text-sm font-medium mb-1 text-cyan-300">
                                 Имя ветки вручную <span className="text-gray-400">(переопределяет выбор PR)</span>
@@ -183,12 +170,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                                 value={manualBranchName}
                                 onChange={(e) => {
                                     setManualBranchName(e.target.value);
-                                    // If user types something, deselect any active PR branch implicitly
                                     if (e.target.value.trim()) {
-                                        onSelectPrBranch(null); // Or signal context differently if needed
+                                        onSelectPrBranch(null); 
                                     }
                                 }}
-                                className="w-full p-3 bg-gray-700 rounded-lg border border-gray-600 focus:border-cyan-500 focus:outline-none transition shadow-inner text-sm text-white placeholder-gray-400 disabled:opacity-50" // Kept rounded-lg
+                                className="w-full p-3 bg-gray-700 rounded-lg border border-gray-600 focus:border-cyan-500 focus:outline-none transition shadow-inner text-sm text-white placeholder-gray-400 disabled:opacity-50" 
                                 placeholder="main, dev, feature/..."
                                 disabled={loading || loadingPrs}
                                 aria-label="Имя ветки вручную"
@@ -199,6 +185,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                 </motion.div>
             )}
         </AnimatePresence>
+      </TooltipProvider>
     );
 };
 

--- a/contexts/RepoXmlPageContext.tsx
+++ b/contexts/RepoXmlPageContext.tsx
@@ -61,6 +61,7 @@ interface RepoXmlPageContextType {
     targetPrData: TargetPrData | null;
     pendingFlowDetails: PendingFlowDetails | null;
     kworkInputValue: string; 
+    urlPathToHighlight: string | null; // New state for URL path
     setFetchStatus: React.Dispatch<React.SetStateAction<FetchStatus>>;
     setRepoUrlEntered: React.Dispatch<React.SetStateAction<boolean>>;
     handleSetFilesFetched: ( fetched: boolean, allFiles: FileNode[], primaryHighlight: string | null, secondaryHighlights: Record<ImportCategory, string[]> ) => void;
@@ -85,7 +86,8 @@ interface RepoXmlPageContextType {
     setIsPreChecking: React.Dispatch<React.SetStateAction<boolean>>;
     setPendingFlowDetails: React.Dispatch<React.SetStateAction<PendingFlowDetails | null>>;
     setShowComponents: React.Dispatch<React.SetStateAction<boolean>>;
-    setKworkInputValue: (value: string | undefined | ((prevState: string) => string | undefined)) => void;
+    setKworkInputValue: (value: string | ((prevState: string) => string)) => void; // Ensure string
+    setUrlPathToHighlight: React.Dispatch<React.SetStateAction<string | null>>; // New setter
     triggerToggleSettingsModal: () => void;
     triggerPreCheckAndFetch: (repoUrlToCheck: string, potentialBranchName: string, flowType: 'ImageSwap' | 'ErrorFix', flowDetails: any, targetPath: string) => Promise<void>;
     triggerFetch: (isRetry?: boolean, branch?: string | null) => Promise<void>;
@@ -115,7 +117,8 @@ interface RepoXmlPageContextType {
 
 const defaultContextValue: Partial<RepoXmlPageContextType> = {
     fetchStatus: 'idle', repoUrlEntered: false, filesFetched: false, selectedFetcherFiles: new Set(), kworkInputHasContent: false, requestCopied: false, aiResponseHasContent: false, filesParsed: false, selectedAssistantFiles: new Set(), assistantLoading: false, aiActionLoading: false, loadingPrs: false, targetBranchName: null, manualBranchName: '', openPrs: [], isSettingsModalOpen: false, isParsing: false, currentAiRequestId: null, imageReplaceTask: null, allFetchedFiles: [], currentStep: 'idle', repoUrl: "https://github.com/salavey13/carTest", primaryHighlightedPath: null, secondaryHighlightedPaths: { component: [], context: [], hook: [], lib: [], other: [] }, targetPrData: null, isPreChecking: false, pendingFlowDetails: null, showComponents: true,
-    kworkInputValue: '',
+    kworkInputValue: '', // Initialize as empty string
+    urlPathToHighlight: null, // Initialize new state
     setFetchStatus: () => { logger.warn("setFetchStatus called on default context value"); },
     setRepoUrlEntered: () => { logger.warn("setRepoUrlEntered called on default context value"); },
     handleSetFilesFetched: () => { logger.warn("handleSetFilesFetched called on default context value"); },
@@ -141,6 +144,7 @@ const defaultContextValue: Partial<RepoXmlPageContextType> = {
     setPendingFlowDetails: () => { logger.warn("setPendingFlowDetails called on default context value"); },
     setShowComponents: () => { logger.warn("setShowComponents called on default context value"); },
     setKworkInputValue: () => { logger.warn("setKworkInputValue called on default context value"); },
+    setUrlPathToHighlight: () => { logger.warn("setUrlPathToHighlight called on default context value"); }, // Default for new setter
     triggerToggleSettingsModal: () => { logger.warn("triggerToggleSettingsModal called on default context value"); },
     triggerPreCheckAndFetch: async () => { logger.warn("triggerPreCheckAndFetch called on default context value"); },
     triggerFetch: async () => { logger.warn("triggerFetch called on default context value"); },
@@ -178,7 +182,7 @@ export const RepoXmlPageProvider: React.FC<{ children: ReactNode; }> = ({ childr
         const [secondaryHighlightPathsState, setSecondaryHighlightPathsState] = useState<Record<ImportCategory, string[]>>({ component: [], context: [], hook: [], lib: [], other: [] });
         const [selectedFetcherFilesState, setSelectedFetcherFilesState] = useState<Set<string>>(new Set());
         const [kworkInputHasContentState, setKworkInputHasContentState] = useState<boolean>(false);
-        const [kworkInputValueState, setKworkInputValueState] = useState<string>('');
+        const [kworkInputValueState, setKworkInputValueState] = useState<string>(''); // Default to empty string
         const [requestCopiedState, setRequestCopiedState] = useState<boolean>(false);
         const [aiResponseHasContentState, setAiResponseHasContentState] = useState<boolean>(false);
         const [filesParsedState, setFilesParsedState] = useState<boolean>(false);
@@ -199,6 +203,7 @@ export const RepoXmlPageProvider: React.FC<{ children: ReactNode; }> = ({ childr
         const [isPreCheckingState, setIsPreCheckingState] = useState<boolean>(false);
         const [pendingFlowDetailsState, setPendingFlowDetailsState] = useState<PendingFlowDetails | null>(null);
         const [showComponentsState, setShowComponentsState] = useState<boolean>(true);
+        const [urlPathToHighlightState, setUrlPathToHighlightState] = useState<string | null>(null); // New state
         
         const { dbUser } = useAppContext(); 
 
@@ -222,12 +227,11 @@ export const RepoXmlPageProvider: React.FC<{ children: ReactNode; }> = ({ childr
         const setRepoUrlEnteredStateStable = useCallback((entered: boolean | ((prevState: boolean) => boolean)) => setRepoUrlEnteredState(entered), []);
         const setSelectedFetcherFilesStateStable = useCallback((files: Set<string> | ((prevState: Set<string>) => Set<string>)) => setSelectedFetcherFilesState(files), []);
         const setKworkInputHasContentStateStable = useCallback((hasContent: boolean | ((prevState: boolean) => boolean)) => setKworkInputHasContentState(hasContent), []);
-        const setKworkInputValueStateStable = useCallback((value: string | undefined | ((prevState: string) => string | undefined)) => {
+        const setKworkInputValueStateStable = useCallback((value: string | ((prevState: string) => string)) => { // Ensure string
             setKworkInputValueState(prev => {
                 const determinedValue = typeof value === 'function' ? value(prev) : value;
-                const finalValue = typeof determinedValue === 'string' ? determinedValue : '';
-                setKworkInputHasContentStateStable(finalValue.trim().length > 0);
-                return finalValue;
+                setKworkInputHasContentStateStable(determinedValue.trim().length > 0);
+                return determinedValue;
             });
          }, [setKworkInputHasContentStateStable]);
         const setRequestCopiedStateStable = useCallback((copied: boolean | ((prevState: boolean) => boolean)) => setRequestCopiedState(copied), []);
@@ -249,6 +253,7 @@ export const RepoXmlPageProvider: React.FC<{ children: ReactNode; }> = ({ childr
         const setIsPreCheckingStateStable = useCallback((checking: boolean | ((prevState: boolean) => boolean)) => setIsPreCheckingState(checking), []);
         const setPendingFlowDetailsStateStable = useCallback((details: PendingFlowDetails | null | ((prevState: PendingFlowDetails | null) => PendingFlowDetails | null)) => setPendingFlowDetailsState(details), []);
         const setShowComponentsStateStable = useCallback((show: boolean | ((prevState: boolean) => boolean)) => setShowComponentsState(show), []);
+        const setUrlPathToHighlightStateStable = useCallback((path: string | null | ((prevState: string | null) => string | null)) => setUrlPathToHighlightState(path), []); // New stable setter
 
         useEffect(() => { imageReplaceTaskStateRef.current = imageReplaceTaskState; }, [imageReplaceTaskState]);
         useEffect(() => { pendingFlowDetailsRef.current = pendingFlowDetailsState; }, [pendingFlowDetailsState]);
@@ -575,7 +580,6 @@ export const RepoXmlPageProvider: React.FC<{ children: ReactNode; }> = ({ childr
             }
         }, [fetcherRef, dbUser?.id, addToastStable]);
 
-
         const [currentStep, setCurrentStep] = useState<WorkflowStep>('idle');
         useEffect(() => {
             let calculatedStep: WorkflowStep = 'idle';
@@ -635,14 +639,14 @@ export const RepoXmlPageProvider: React.FC<{ children: ReactNode; }> = ({ childr
           }, [ currentStep, manualBranchNameState, targetBranchNameState, imageReplaceTaskState, fetchStatusState, allFetchedFilesState, filesFetchedState, assistantLoadingState, selectedFetcherFilesState.size, selectedAssistantFilesState.size, isPreCheckingState, pendingFlowDetailsState ]);
 
         const contextValue = useMemo((): RepoXmlPageContextType => ({
-            fetchStatus: fetchStatusState, repoUrlEntered: repoUrlEnteredState, filesFetched: filesFetchedState, kworkInputHasContent: kworkInputHasContentState, requestCopied: requestCopiedState, aiResponseHasContent: aiResponseHasContentState, filesParsed: filesParsedState, assistantLoading: assistantLoadingState, aiActionLoading: aiActionLoadingState, loadingPrs: loadingPrsState, isSettingsModalOpen: isSettingsModalOpenState, isParsing: isParsingState, isPreChecking: isPreCheckingState, showComponents: showComponentsState, selectedFetcherFiles: selectedFetcherFilesState, selectedAssistantFiles: selectedAssistantFilesState, targetBranchName: targetBranchNameState, manualBranchName: manualBranchNameState, openPrs: openPrsState, currentAiRequestId: currentAiRequestIdState, imageReplaceTask: imageReplaceTaskState, allFetchedFiles: allFetchedFilesState, currentStep, repoUrl: repoUrlState, primaryHighlightedPath: primaryHighlightPathState, secondaryHighlightedPaths: secondaryHighlightPathsState, targetPrData: targetPrDataState, pendingFlowDetails: pendingFlowDetailsState, kworkInputValue: kworkInputValueState,
-            setFetchStatus: setFetchStatusStateStable, setRepoUrlEntered: setRepoUrlEnteredStateStable, handleSetFilesFetched: handleSetFilesFetchedStable, setSelectedFetcherFiles: setSelectedFetcherFilesStateStable, setKworkInputHasContent: setKworkInputHasContentStateStable, setRequestCopied: setRequestCopiedStateStable, setAiResponseHasContent: setAiResponseHasContentStateStable, setFilesParsed: setFilesParsedStateStable, setSelectedAssistantFiles: setSelectedAssistantFilesStateStable, setAssistantLoading: setAssistantLoadingStateStable, setAiActionLoading: setAiActionLoadingStateStable, setLoadingPrs: setLoadingPrsStateStable, setTargetBranchName: setTargetBranchNameStateStable, setManualBranchName: setManualBranchNameStateStable, setOpenPrs: setOpenPrsStateStable, setIsParsing: setIsParsingStateStable, setContextIsParsing: setIsParsingStateStable, setCurrentAiRequestId: setCurrentAiRequestIdStateStable, setImageReplaceTask: setImageReplaceTaskStateStable, setRepoUrl: setRepoUrlStateStable, setTargetPrData: setTargetPrDataStable, setIsPreChecking: setIsPreCheckingStateStable, setPendingFlowDetails: setPendingFlowDetailsStateStable, setShowComponents: setShowComponentsStateStable, setKworkInputValue: setKworkInputValueStateStable,
+            fetchStatus: fetchStatusState, repoUrlEntered: repoUrlEnteredState, filesFetched: filesFetchedState, kworkInputHasContent: kworkInputHasContentState, requestCopied: requestCopiedState, aiResponseHasContent: aiResponseHasContentState, filesParsed: filesParsedState, assistantLoading: assistantLoadingState, aiActionLoading: aiActionLoadingState, loadingPrs: loadingPrsState, isSettingsModalOpen: isSettingsModalOpenState, isParsing: isParsingState, isPreChecking: isPreCheckingState, showComponents: showComponentsState, selectedFetcherFiles: selectedFetcherFilesState, selectedAssistantFiles: selectedAssistantFilesState, targetBranchName: targetBranchNameState, manualBranchName: manualBranchNameState, openPrs: openPrsState, currentAiRequestId: currentAiRequestIdState, imageReplaceTask: imageReplaceTaskState, allFetchedFiles: allFetchedFilesState, currentStep, repoUrl: repoUrlState, primaryHighlightedPath: primaryHighlightPathState, secondaryHighlightedPaths: secondaryHighlightPathsState, targetPrData: targetPrDataState, pendingFlowDetails: pendingFlowDetailsState, kworkInputValue: kworkInputValueState, urlPathToHighlight: urlPathToHighlightState, // Expose new state
+            setFetchStatus: setFetchStatusStateStable, setRepoUrlEntered: setRepoUrlEnteredStateStable, handleSetFilesFetched: handleSetFilesFetchedStable, setSelectedFetcherFiles: setSelectedFetcherFilesStateStable, setKworkInputHasContent: setKworkInputHasContentStateStable, setRequestCopied: setRequestCopiedStateStable, setAiResponseHasContent: setAiResponseHasContentStateStable, setFilesParsed: setFilesParsedStateStable, setSelectedAssistantFiles: setSelectedAssistantFilesStateStable, setAssistantLoading: setAssistantLoadingStateStable, setAiActionLoading: setAiActionLoadingStateStable, setLoadingPrs: setLoadingPrsStateStable, setTargetBranchName: setTargetBranchNameStateStable, setManualBranchName: setManualBranchNameStateStable, setOpenPrs: setOpenPrsStateStable, setIsParsing: setIsParsingStateStable, setContextIsParsing: setIsParsingStateStable, setCurrentAiRequestId: setCurrentAiRequestIdStateStable, setImageReplaceTask: setImageReplaceTaskStateStable, setRepoUrl: setRepoUrlStateStable, setTargetPrData: setTargetPrDataStable, setIsPreChecking: setIsPreCheckingStateStable, setPendingFlowDetails: setPendingFlowDetailsStateStable, setShowComponents: setShowComponentsStateStable, setKworkInputValue: setKworkInputValueStateStable, setUrlPathToHighlight: setUrlPathToHighlightStateStable, // Expose new setter
             triggerToggleSettingsModal, triggerPreCheckAndFetch, triggerFetch, triggerSelectHighlighted, triggerAddSelectedToKwork, triggerCopyKwork, triggerAskAi, triggerParseResponse, triggerSelectAllParsed, triggerCreateOrUpdatePR, triggerUpdateBranch: triggerUpdateBranchStable, triggerGetOpenPRs: triggerGetOpenPRsStable, updateRepoUrlInAssistant: updateRepoUrlInAssistantStable, getXuinityMessage: getXuinityMessageStable, scrollToSection: scrollToSectionStable, triggerAddImportantToKwork: triggerAddImportantToKworkStable, triggerAddTreeToKwork: triggerAddTreeToKworkStable, triggerSelectAllFetcherFiles: triggerSelectAllFetcherFilesStable, triggerDeselectAllFetcherFiles: triggerDeselectAllFetcherFilesStable, triggerClearKworkInput: triggerClearKworkInputStable,
             kworkInputRef, aiResponseInputRef, fetcherRef, assistantRef,
             addToast: addToastStable,
         }), [
-            fetchStatusState, repoUrlEnteredState, filesFetchedState, kworkInputHasContentState, requestCopiedState, aiResponseHasContentState, filesParsedState, assistantLoadingState, aiActionLoadingState, loadingPrsState, isSettingsModalOpenState, isParsingState, isPreCheckingState, showComponentsState, selectedFetcherFilesState, selectedAssistantFilesState, targetBranchNameState, manualBranchNameState, openPrsState, currentAiRequestIdState, imageReplaceTaskState, allFetchedFilesState, currentStep, repoUrlState, primaryHighlightPathState, secondaryHighlightPathsState, targetPrDataState, pendingFlowDetailsState, kworkInputValueState,
-            setFetchStatusStateStable, setRepoUrlEnteredStateStable, handleSetFilesFetchedStable, setSelectedFetcherFilesStateStable, setKworkInputHasContentStateStable, setRequestCopiedStateStable, setAiResponseHasContentStateStable, setFilesParsedStateStable, setSelectedAssistantFilesStateStable, setAssistantLoadingStateStable, setAiActionLoadingStateStable, setLoadingPrsStateStable, setTargetBranchNameStateStable, setManualBranchNameStateStable, setOpenPrsStateStable, setIsParsingStateStable, setCurrentAiRequestIdStateStable, setImageReplaceTaskStateStable, setRepoUrlStateStable, setTargetPrDataStable, setIsPreCheckingStateStable, setPendingFlowDetailsStateStable, setShowComponentsStateStable, setKworkInputValueStateStable,
+            fetchStatusState, repoUrlEnteredState, filesFetchedState, kworkInputHasContentState, requestCopiedState, aiResponseHasContentState, filesParsedState, assistantLoadingState, aiActionLoadingState, loadingPrsState, isSettingsModalOpenState, isParsingState, isPreCheckingState, showComponentsState, selectedFetcherFilesState, selectedAssistantFilesState, targetBranchNameState, manualBranchNameState, openPrsState, currentAiRequestIdState, imageReplaceTaskState, allFetchedFilesState, currentStep, repoUrlState, primaryHighlightPathState, secondaryHighlightPathsState, targetPrDataState, pendingFlowDetailsState, kworkInputValueState, urlPathToHighlightState, // Include new state
+            setFetchStatusStateStable, setRepoUrlEnteredStateStable, handleSetFilesFetchedStable, setSelectedFetcherFilesStateStable, setKworkInputHasContentStateStable, setRequestCopiedStateStable, setAiResponseHasContentStateStable, setFilesParsedStateStable, setSelectedAssistantFilesStateStable, setAssistantLoadingStateStable, setAiActionLoadingStateStable, setLoadingPrsStateStable, setTargetBranchNameStateStable, setManualBranchNameStateStable, setOpenPrsStateStable, setIsParsingStateStable, setCurrentAiRequestIdStateStable, setImageReplaceTaskStateStable, setRepoUrlStateStable, setTargetPrDataStable, setIsPreCheckingStateStable, setPendingFlowDetailsStateStable, setShowComponentsStateStable, setKworkInputValueStateStable, setUrlPathToHighlightStateStable, // Include new setter
             triggerToggleSettingsModal, triggerPreCheckAndFetch, triggerFetch, triggerSelectHighlighted, triggerAddSelectedToKwork, triggerCopyKwork, triggerAskAi, triggerParseResponse, triggerSelectAllParsed, triggerCreateOrUpdatePR, triggerUpdateBranchStable, triggerGetOpenPRsStable, updateRepoUrlInAssistantStable, getXuinityMessageStable, scrollToSectionStable, triggerAddImportantToKworkStable, triggerAddTreeToKworkStable, triggerSelectAllFetcherFilesStable, triggerDeselectAllFetcherFilesStable, triggerClearKworkInputStable,
             addToastStable,
         ]);


### PR DESCRIPTION
Refactor: Centralize URL parameters in RepoXmlPageContext to reduce prop drilling

Данный PR решает проблему передачи начальных параметров (`initialPath`, `initialIdea`) через пропсы в компоненте `ActualPageContent` на странице `/repo-xml`. Вместо этого, параметры из URL теперь устанавливаются напрямую в `RepoXmlPageContext`, откуда их могут использовать дочерние компоненты.

**Основные изменения:**

1.  **`RepoXmlPageContext.tsx`**:
    *   Добавлено новое состояние `urlPathToHighlight: string | null` для хранения пути из URL, который должен быть подсвечен в `RepoTxtFetcher`.
    *   Добавлен соответствующий стабильный сеттер `setUrlPathToHighlight`.
    *   Тип состояния `kworkInputValue` изменен на `string` (ранее был `string | undefined`) и инициализируется пустой строкой `''`. Сеттер `setKworkInputValue` также теперь ожидает `string`. Это обеспечивает консистентность и избавляет от необходимости проверок на `undefined` в компонентах-потребителях, таких как `RequestInput`.

2.  **`/app/repo-xml/page.tsx`**:
    *   В компоненте `RepoXmlPageInternalContent`:
        *   Параметры `path` (для подсветки) и `idea` (для поля запроса) извлекаются из `useSearchParams()`.
        *   С помощью `useEffect` эти значения устанавливаются в контекст: `setUrlPathToHighlight(path)` и `setKworkInputValue(idea || '')`.
    *   Из интерфейса пропсов `ActualPageContentProps` удалены `initialPath` и `initialIdea`.
    *   Компонент `ActualPageContent`:
        *   Больше не принимает `initialPath` и `initialIdea` как пропсы.
        *   Получает `urlPathToHighlight` из `RepoXmlPageContext`.
        *   Передает `urlPathToHighlight` в `RepoTxtFetcher` как `highlightedPathProp`.
        *   Проп `ideaProp` для `RepoTxtFetcher` больше не нужен, так как предполагается,  что `RepoTxtFetcher` использует `kworkInputValue` из контекста для своего поля ввода, которое уже инициализируется значением `idea` из URL.

3.  **Consistency Check**:
    *   В `RequestInput.tsx` и других местах, где используется `kworkInputValue`, теперь можно ожидать `string`, что упрощает логику.
    *   Проверена общая консистентность использования контекста и передачи пропсов в затронутых файлах.

Эти изменения улучшают управление состоянием, уменьшают явную передачу пропсов через промежуточные компоненты и делают код более чистым и предсказуемым. <FaCodeBranch /> <FaReact />

**Файлы (2):**
- `app/repo-xml/page.tsx`
- `contexts/RepoXmlPageContext.tsx`