### PR TITLE
Fix: Оптимизирован `useInactivityTimer` для устранения "залипания" скр

### DIFF
--- a/hooks/useInactivityTimer.ts
+++ b/hooks/useInactivityTimer.ts
@@ -1,84 +1,90 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+"use client";
+
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { debugLogger as logger } from '@/lib/debugLogger';
 
 const useInactivityTimer = (
-    inactiveTimeout: number,
+    inactiveTimeoutMs: number,
     onInactive: () => void,
     onActive?: () => void,
     componentName: string = "UnnamedComponent"
 ) => {
-    const [isCurrentlyInactive, setIsCurrentlyInactive] = useState(false);
-    const timerRef = useRef<NodeJS.Timeout | null>(null);
-    
-    const onInactiveRef = useRef(onInactive);
-    const onActiveRef = useRef(onActive);
+    const timerIdRef = useRef<NodeJS.Timeout | null>(null);
+    // Use a ref to track the "inactive" status internally for logic,
+    // to avoid making the event handler callback dependent on state for its identity.
+    const internalIsInactiveRef = useRef(false); 
 
-    useEffect(() => {
-        onInactiveRef.current = onInactive;
-    }, [onInactive]);
+    // State to return to the consumer if they need to know (optional)
+    // This state is updated by the stableEventHandler.
+    const [consumerFacingIsInactive, setConsumerFacingIsInactive] = useState(false);
 
-    useEffect(() => {
-        onActiveRef.current = onActive;
-    }, [onActive]);
+    const onInactiveCallbackRef = useRef(onInactive);
+    const onActiveCallbackRef = useRef(onActive);
 
-    const resetTimer = useCallback(() => {
-        if (timerRef.current) {
-            clearTimeout(timerRef.current);
+    useEffect(() => { onInactiveCallbackRef.current = onInactive; }, [onInactive]);
+    useEffect(() => { onActiveCallbackRef.current = onActive; }, [onActive]);
+
+    const stableEventHandler = useCallback(() => {
+        if (timerIdRef.current) {
+            clearTimeout(timerIdRef.current);
         }
 
-        // Only call onActive if state is transitioning from inactive to active
-        if (isCurrentlyInactive) {
-            setIsCurrentlyInactive(false);
+        if (internalIsInactiveRef.current) { // User was inactive, now active
+            internalIsInactiveRef.current = false;
+            setConsumerFacingIsInactive(false);
             logger.log(`[useInactivityTimer - ${componentName}] Activity resumed.`);
-            if (onActiveRef.current) {
-                onActiveRef.current();
+            if (onActiveCallbackRef.current) {
+                onActiveCallbackRef.current();
             }
         }
-
-        if (inactiveTimeout > 0) {
-            timerRef.current = setTimeout(() => {
-                setIsCurrentlyInactive(true); // Set inactive state before calling the callback
-                logger.log(`[useInactivityTimer - ${componentName}] Inactivity detected after ${inactiveTimeout}ms.`);
-                if (onInactiveRef.current) {
-                    onInactiveRef.current();
+        
+        if (inactiveTimeoutMs > 0) {
+            timerIdRef.current = setTimeout(() => {
+                internalIsInactiveRef.current = true;
+                setConsumerFacingIsInactive(true);
+                logger.log(`[useInactivityTimer - ${componentName}] Inactivity detected after ${inactiveTimeoutMs}ms.`);
+                if (onInactiveCallbackRef.current) {
+                    onInactiveCallbackRef.current();
                 }
-            }, inactiveTimeout);
+            }, inactiveTimeoutMs);
         }
-    }, [inactiveTimeout, isCurrentlyInactive, componentName]); 
+    }, [inactiveTimeoutMs, componentName]); // This handler is now stable as its deps don't include internal state.
 
     useEffect(() => {
         const events: Array<keyof WindowEventMap> = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll'];
         
-        const handleActivity = () => {
-            // No need to check inactiveTimeout here, resetTimer handles it
-            resetTimer();
-        };
+        if (inactiveTimeoutMs > 0) {
+            logger.log(`[useInactivityTimer - ${componentName}] Initializing. Timeout: ${inactiveTimeoutMs}ms.`);
+            
+            // Initial setup: assume user is active, reset ref, and start the first timer.
+            internalIsInactiveRef.current = false; 
+            setConsumerFacingIsInactive(false);
+            stableEventHandler(); // Call to set the first timer based on current (active) state.
 
-        if (inactiveTimeout > 0) {
-            logger.log(`[useInactivityTimer - ${componentName}] Initializing timer with ${inactiveTimeout}ms.`);
-            resetTimer(); // Initial timer start
+            events.forEach(event => window.addEventListener(event, stableEventHandler, { passive: true }));
+            logger.log(`[useInactivityTimer - ${componentName}] Event listeners ADDED.`);
 
-            events.forEach(event => window.addEventListener(event, handleActivity, { passive: true }));
+            return () => {
+                events.forEach(event => window.removeEventListener(event, stableEventHandler));
+                if (timerIdRef.current) {
+                    clearTimeout(timerIdRef.current);
+                }
+                logger.log(`[useInactivityTimer - ${componentName}] Event listeners REMOVED and timer cleared.`);
+            };
         } else {
-            logger.log(`[useInactivityTimer - ${componentName}] Inactivity timer disabled (timeout <= 0). Clearing existing timer if any.`);
-            if (timerRef.current) {
-                clearTimeout(timerRef.current);
+            // If timer is disabled (timeout <= 0)
+            if (timerIdRef.current) {
+                clearTimeout(timerIdRef.current);
             }
-            // No listeners should be active if timeout is <= 0
+            // Optionally set a default state when disabled
+            // internalIsInactiveRef.current = false; // Or true, depending on definition
+            // setConsumerFacingIsInactive(false);
+            logger.log(`[useInactivityTimer - ${componentName}] Disabled (timeout: ${inactiveTimeoutMs}ms). Timer cleared.`);
+            return () => {}; // No listeners were added if inactiveTimeoutMs <= 0
         }
+    }, [inactiveTimeoutMs, componentName, stableEventHandler]); // stableEventHandler is stable.
 
-        return () => {
-            if (timerRef.current) {
-                clearTimeout(timerRef.current);
-            }
-            if (inactiveTimeout > 0) { // Only remove listeners if they were added
-                events.forEach(event => window.removeEventListener(event, handleActivity));
-                logger.log(`[useInactivityTimer - ${componentName}] Cleaned up event listeners.`);
-            }
-        };
-    }, [resetTimer, inactiveTimeout, componentName]); // resetTimer is stable, inactiveTimeout and componentName are key dependencies
-
-    return { isInactive: isCurrentlyInactive }; // isInactive reflects the current state
+    return { isInactive: consumerFacingIsInactive }; 
 };
 
 export default useInactivityTimer;


### PR DESCRIPTION
Fix: Оптимизирован `useInactivityTimer` для устранения "залипания" скролла

**Анализ Проблемы (Повторно):**

Интерфейс периодически переставал реагировать на скролл. Клики работали. Проблема была связана с частым добавлением и удалением глобальных обработчиков событий (включая `scroll`) несколькими экземплярами хука `useInactivityTimer`. Это происходило каждый раз, когда внутреннее состояние неактивности таймера (`isCurrentlyInactive`) изменялось, что приводило к пересозданию колбэка-обработчика активности и, как следствие, к повторному запуску `useEffect`, который управляет слушателями. Такая частая "тряска" глобальных слушателей могла приводить к конфликтам или потере реакции на скролл.

**Коренная Причина:**

Основная проблема заключалась в том, что `useEffect` в `useInactivityTimer`, ответственный за установку и удаление глобальных слушателей событий (`mousemove`, `scroll` и т.д.), имел в зависимостях колбэк (`activityHandler` или `resetTimerCallback` в предыдущих итерациях), который, в свою очередь, зависел от внутреннего состояния неактивности (`isCurrentlyInactive` или `isTimerInactive`). Когда это состояние изменялось (пользователь становился активным/неактивным), колбэк получал новую ссылку, что заставляло `useEffect` выполняться заново: удалять всех слушателей и добавлять их снова. Это происходило для каждого экземпляра `useInactivityTimer` (в `GlobalAppFocusTracker`, `AutomationBuddy`, `StickyChatButton`).

**Решение:**

Хук `useInactivityTimer` был переработан следующим образом:

1.  **Стабильный Обработчик Событий (`stableEventHandler`):**
    *   Создан `useCallback` (`stableEventHandler`), который непосредственно передается в `window.addEventListener` и `window.removeEventListener`.
    *   Зависимости этого `stableEventHandler` минимизированы (`inactiveTimeoutMs`, `componentName`). Важно, что он *не зависит* от внутреннего состояния неактивности для своей идентичности.
    *   Внутри `stableEventHandler` используется `useRef` (`internalIsInactiveRef`) для отслеживания текущего состояния неактивности и `useState` (`setIsConsumerFacingInactive`) для состояния, возвращаемого потребителю хука. Это позволяет логике внутри `stableEventHandler` всегда иметь доступ к актуальному состоянию без изменения ссылки на сам `stableEventHandler`.

2.  **Управление `useEffect` для Слушателей:**
    *   `useEffect`, который добавляет и удаляет глобальные слушатели, теперь зависит только от `inactiveTimeoutMs`, `componentName` и `stableEventHandler`. Поскольку `stableEventHandler` теперь действительно стабилен (его ссылка меняется очень редко), этот `useEffect` будет выполняться гораздо реже, только при изменении конфигурации таймера.

Это изменение значительно снижает частоту добавления/удаления глобальных обработчиков событий, что должно устранить "залипание" скролла и повысить общую стабильность.

**Измененные файлы:**

*   `/hooks/useInactivityTimer.ts`

**Файлы (1):**
- `hooks/useInactivityTimer.ts`