### PR TITLE
Feat: Revamp RockstarHeroSection and Enhance WTF Button Styling

### DIFF
--- a/app/start-training/page.tsx
+++ b/app/start-training/page.tsx
@@ -59,8 +59,8 @@ const pageTranslations = {
         trainingTitle: "::FaDumbbell:: ФИЗУХА ДЛЯ КИБЕР-АТЛЕТА (МОЖНО СКИПНУТЬ, ЕСЛИ ТЫ ДРИЩ)",
         missionsTitle: "::FaGamepad:: GTA Vibe Missions ::FaStreetView::",
         missionsSubtitle: "Хватит катать вату! Это не школа, это GTA Vibe! Пройди эти миссии, чтобы стать реальным пацаном в кодинге. WTF-режим – для тех, кто не боится запачкать руки и сломать пару правил. GO GO GO!",
-        toggleButtonToWtf: "::FaPooStorm:: Врубить WTF-Режим СТРАНИЦЫ!",
-        toggleButtonToNormal: "::FaBook:: Вернуть Норм Вид",
+        toggleButtonToWtf: "::FaPooStorm:: Врубить WTF-Режим СТРАНИЦЫ!", // This text remains for WTF mode, button switches to Normal
+        toggleButtonToNormal: "::FaBook:: Вернуть Норм Вид", // This text is for Ru mode, button switches to WTF
         lockedMissionTooltip: "СНАЧАЛА ПРЕДЫДУЩУЮ, НУБАС!",
     }
 }
@@ -169,9 +169,9 @@ function StartTrainingContent() {
     <div className="relative min-h-screen bg-background text-foreground overflow-x-hidden">
       <RockstarHeroSection
         title={t.pageTitle}
-        subtitle={currentMode === 'ru' ? t.pageSubtitleTraining : pageTranslations.wtf.pageSubtitleTraining}
+        subtitle={t.pageSubtitleTraining} // Subtitle passed here now
         triggerElementSelector={`#${heroTriggerId}`}
-        mainBackgroundImageUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/tutorial-1-img-swap//Screenshot_2025-05-17-11-07-09-401_org.telegram.messenger.jpg"
+        // mainBackgroundImageUrl uses new default from RockstarHeroSection if not overridden
         backgroundImageObjectUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/appStore/oneSitePls_transparent_icon.png"
       >
          <Button 
@@ -179,21 +179,19 @@ function StartTrainingContent() {
             variant="outline" 
             size="lg"
             className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-pink-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-pink-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
+              "backdrop-blur-lg transition-all duration-300 font-orbitron active:scale-95 transform hover:scale-105 focus:ring-offset-background",
               currentMode === 'ru' 
-                ? "border-pink-500/80 text-pink-400 hover:text-pink-200 focus:ring-2 focus:ring-pink-500" 
-                : "border-blue-500/80 text-blue-400 hover:text-blue-200 focus:ring-2 focus:ring-blue-500"
+                ? "bg-brand-pink/10 border-2 border-brand-pink text-brand-pink shadow-md shadow-brand-pink/40 hover:bg-brand-pink/20 hover:text-white hover:shadow-pink-glow focus:ring-2 focus:ring-brand-pink" 
+                : "bg-brand-blue/10 border-2 border-brand-blue text-brand-blue shadow-md shadow-brand-blue/40 hover:bg-brand-blue/20 hover:text-white hover:shadow-blue-glow focus:ring-2 focus:ring-brand-blue"
             )}
         >
-          <VibeContentRenderer content={currentMode === 'ru' ? t.toggleButtonToWtf : t.toggleButtonToNormal} />
+          {/* Text of button depends on current mode, leads to the OTHER mode */}
+          <VibeContentRenderer content={currentMode === 'ru' ? pageTranslations.ru.toggleButtonToWtf : pageTranslations.wtf.toggleButtonToNormal} />
         </Button>
       </RockstarHeroSection>
 
-      {/* This div acts as a spacer to push content below the fixed RockstarHeroSection */}
-      {/* Its height determines how much scroll is needed before content is fully visible */}
       <div id={heroTriggerId} style={{ height: '150vh' }} aria-hidden="true" />
       
-      {/* Actual page content starts here, positioned relatively */}
       <div className="container mx-auto px-4 py-12 md:py-16 relative z-10">
         <motion.div
           initial={{ opacity: 0, y: -20 }}

--- a/app/tutorials/RockstarHeroSection.tsx
+++ b/app/tutorials/RockstarHeroSection.tsx
@@ -1,62 +1,16 @@
 "use client";
-import React, { useState, useEffect, useRef, useId } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { VibeContentRenderer } from '@/components/VibeContentRenderer'; 
 
-interface TextToSVGMaskProps {
-  text: string;
-  maskId: string;
-  svgX?: string; 
-  svgY?: string; 
-}
-
-const TextToSVGMask: React.FC<TextToSVGMaskProps> = ({
-  text,
-  maskId,
-  svgX = "50%",
-  svgY = "50%", 
-}) => {
-  const fontFamily = `"Orbitron", sans-serif`; 
-  const fontWeight = "bold";
-  const fontSize = "100"; 
-  const letterSpacing = "0.01em";
-
-  return (
-    <svg className="rockstar-svg-mask-defs" aria-hidden="true">
-      <defs>
-        <mask id={maskId} maskUnits="objectBoundingBox" maskContentUnits="objectBoundingBox">
-          <rect x="0" y="0" width="1" height="1" fill="white" />
-          <svg x="0.02" y="0.05" width="0.96" height="0.9" 
-               viewBox="0 0 1000 250" 
-               preserveAspectRatio="xMidYMid meet">
-            <text 
-              x={svgX} 
-              y={svgY}
-              dominantBaseline="central" 
-              textAnchor="middle" 
-              fill="black" 
-              fontFamily={fontFamily}
-              fontWeight={fontWeight}
-              fontSize={fontSize} 
-              letterSpacing={letterSpacing}
-              className="uppercase" 
-            >
-              {text.toUpperCase()}
-            </text>
-          </svg>
-        </mask>
-      </defs>
-    </svg>
-  );
-};
+// TextToSVGMask and related logic for mask are removed as per request to disable mask layer.
 
 interface RockstarHeroSectionProps {
   title: string;
   subtitle?: string; 
   mainBackgroundImageUrl?: string;
   backgroundImageObjectUrl?: string; 
-  logoMaskPathD?: string; 
-  logoMaskViewBox?: string; 
+  // logoMaskPathD and logoMaskViewBox are removed as mask is disabled
   children?: React.ReactNode; 
   triggerElementSelector: string;
 }
@@ -64,10 +18,10 @@ interface RockstarHeroSectionProps {
 const RockstarHeroSection: React.FC<RockstarHeroSectionProps> = ({
   title,
   subtitle,
-  mainBackgroundImageUrl = "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/content/purple-abstract-bg.jpeg", 
+  mainBackgroundImageUrl = "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/tutorial-1-img-swap//Screenshot_2025-05-17-11-07-09-401_org.telegram.messenger.jpg", 
   backgroundImageObjectUrl, 
-  logoMaskPathD,
-  logoMaskViewBox,
+  // logoMaskPathD, (removed)
+  // logoMaskViewBox, (removed)
   children,
   triggerElementSelector,
 }) => {
@@ -76,9 +30,7 @@ const RockstarHeroSection: React.FC<RockstarHeroSectionProps> = ({
   const fixedHeroContainerRef = useRef<HTMLDivElement>(null);
   const fadeOverlayRef = useRef<HTMLDivElement>(null); 
   
-  const baseUniqueId = useId(); 
-  const sanitizedBaseId = baseUniqueId.replace(/:/g, "-");
-  const uniqueMaskId = `mask-${sanitizedBaseId}`;
+  // UniqueMaskId and related logic are removed as mask is disabled.
 
   useEffect(() => {
     const triggerElement = document.querySelector(triggerElementSelector);
@@ -132,17 +84,19 @@ const RockstarHeroSection: React.FC<RockstarHeroSectionProps> = ({
   }, [isVisible, triggerElementSelector]);
 
   const scrollThresholds = {
-    maskZoomStart: 0.05, 
-    maskZoomEnd: 0.75,
+    // maskZoomStart and maskZoomEnd are removed
     fadeOverlayStart: 0.65, 
     fadeOverlayEnd: 0.95,   
   };
 
   const mainBgInitialScale = 1.5;
   const mainBgTargetScale = 1;
+  // Adjusted mainBgScaleProgress to depend on scrollProgress up to fadeOverlayStart
   let mainBgScaleProgress = 0;
-  if (scrollProgress >= scrollThresholds.maskZoomStart) {
-    mainBgScaleProgress = Math.min(1, (scrollProgress - scrollThresholds.maskZoomStart) / (scrollThresholds.maskZoomEnd - scrollThresholds.maskZoomStart));
+  if (scrollThresholds.fadeOverlayStart > 0) {
+    mainBgScaleProgress = Math.min(1, scrollProgress / scrollThresholds.fadeOverlayStart);
+  } else {
+    mainBgScaleProgress = scrollProgress >= 0.01 ? 1 : 0; // If fadeOverlayStart is 0, scale immediately
   }
   const mainBgScale = mainBgInitialScale - mainBgScaleProgress * (mainBgInitialScale - mainBgTargetScale);
   const mainBgTranslateY = scrollProgress * 1; 
@@ -153,16 +107,7 @@ const RockstarHeroSection: React.FC<RockstarHeroSectionProps> = ({
   const bgObjectTranslateY = -scrollProgress * 3; 
   const bgObjectOpacity = Math.max(0.05, 0.6 - scrollProgress * 0.55); 
 
-  const initialMaskScale = 50; 
-  const targetMaskScale = 1;
-  let maskProgress = 0;
-  if (scrollProgress >= scrollThresholds.maskZoomStart) {
-    maskProgress = Math.min(1, (scrollProgress - scrollThresholds.maskZoomStart) / (scrollThresholds.maskZoomEnd - scrollThresholds.maskZoomStart));
-  }
-  const currentMaskScale = initialMaskScale - (initialMaskScale - targetMaskScale) * Math.pow(maskProgress, 1.5); 
-  const maskOverlayOpacity = maskProgress > 0.01 ? maskProgress : 0; 
-
-  const svgMaskUrl = `url(#${uniqueMaskId})`;
+  // Mask related calculations (maskProgress, currentMaskScale, maskOverlayOpacity, svgMaskUrl) are removed.
 
   let fadeOverlayProgress = 0;
   if (scrollProgress >= scrollThresholds.fadeOverlayStart) {
@@ -208,51 +153,24 @@ const RockstarHeroSection: React.FC<RockstarHeroSectionProps> = ({
           </div>
         )}
         
-        {/* Layer 3: Initial Title & Subtitle (Static) z-10 */}
+        {/* Layer 3: Title (Static, centrally aligned) z-10 */}
         <div className="relative text-center px-4 z-10" style={{ opacity: heroContentOverallOpacity }}>
-          <h1 className={cn("text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-orbitron font-bold gta-vibe-text-effect mb-4 md:mb-6")} data-text={title}>
+          <h1 className={cn(
+              "text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-orbitron font-bold mb-4 md:mb-6",
+              "gta-vibe-text-effect", 
+              "animate-glitch"        
+            )} 
+            data-text={title}
+          >
             <VibeContentRenderer content={title} />
           </h1>
-          {subtitle && (
-            <p className="text-lg sm:text-xl md:text-2xl text-gray-300/70 font-mono max-w-3xl mx-auto">
-              <VibeContentRenderer content={subtitle} />
-            </p>
-          )}
+          {/* Subtitle is moved to the bottom section */}
         </div>
 
-        {/* Layer 4: Masked Overlay z-20 */}
-        <div
-          className="absolute inset-0 z-20" 
-          style={{
-            backgroundColor: 'hsl(var(--background))', 
-            opacity: maskOverlayOpacity * heroContentOverallOpacity, 
-            transform: `scale(${Math.max(targetMaskScale, currentMaskScale)})`,
-            transformOrigin: 'center center', 
-            willChange: 'transform, opacity',
-            mask: svgMaskUrl,
-            WebkitMask: svgMaskUrl,
-          }}
-        />
+        {/* Layer 4: Masked Overlay z-20 - REMOVED */}
+        {/* SVG Mask Definitions - REMOVED */}
         
-        {logoMaskPathD && logoMaskViewBox ? (
-           <svg className="rockstar-svg-mask-defs" aria-hidden="true">
-             <defs>
-               <mask id={uniqueMaskId} maskUnits="objectBoundingBox" maskContentUnits="objectBoundingBox">
-                 <rect x="0" y="0" width="1" height="1" fill="white" />
-                 <svg viewBox={logoMaskViewBox} x="0.1" y="0.1" width="0.8" height="0.8" preserveAspectRatio="xMidYMid meet">
-                    <path d={logoMaskPathD} fill="black" />
-                 </svg>
-               </mask>
-             </defs>
-           </svg>
-        ) : (
-          <TextToSVGMask 
-            text={title} 
-            maskId={uniqueMaskId}
-          />
-        )}
-        
-        {/* Gradient Fade Overlay - z-40 (above mask, below children) */}
+        {/* Gradient Fade Overlay - z-40 (above background, below content at bottom) */}
         <div
           ref={fadeOverlayRef}
           className="absolute inset-0 z-40 pointer-events-none"
@@ -263,15 +181,25 @@ const RockstarHeroSection: React.FC<RockstarHeroSectionProps> = ({
           }}
         />
         
-        {/* Layer 6: Children (Buttons, etc.) z-50 */}
-        {children && (
-            <div 
-                className="absolute bottom-[10vh] md:bottom-[15vh] z-50" 
-                style={{ opacity: heroContentOverallOpacity > 0.1 ? 1 : 0, transition: 'opacity 0.3s ease-in-out' }} 
-            >
-                {children}
-            </div>
-        )}
+        {/* Layer 6: Subtitle and Children (Buttons, etc.) z-50, at the bottom */}
+        <div 
+            className="absolute bottom-[8vh] md:bottom-[10vh] w-full px-4 text-center z-50 flex flex-col items-center gap-4 md:gap-6" 
+            style={{ 
+                opacity: heroContentOverallOpacity > 0.1 ? 1 : 0, 
+                transition: 'opacity 0.3s ease-in-out' 
+            }} 
+        >
+            {subtitle && (
+                <p className="text-lg sm:text-xl md:text-2xl text-light-text/80 font-mono max-w-3xl mx-auto">
+                    <VibeContentRenderer content={subtitle} />
+                </p>
+            )}
+            {children && (
+                <div className={cn(subtitle ? "mt-2 md:mt-4" : "")}>
+                     {children}
+                </div>
+            )}
+        </div>
     </div>
   );
 };

--- a/app/tutorials/icon-swap/page.tsx
+++ b/app/tutorials/icon-swap/page.tsx
@@ -67,6 +67,7 @@ const iconSwapTutorialTranslations = {
     nextLevelText: "Отличная работа, сапёр! Теперь ты можешь поддерживать визуальную целостность интерфейсов. <Link href='/start-training' class='text-brand-blue hover:underline font-semibold'>Следующая Миссия</Link> ждет!",
     tryLiveButton: "::FaTools:: Перейти в Студию",
     toggleButtonToWtf: "::FaPooStorm:: Врубить Режим БОГА (WTF?!)",
+    toggleButtonToNormal: "::FaBook:: Вернуть Скучную Инструкцию", 
   },
   wtf: {
     pageTitle: "WTF IS THIS ICON?! ::FaHandMiddleFinger::",
@@ -108,6 +109,7 @@ const iconSwapTutorialTranslations = {
     nextLevelTitle: "::FaCrown:: ИКОНКИ ПОДЧИНЯЮТСЯ ТЕБЕ!",
     nextLevelText: "Ты теперь повелитель иконок! Го на <Link href='/start-training' class='text-brand-blue hover:underline font-semibold'>Следующую Миссию</Link>, там РЕАЛЬНЫЕ ДЕЛА.",
     tryLiveButton: "::FaHammer:: В Студию, РАБОТЯГА!",
+    toggleButtonToWtf: "::FaPooStorm:: Врубить Режим БОГА (WTF?!)", 
     toggleButtonToNormal: "::FaBook:: Вернуть Скучную Инструкцию", 
   }
 };
@@ -171,35 +173,22 @@ function IconSwapTutorialContent() {
         title={t.pageTitle}
         subtitle={t.pageSubtitle}
         triggerElementSelector={`#${heroTriggerId}`}
-        mainBackgroundImageUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/tutorial-1-img-swap//Screenshot_2025-05-17-11-07-09-401_org.telegram.messenger.jpg" 
+        // mainBackgroundImageUrl uses new default from RockstarHeroSection if not overridden
         backgroundImageObjectUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/appStore/oneSitePls_transparent_icon.png"
       >
-        {!initialModeFromUrl && currentMode === 'ru' && (
-           <Button 
+        <Button 
             onClick={toggleMode} 
             variant="outline" 
             size="lg"
             className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-pink-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-pink-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
-              "border-pink-500/80 text-pink-400 hover:text-pink-200 focus:ring-2 focus:ring-pink-500"
+                "backdrop-blur-lg transition-all duration-300 font-orbitron active:scale-95 transform hover:scale-105 focus:ring-offset-background",
+                currentMode === 'ru' 
+                ? "bg-brand-pink/10 border-2 border-brand-pink text-brand-pink shadow-md shadow-brand-pink/40 hover:bg-brand-pink/20 hover:text-white hover:shadow-pink-glow focus:ring-2 focus:ring-brand-pink" 
+                : "bg-brand-blue/10 border-2 border-brand-blue text-brand-blue shadow-md shadow-brand-blue/40 hover:bg-brand-blue/20 hover:text-white hover:shadow-blue-glow focus:ring-2 focus:ring-brand-blue"
             )}
-          >
-            <VibeContentRenderer content={iconSwapTutorialTranslations.ru.toggleButtonToWtf} />
-          </Button>
-        )}
-        {initialModeFromUrl && currentMode === 'wtf' && (
-           <Button 
-            onClick={toggleMode} 
-            variant="outline" 
-            size="lg"
-            className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-blue-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-blue-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
-              "border-blue-500/80 text-blue-400 hover:text-blue-200 focus:ring-2 focus:ring-blue-500"
-            )}
-          >
-            <VibeContentRenderer content={iconSwapTutorialTranslations.wtf.toggleButtonToNormal} />
-          </Button>
-        )}
+        >
+            <VibeContentRenderer content={currentMode === 'ru' ? iconSwapTutorialTranslations.ru.toggleButtonToWtf : iconSwapTutorialTranslations.wtf.toggleButtonToNormal} />
+        </Button>
       </RockstarHeroSection>
 
       <div id={heroTriggerId} style={{ height: '250vh' }} aria-hidden="true" />

--- a/app/tutorials/image-swap/page.tsx
+++ b/app/tutorials/image-swap/page.tsx
@@ -32,6 +32,7 @@ const imageSwapTutorialTranslations = {
     nextLevelText: "Основы у тебя в кармане, Агент! Готов применить эти навыки в реальном бою? <Link href='/start-training' class='text-brand-blue hover:underline font-semibold'>Следующая Миссия</Link> ждет!",
     tryLiveButton: "<FaWandMagicSparkles /> Попробовать в Студии",
     toggleButtonToWtf: "<FaPooStorm /> Включить Режим БОГА (WTF?!)",
+    toggleButtonToNormal: "<FaBookOpen /> Вернуть Скучную Инструкцию", 
   },
   wtf: {
     pageTitle: "КАРТИНКИ МЕНЯТЬ – КАК ДВА БАЙТА ПЕРЕСЛАТЬ!",
@@ -45,6 +46,7 @@ const imageSwapTutorialTranslations = {
     nextLevelTitle: "<FaRocket /> ТЫ ПРОКАЧАЛСЯ, БРО!",
     nextLevelText: "Менять картинки – это для лохов. Ты уже ПРО. Го на <Link href='/start-training' class='text-brand-blue hover:underline font-semibold'>Следующую Миссию</Link>, там РЕАЛЬНЫЕ ДЕЛА.",
     tryLiveButton: "<FaArrowRight /> В Студию, НЕ ТОРМОЗИ!",
+    toggleButtonToWtf: "<FaPooStorm /> Включить Режим БОГА (WTF?!)", // Should match RU version for consistency if button always visible
     toggleButtonToNormal: "<FaBookOpen /> Вернуть Скучную Инструкцию", 
   }
 };
@@ -107,7 +109,7 @@ function ImageSwapTutorialContent() {
         title={t.pageTitle} 
         subtitle={t.pageSubtitle}
         triggerElementSelector={`#${heroTriggerId}`}
-        mainBackgroundImageUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/tutorial-1-img-swap//Screenshot_2025-05-17-11-07-09-401_org.telegram.messenger.jpg" 
+        // mainBackgroundImageUrl uses new default from RockstarHeroSection if not overridden
         backgroundImageObjectUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/appStore/oneSitePls_transparent_icon.png"
       >
         <Button 
@@ -115,13 +117,13 @@ function ImageSwapTutorialContent() {
             variant="outline" 
             size="lg"
             className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-pink-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-pink-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
+              "backdrop-blur-lg transition-all duration-300 font-orbitron active:scale-95 transform hover:scale-105 focus:ring-offset-background",
               currentMode === 'ru' 
-                ? "border-pink-500/80 text-pink-400 hover:text-pink-200 focus:ring-2 focus:ring-pink-500" 
-                : "border-blue-500/80 text-blue-400 hover:text-blue-200 focus:ring-2 focus:ring-blue-500"
+                ? "bg-brand-pink/10 border-2 border-brand-pink text-brand-pink shadow-md shadow-brand-pink/40 hover:bg-brand-pink/20 hover:text-white hover:shadow-pink-glow focus:ring-2 focus:ring-brand-pink" 
+                : "bg-brand-blue/10 border-2 border-brand-blue text-brand-blue shadow-md shadow-brand-blue/40 hover:bg-brand-blue/20 hover:text-white hover:shadow-blue-glow focus:ring-2 focus:ring-brand-blue"
             )}
         >
-            <VibeContentRenderer content={currentMode === 'ru' ? t.toggleButtonToWtf : t.toggleButtonToNormal} />
+            <VibeContentRenderer content={currentMode === 'ru' ? imageSwapTutorialTranslations.ru.toggleButtonToWtf : imageSwapTutorialTranslations.wtf.toggleButtonToNormal} />
         </Button>
       </RockstarHeroSection>
       

--- a/app/tutorials/inception-swap/page.tsx
+++ b/app/tutorials/inception-swap/page.tsx
@@ -17,7 +17,6 @@ import TutorialContentContainer from '../TutorialContentContainer';
 import TutorialStepSection from '../TutorialStepSection';
 import NextLevelTeaser from '../NextLevelTeaser';
 
-
 const inceptionSwapTutorialTranslations = {
   ru: {
     pageTitle: "Миссия 4: ::FaInfinity:: Inception Swap",
@@ -56,6 +55,7 @@ const inceptionSwapTutorialTranslations = {
     nextLevelText: "Ты постиг Дзен разработки на oneSitePls. Теперь ты видишь код. <Link href='/start-training' class='text-brand-blue hover:underline font-semibold'>Следующая Миссия</Link> — твой верстак, а идеи — твои чертежи. Строй будущее!",
     tryLiveButton: "::FaTools:: В SUPERVIBE Studio",
     toggleButtonToWtf: "::FaPooStorm:: Включить Режим БОГА (WTF?!)",
+    toggleButtonToNormal: "::FaBook:: Вернуть Скучную Инструкцию", 
   },
   wtf: {
     pageTitle: "::FaBomb:: ВСЁ ЕСТЬ КОД! WTF?!",
@@ -93,6 +93,7 @@ const inceptionSwapTutorialTranslations = {
     nextLevelTitle: "::FaSatelliteDish:: ТЫ ПОДКЛЮЧЕН К ИСТОЧНИКУ!",
     nextLevelText: "РЕАЛЬНОСТЬ – ЭТО КОД. ТЫ – ЕГО АРХИТЕКТОР. <Link href='/start-training' class='text-brand-blue hover:underline font-semibold'>Следующая Миссия</Link> – ТВОЯ КИБЕРДЕКА. ВРЕМЯ ЛОМАТЬ СИСТЕМУ!",
     tryLiveButton: "::FaLaptopCode:: В БОЙ!",
+    toggleButtonToWtf: "::FaPooStorm:: Включить Режим БОГА (WTF?!)", 
     toggleButtonToNormal: "::FaBook:: Вернуть Скучную Инструкцию", 
   }
 };
@@ -137,8 +138,15 @@ function InceptionSwapTutorialContent() {
   const toggleMode = () => {
     const newMode = currentMode === 'ru' ? 'wtf' : 'ru';
     setCurrentMode(newMode);
-    if (newMode === 'wtf') {
-      router.replace(`/tutorials/inception-swap?mode=wtf`);
+    // router.replace(`/tutorials/inception-swap${newMode === 'wtf' ? '?mode=wtf' : ''}`, { scroll: false });
+    // Per original logic, this button only appears in RU mode to go to WTF, so no need to toggle back if started in WTF
+     if (newMode === 'wtf') {
+      router.replace(`/tutorials/inception-swap?mode=wtf`, { scroll: false });
+    } else {
+      // If currentMode was 'wtf' (meaning button was "back to normal") and we are here,
+      // it means user clicked "back to normal".
+      // We should remove the ?mode=wtf query param.
+      router.replace(`/tutorials/inception-swap`, { scroll: false });
     }
   };
 
@@ -158,30 +166,31 @@ function InceptionSwapTutorialContent() {
         title={t.pageTitle}
         subtitle={t.pageSubtitle}
         triggerElementSelector={`#${heroTriggerId}`}
-        mainBackgroundImageUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/tutorial-1-img-swap//Screenshot_2025-05-17-11-07-09-401_org.telegram.messenger.jpg" 
+        // mainBackgroundImageUrl uses new default from RockstarHeroSection if not overridden
         backgroundImageObjectUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/appStore/oneSitePls_transparent_icon.png"
       >
-        {!initialModeFromUrl && currentMode === 'ru' && (
+        {/* Logic for button visibility based on original page structure */}
+        {currentMode === 'ru' && (
            <Button 
             onClick={toggleMode} 
             variant="outline" 
             size="lg"
             className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-pink-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-pink-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
-              "border-pink-500/80 text-pink-400 hover:text-pink-200 focus:ring-2 focus:ring-pink-500" 
+              "backdrop-blur-lg transition-all duration-300 font-orbitron active:scale-95 transform hover:scale-105 focus:ring-offset-background",
+              "bg-brand-pink/10 border-2 border-brand-pink text-brand-pink shadow-md shadow-brand-pink/40 hover:bg-brand-pink/20 hover:text-white hover:shadow-pink-glow focus:ring-2 focus:ring-brand-pink" 
             )}
           >
             <VibeContentRenderer content={inceptionSwapTutorialTranslations.ru.toggleButtonToWtf} />
           </Button>
           )}
-        {initialModeFromUrl && currentMode === 'wtf' && (
+        {currentMode === 'wtf' && initialModeFromUrl && ( // Show "back to normal" only if started in WTF
            <Button 
             onClick={toggleMode} 
             variant="outline" 
             size="lg"
             className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-blue-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-blue-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
-              "border-blue-500/80 text-blue-400 hover:text-blue-200 focus:ring-2 focus:ring-blue-500"
+              "backdrop-blur-lg transition-all duration-300 font-orbitron active:scale-95 transform hover:scale-105 focus:ring-offset-background",
+              "bg-brand-blue/10 border-2 border-brand-blue text-brand-blue shadow-md shadow-brand-blue/40 hover:bg-brand-blue/20 hover:text-white hover:shadow-blue-glow focus:ring-2 focus:ring-brand-blue"
             )}
           >
             <VibeContentRenderer content={inceptionSwapTutorialTranslations.wtf.toggleButtonToNormal} />

--- a/app/tutorials/the-fifth-door/page.tsx
+++ b/app/tutorials/the-fifth-door/page.tsx
@@ -62,6 +62,7 @@ const theFifthDoorTutorialTranslations = {
     nextLevelText: "Все миссии пройдены. Все печати сломаны. Теперь у тебя есть всё, чтобы стать легендой. <Link href='/repo-xml' class='text-brand-blue hover:underline font-semibold'>SUPERVIBE Studio</Link> ждет твоих гениальных идей. Вперёд, творить историю!",
     tryLiveButton: "::FaRocket:: К ЗВЁЗДАМ!",
     toggleButtonToWtf: "::FaPooStorm:: Включить Режим БОГА (WTF?!)",
+    toggleButtonToNormal: "::FaBook:: Вернуть Скучную Инструкцию", 
   },
   wtf: {
     pageTitle: "::FaKey:: ПЯТАЯ ДВЕРЬ! ВЫХОД ИЗ МАТРИЦЫ, БЛ*ТЬ!",
@@ -106,6 +107,7 @@ const theFifthDoorTutorialTranslations = {
     nextLevelTitle: "::FaSatelliteDish:: ТЫ НЕ ПРОСТО В МАТРИЦЕ, ТЫ И ЕСТЬ МАТРИЦА!",
     nextLevelText: "Ты – Джонни Сильверхенд этого города. Код – твоя гитара. <Link href='/repo-xml' class='text-brand-blue hover:underline font-semibold'>SUPERVIBE Studio</Link> – твоя сцена. Зажги!",
     tryLiveButton: "::FaGuitar:: ВПЕРЕД, В NIGHT CITY!",
+    toggleButtonToWtf: "::FaPooStorm:: Включить Режим БОГА (WTF?!)", 
     toggleButtonToNormal: "::FaBook:: Вернуть Скучную Инструкцию", 
   }
 };
@@ -151,8 +153,12 @@ function TheFifthDoorTutorialContent() {
   const toggleMode = () => {
     const newMode = currentMode === 'ru' ? 'wtf' : 'ru';
     setCurrentMode(newMode);
+    // router.replace(`/tutorials/the-fifth-door${newMode === 'wtf' ? '?mode=wtf' : ''}`, { scroll: false });
+    // Per original logic, this button only appears in RU mode to go to WTF, so no need to toggle back if started in WTF
     if (newMode === 'wtf') {
-      router.replace(`/tutorials/the-fifth-door?mode=wtf`);
+      router.replace(`/tutorials/the-fifth-door?mode=wtf`, { scroll: false });
+    } else {
+      router.replace(`/tutorials/the-fifth-door`, { scroll: false });
     }
   };
 
@@ -172,30 +178,31 @@ function TheFifthDoorTutorialContent() {
         title={t.pageTitle}
         subtitle={t.pageSubtitle}
         triggerElementSelector={`#${heroTriggerId}`}
-        mainBackgroundImageUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/tutorial-1-img-swap//Screenshot_2025-05-17-11-07-09-401_org.telegram.messenger.jpg" 
+        // mainBackgroundImageUrl uses new default from RockstarHeroSection if not overridden
         backgroundImageObjectUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/appStore/oneSitePls_transparent_icon.png"
       >
-           {!initialModeFromUrl && currentMode === 'ru' && (
+           {/* Logic for button visibility based on original page structure */}
+           {currentMode === 'ru' && (
            <Button 
             onClick={toggleMode} 
             variant="outline" 
             size="lg"
             className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-pink-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-pink-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
-              "border-pink-500/80 text-pink-400 hover:text-pink-200 focus:ring-2 focus:ring-pink-500"
+              "backdrop-blur-lg transition-all duration-300 font-orbitron active:scale-95 transform hover:scale-105 focus:ring-offset-background",
+              "bg-brand-pink/10 border-2 border-brand-pink text-brand-pink shadow-md shadow-brand-pink/40 hover:bg-brand-pink/20 hover:text-white hover:shadow-pink-glow focus:ring-2 focus:ring-brand-pink"
             )}
           >
             <VibeContentRenderer content={theFifthDoorTutorialTranslations.ru.toggleButtonToWtf} />
           </Button>
            )}
-        {initialModeFromUrl && currentMode === 'wtf' && (
+        {currentMode === 'wtf' && initialModeFromUrl && ( // Show "back to normal" only if started in WTF
            <Button 
             onClick={toggleMode} 
             variant="outline" 
             size="lg"
             className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-blue-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-blue-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
-              "border-blue-500/80 text-blue-400 hover:text-blue-200 focus:ring-2 focus:ring-blue-500"
+              "backdrop-blur-lg transition-all duration-300 font-orbitron active:scale-95 transform hover:scale-105 focus:ring-offset-background",
+              "bg-brand-blue/10 border-2 border-brand-blue text-brand-blue shadow-md shadow-brand-blue/40 hover:bg-brand-blue/20 hover:text-white hover:shadow-blue-glow focus:ring-2 focus:ring-brand-blue"
             )}
           >
             <VibeContentRenderer content={theFifthDoorTutorialTranslations.wtf.toggleButtonToNormal} />

--- a/app/tutorials/video-swap/page.tsx
+++ b/app/tutorials/video-swap/page.tsx
@@ -60,6 +60,7 @@ const videoSwapTutorialTranslations = {
     nextLevelText: "Отличная работа, Агент! Ты освоил замену видео. <Link href='/start-training' class='text-brand-blue hover:underline font-semibold'>Следующая Миссия</Link> ждет. *Заметка: для видео используется тот же ImageSwap флоу в студии.*",
     tryLiveButton: "::FaWandMagicSparkles:: Попробовать в Студии",
     toggleButtonToWtf: "::FaPooStorm:: Включить Режим БОГА (WTF?!)",
+    toggleButtonToNormal: "::FaBook:: Вернуть Скучную Инструкцию", 
   },
   wtf: {
     pageTitle: "ВИДОСЫ МЕНЯТЬ – ЕЩЁ ПРОЩЕ, ЧЕМ ТЫ ДУМАЛ!",
@@ -101,6 +102,7 @@ const videoSwapTutorialTranslations = {
     nextLevelTitle: "::FaPhotoFilm:: ТЫ ТЕПЕРЬ ВИДЕО-МАГНАТ!",
     nextLevelText: "Картинки, иконки, видосы... Что дальше? Весь Голливуд твой! <Link href='/start-training' class='text-brand-blue hover:underline font-semibold'>Следующая Миссия</Link> ждет.",
     tryLiveButton: "::FaVideoCamera:: В Монтажную!",
+    toggleButtonToWtf: "::FaPooStorm:: Включить Режим БОГА (WTF?!)",
     toggleButtonToNormal: "::FaBook:: Вернуть Скучную Инструкцию", 
   }
 };
@@ -165,35 +167,22 @@ function VideoSwapTutorialContent() {
         title={t.pageTitle}
         subtitle={t.pageSubtitle}
         triggerElementSelector={`#${heroTriggerId}`}
-        mainBackgroundImageUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/tutorial-1-img-swap//Screenshot_2025-05-17-11-07-09-401_org.telegram.messenger.jpg" 
+        // mainBackgroundImageUrl uses new default from RockstarHeroSection if not overridden
         backgroundImageObjectUrl="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/appStore/oneSitePls_transparent_icon.png"
       >
-        {!initialModeFromUrl && currentMode === 'ru' && (
-           <Button 
+        <Button 
             onClick={toggleMode} 
             variant="outline" 
             size="lg"
             className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-pink-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-pink-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
-              "border-pink-500/80 text-pink-400 hover:text-pink-200 focus:ring-2 focus:ring-pink-500"
+                "backdrop-blur-lg transition-all duration-300 font-orbitron active:scale-95 transform hover:scale-105 focus:ring-offset-background",
+                currentMode === 'ru' 
+                ? "bg-brand-pink/10 border-2 border-brand-pink text-brand-pink shadow-md shadow-brand-pink/40 hover:bg-brand-pink/20 hover:text-white hover:shadow-pink-glow focus:ring-2 focus:ring-brand-pink" 
+                : "bg-brand-blue/10 border-2 border-brand-blue text-brand-blue shadow-md shadow-brand-blue/40 hover:bg-brand-blue/20 hover:text-white hover:shadow-blue-glow focus:ring-2 focus:ring-brand-blue"
             )}
-          >
-            <VibeContentRenderer content={videoSwapTutorialTranslations.ru.toggleButtonToWtf} />
-          </Button>
-        )}
-        {initialModeFromUrl && currentMode === 'wtf' && (
-           <Button 
-            onClick={toggleMode} 
-            variant="outline" 
-            size="lg"
-            className={cn(
-              "bg-card/80 backdrop-blur-md hover:bg-blue-600/30 transition-all duration-200 font-semibold shadow-xl hover:shadow-blue-600/50 focus:ring-offset-background active:scale-95 transform hover:scale-105",
-               "border-blue-500/80 text-blue-400 hover:text-blue-200 focus:ring-2 focus:ring-blue-500"
-            )}
-          >
-            <VibeContentRenderer content={videoSwapTutorialTranslations.wtf.toggleButtonToNormal} />
-          </Button>
-        )}
+        >
+            <VibeContentRenderer content={currentMode === 'ru' ? videoSwapTutorialTranslations.ru.toggleButtonToWtf : videoSwapTutorialTranslations.wtf.toggleButtonToNormal} />
+        </Button>
       </RockstarHeroSection>
       
       <div id={heroTriggerId} style={{ height: '250vh' }} aria-hidden="true" />


### PR DESCRIPTION
Feat: Revamp RockstarHeroSection and Enhance WTF Button Styling

Привет! В этом обновлении мы значительно переработали компонент `RockstarHeroSection` и улучшили стиль кнопок переключения WTF-режима на страницах тренировок и туториалов.

**Изменения в `RockstarHeroSection`:**

1.  **Новое Фоновое Изображение по Умолчанию:**
    *   Заменено стандартное фоновое изображение на более тематическое: `"https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/tutorial-1-img-swap//Screenshot_2025-05-17-11-07-09-401_org.telegram.messenger.jpg"`.

2.  **Отключение Эффекта Текстовой Маски:**
    *   Слой с SVG-маской (Layer 4) и связанная с ним логика генерации SVG-маски (`TextToSVGMask`, `logoMaskPathD`) были полностью удалены. Это упрощает эффект, делая акцент на основном заголовке и фоновых анимациях.
    *   Анимация масштабирования основного фона теперь привязана к прогрессу прокрутки до начала эффекта затухания (`fadeOverlayStart`), а не к параметрам удаленной маски.

3.  **Перемещение Описания (Subtitle):**
    *   Подзаголовок (`subtitle`) теперь отображается в нижней части Hero-секции, над дочерними элементами (например, кнопками). Раньше он был расположен под основным заголовком.
    *   Заголовок (`title`) остается на своем прежнем месте, сохраняя свой "глитчующий" эффект (`gta-vibe-text-effect` и `animate-glitch`).

**Улучшение Стиля WTF-Кнопок:**

Кнопки для переключения между обычным и WTF-режимом на странице `/start-training` и на всех страницах туториалов (`/tutorials/*`) получили более "сочный" и привлекательный вид:

*   **Шрифт:** Используется `font-orbitron` для более технологичного вида.
*   **Фон и Граница:** Легкий фон (`bg-brand-pink/10` или `bg-brand-blue/10`) с яркой границей (`border-2 border-brand-pink` или `border-brand-blue`).
*   **Текст:** Цвет текста соответствует основному цвету кнопки (`text-brand-pink` или `text-brand-blue`).
*   **Тени:** Добавлена базовая тень (`shadow-md`) и специфическая цветная тень (`shadow-brand-pink/40` или `shadow-brand-blue/40`).
*   **Эффекты при Наведении:**
    *   Фон становится чуть насыщеннее (`hover:bg-brand-pink/20` или `hover:bg-brand-blue/20`).
    *   Цвет текста меняется на белый (`hover:text-white`).
    *   Тень усиливается до яркого свечения (`hover:shadow-pink-glow` или `hover:shadow-blue-glow`).
*   **Фокус:** Четкое кольцо фокуса в цвет кнопки (`focus:ring-2 focus:ring-brand-pink` или `focus:ring-brand-blue`).
*   **Анимации:** Сохранены общие анимации перехода, масштабирования при наведении и нажатии.

Эти изменения направлены на улучшение визуального восприятия Hero-секции и придание кнопкам более выразительного и стильного вида, соответствующего общей концепции "киберпанк-вайба".

**Файлы (7):**
- `app/tutorials/RockstarHeroSection.tsx`
- `app/start-training/page.tsx`
- `app/tutorials/image-swap/page.tsx`
- `app/tutorials/icon-swap/page.tsx`
- `app/tutorials/video-swap/page.tsx`
- `app/tutorials/inception-swap/page.tsx`
- `app/tutorials/the-fifth-door/page.tsx`