### PR TITLE
Feat: Автоматически разворачивать Web App в Telegram для отключения же

### DIFF
--- a/hooks/useTelegram.ts
+++ b/hooks/useTelegram.ts
@@ -218,6 +218,13 @@ export function useTelegram() {
           if (isMounted) {
             telegram.ready(); 
             globalLogger.log("[HOOK_TELEGRAM initialize] STEP 3.3: Called telegram.ready()");
+
+            // If in a real Telegram context (initData is present), expand the Web App.
+            // This typically disables the swipe-down-to-minimize gesture.
+            if (inTgContextReal && telegram.expand) {
+                telegram.expand();
+                globalLogger.info("[HOOK_TELEGRAM initialize] STEP 3.3.1: Called telegram.expand() to maximize Web App and potentially disable swipe-down gesture.");
+            }
           }
 
           if (inTgContextReal) { // initData is present and non-empty


### PR DESCRIPTION
Feat: Автоматически разворачивать Web App в Telegram для отключения жеста "swipe down to minimize"

Изменения направлены на улучшение пользовательского опыта в Telegram Web App за счет автоматического вызова метода `WebApp.expand()`. Это действие разворачивает веб-приложение на весь экран, что, в свою очередь, отключает стандартный жест Telegram "смахнуть вниз, чтобы свернуть".

**Ключевые изменения:**

*   **`useTelegram.ts`**:
    *   В хуке `useTelegram`, внутри основного `useEffect` (блок `initialize`), после вызова `telegram.ready()` добавлена проверка на наличие `telegram.initData`.
    *   Если `initData` присутствует (что указывает на реальный контекст Telegram), вызывается `telegram.expand()`.
    *   Добавлено логирование этого действия для отладки.

Это изменение гарантирует, что как только приложение инициализируется в Telegram и готово к работе, оно сразу же переходит в полноэкранный режим, предотвращая случайное сворачивание пользователем.

**Файлы (1):**
- `hooks/useTelegram.ts`