### PR TITLE
Fix: Восстановлен `require` для `pdf-lib` для стабильной регистрации `

### DIFF
--- a/app/topdf/actions.ts
+++ b/app/topdf/actions.ts
@@ -3,37 +3,45 @@
 import { sendTelegramDocument } from '@/app/actions';
 import { logger } from '@/lib/logger';
 import { debugLogger } from '@/lib/debugLogger';
-// Use standard ESM imports now that pdf-lib and fontkit are externalized in webpack config.
-import { PDFDocument, StandardFonts, rgb, PageSizes, PDFFont } from 'pdf-lib';
-import fs from 'fs'; 
-import path from 'path'; 
-import fontkit from '@pdf-lib/fontkit'; 
 
-// Register fontkit globally when the module is loaded.
-// This is safe now that pdf-lib and fontkit are externalized in webpack config,
-// preventing bundling issues that caused `registerFontkit is not a function`.
-PDFDocument.registerFontkit(fontkit);
-debugLogger.log("[PDF Gen] fontkit registered with PDFDocument globally via externalization.");
+// Use require for pdf-lib to ensure stable access to static methods like registerFontkit
+// in Next.js server environments, especially when externalized.
+const { PDFDocument, StandardFonts, rgb, PageSizes, PDFFont } = require('pdf-lib');
+import fs from 'fs';
+import path from 'path';
+import fontkit from '@pdf-lib/fontkit';
+
+// Register fontkit with the PDFDocument class obtained via require.
+// This must be done *after* pdf-lib is loaded via require.
+try {
+    PDFDocument.registerFontkit(fontkit);
+    debugLogger.log("[PDF Gen] fontkit registered with PDFDocument successfully (via require).");
+} catch (e: any) {
+    logger.error("[PDF Gen] CRITICAL: Failed to register fontkit with PDFDocument.", e);
+    // This is a critical failure, re-throw or handle appropriately if actions can't proceed.
+    // For now, it will likely cause failures downstream in embedFont.
+}
+
 
 // Helper function definitions remain the same.
 async function drawMarkdownWrappedText(
-    page: any,
+    page: any, // Should be PDFPage from pdf-lib but require might make types tricky without more setup
     text: string,
     x: number,
     y: number,
     maxWidth: number,
     lineHeight: number,
-    baseFont: PDFFont, 
-    boldFont: PDFFont, 
+    baseFont: any, // PDFFont
+    boldFont: any, // PDFFont
     baseFontSize: number,
     color = rgb(0, 0, 0)
 ): Promise<number> {
     const lines = text.split('\n');
     let currentY = y;
-    const margin = 50; 
+    const margin = 50; // Assuming this is page margin, already accounted for in x, y, maxWidth
 
     for (const line of lines) {
-        if (currentY < margin) {
+        if (currentY < margin) { // Check against bottom margin
             debugLogger.warn("[PDF Gen] Content overflowing page, stopping text draw for this line.");
             break;
         }
@@ -57,11 +65,11 @@ async function drawMarkdownWrappedText(
             lineToDraw = line.substring(2);
         } else if (line.startsWith('* ') || line.startsWith('- ')) {
             lineToDraw = `• ${line.substring(2)}`;
-            currentX += 10;
-        } else if (line.match(/^(\s*)\* /) || line.match(/^(\s*)- /)) {
+            currentX += 10; // Indent for list items
+        } else if (line.match(/^(\s*)\* /) || line.match(/^(\s*)- /)) { // Nested lists
             const indentMatch = line.match(/^(\s*)/);
             const indent = indentMatch ? indentMatch[0].length : 0;
-            currentX += 10 + (indent * 5);
+            currentX += 10 + (indent * 5); // Base indent + nested indent
             lineToDraw = `• ${line.replace(/^(\s*)[\*-] /, '')}`;
         }
 
@@ -70,18 +78,22 @@ async function drawMarkdownWrappedText(
         for (const word of words) {
             const testSegment = currentLineSegment + (currentLineSegment ? ' ' : '') + word;
             try {
+                // widthOfTextAtSize might not be available if font is not correctly typed PDFFont
                 const textWidth = effectiveFont.widthOfTextAtSize(testSegment, effectiveSize);
                 if (currentX + textWidth > maxWidth && currentLineSegment) {
                     page.drawText(currentLineSegment, { x: currentX, y: currentY, font: effectiveFont, size: effectiveSize, color });
-                    currentY -= lineHeight * (effectiveSize / baseFontSize);
+                    currentY -= lineHeight * (effectiveSize / baseFontSize); // Adjust line height based on font size changes
                     currentLineSegment = word;
-                    if (currentY < margin) break;
+                    if (currentY < margin) break; // Check again after moving Y
                 } else {
                     currentLineSegment = testSegment;
                 }
             } catch (e: any) {
                 logger.warn(`[PDF Gen] Skipping character/word due to font error: "${word}" in segment "${testSegment}". Error: ${e.message}`);
-                currentLineSegment = currentLineSegment.replace(/[^\x00-\x7F]/g, "?"); 
+                // Attempt to replace problematic characters if any, or just skip.
+                // This usually happens if a character is not in the font's glyph set.
+                // For DejaVuSans, this should be rare for Cyrillic, but good to have fallback.
+                currentLineSegment = currentLineSegment.replace(/[^\x00-\u04FF\u0500-\u052F\s\d\p{P}]/gu, "?"); // Keep ASCII, Cyrillic, spaces, digits, punctuation
             }
         }
         if (currentLineSegment && currentY >= margin) {
@@ -89,15 +101,15 @@ async function drawMarkdownWrappedText(
                 page.drawText(currentLineSegment, { x: currentX, y: currentY, font: effectiveFont, size: effectiveSize, color });
             } catch (e: any) {
                 logger.warn(`[PDF Gen] Skipping final line segment due to font error: "${currentLineSegment}". Error: ${e.message}`);
-                page.drawText(currentLineSegment.replace(/[^\x00-\x7F]/g, "?"), { x: currentX, y: currentY, font: effectiveFont, size: effectiveSize, color });
+                page.drawText(currentLineSegment.replace(/[^\x00-\u04FF\u0500-\u052F\s\d\p{P}]/gu, "?"), { x: currentX, y: currentY, font: effectiveFont, size: effectiveSize, color });
             }
-            currentY -= lineHeight * (effectiveSize / baseFontSize);
+            currentY -= lineHeight * (effectiveSize / baseFontSize); // Adjust line height
         }
         if (currentY < margin) break;
     }
     return currentY;
 }
-const margin = 50;
+const pageMargins = 50; // Consistent margin definition
 
 export async function generatePdfFromMarkdownAndSend(
     markdownContent: string,
@@ -116,85 +128,79 @@ export async function generatePdfFromMarkdownAndSend(
     try {
         const pdfDoc = await PDFDocument.create();
 
-        // Use DejaVuSans fonts for Cyrillic support
         const regularFontName = 'DejaVuSans.ttf';
         const boldFontName = 'DejaVuSans-Bold.ttf';
         const currentWorkingDirectory = process.cwd();
-        // The 'server-assets/fonts' directory needs to be explicitly included in Next.js config for bundling
         const fontsDir = path.join(currentWorkingDirectory, 'server-assets', 'fonts');
 
         debugLogger.log(`[PDF Gen] Current working directory (process.cwd()): ${currentWorkingDirectory}`);
         debugLogger.log(`[PDF Gen] Attempting to access fonts directory at absolute path: ${fontsDir}`);
 
         if (!fs.existsSync(fontsDir)) {
-            logger.error(`[PDF Gen] CRITICAL: Fonts directory NOT FOUND at specified path: ${fontsDir}. This means the 'server-assets/fonts' directory is not accessible or does not exist at this location in the server environment.`);
-            return { success: false, error: `Core fonts directory missing on server. Expected at: ${fontsDir}. Please check server deployment and logs.` };
+            logger.error(`[PDF Gen] CRITICAL: Fonts directory NOT FOUND at specified path: ${fontsDir}.`);
+            return { success: false, error: `Core fonts directory missing on server. Expected at: ${fontsDir}.` };
         } else {
-            debugLogger.log(`[PDF Gen] Fonts directory found at: ${fontsDir}. Attempting to list contents...`);
+            debugLogger.log(`[PDF Gen] Fonts directory found at: ${fontsDir}. Checking contents...`);
             try {
                 const filesInFontsDir = fs.readdirSync(fontsDir);
-                debugLogger.log(`[PDF Gen] Files successfully listed in ${fontsDir}: [${filesInFontsDir.join(', ')}]`);
+                debugLogger.log(`[PDF Gen] Files in ${fontsDir}: [${filesInFontsDir.join(', ')}]`);
                 if (filesInFontsDir.length === 0) {
                     logger.warn(`[PDF Gen] Warning: Fonts directory ${fontsDir} is empty.`);
                 }
             } catch (readDirError: any) {
-                logger.warn(`[PDF Gen] Warning: Could not read contents of fonts directory ${fontsDir}, though the directory itself exists. Error: ${readDirError.message}`);
+                logger.warn(`[PDF Gen] Warning: Could not read contents of fonts directory ${fontsDir}. Error: ${readDirError.message}`);
             }
         }
         
-        // --- Load Regular Font ---
         const regularFontPath = path.join(fontsDir, regularFontName);
-        debugLogger.log(`[PDF Gen] Attempting to load regular font from absolute path: ${regularFontPath}`);
-        
+        debugLogger.log(`[PDF Gen] Attempting to load regular font from: ${regularFontPath}`);
         if (!fs.existsSync(regularFontPath)) {
-            logger.error(`[PDF Gen] CRITICAL: Regular font file '${regularFontName}' NOT FOUND at specified path: ${regularFontPath}.`);
-            return { success: false, error: `Core font file (${regularFontName}) for PDF generation is missing on the server. Path checked: ${regularFontPath}` };
+            logger.error(`[PDF Gen] CRITICAL: Regular font file '${regularFontName}' NOT FOUND at: ${regularFontPath}.`);
+            return { success: false, error: `Font file (${regularFontName}) missing. Path: ${regularFontPath}` };
         }
         
         let regularFontBytes;
         try {
             regularFontBytes = fs.readFileSync(regularFontPath);
-            debugLogger.log(`[PDF Gen] Successfully read regular font file '${regularFontName}'. Size: ${regularFontBytes.byteLength} bytes.`);
+            debugLogger.log(`[PDF Gen] Read regular font '${regularFontName}'. Size: ${regularFontBytes.byteLength} bytes.`);
         } catch (fontError: any) {
-            logger.error(`[PDF Gen] CRITICAL: Failed to READ regular font file '${regularFontName}' from ${regularFontPath}. Error: ${fontError.message}`);
-            return { success: false, error: `Failed to read core font file (${regularFontName}). Ensure it's not corrupted and server has permissions. Path: ${regularFontPath}` };
+            logger.error(`[PDF Gen] CRITICAL: Failed to READ regular font '${regularFontName}' from ${regularFontPath}. Error: ${fontError.message}`);
+            return { success: false, error: `Failed to read font file (${regularFontName}). Path: ${regularFontPath}` };
         }
         
         const customFont = await pdfDoc.embedFont(regularFontBytes); 
-        debugLogger.log(`[PDF Gen] Custom font '${regularFontName}' embedded successfully into PDF.`);
+        debugLogger.log(`[PDF Gen] Custom font '${regularFontName}' embedded.`);
         
-        // --- Load Bold Font ---
-        let customBoldFont: PDFFont; 
+        let customBoldFont: any; // PDFFont
         const boldFontPath = path.join(fontsDir, boldFontName);
-        debugLogger.log(`[PDF Gen] Attempting to load bold font from absolute path: ${boldFontPath}`);
+        debugLogger.log(`[PDF Gen] Attempting to load bold font from: ${boldFontPath}`);
 
         if (!fs.existsSync(boldFontPath)) {
-            logger.warn(`[PDF Gen] Warning: Bold font file '${boldFontName}' NOT FOUND at ${boldFontPath}. Falling back to regular font for bold text.`);
+            logger.warn(`[PDF Gen] Warning: Bold font '${boldFontName}' NOT FOUND at ${boldFontPath}. Using regular font for bold.`);
             customBoldFont = customFont; 
         } else {
             try {
                 const boldFontBytes = fs.readFileSync(boldFontPath);
-                debugLogger.log(`[PDF Gen] Successfully read bold font file '${boldFontName}'. Size: ${boldFontBytes.byteLength} bytes.`);
+                debugLogger.log(`[PDF Gen] Read bold font '${boldFontName}'. Size: ${boldFontBytes.byteLength} bytes.`);
                 customBoldFont = await pdfDoc.embedFont(boldFontBytes); 
-                debugLogger.log(`[PDF Gen] Custom bold font '${boldFontName}' embedded successfully into PDF.`);
+                debugLogger.log(`[PDF Gen] Custom bold font '${boldFontName}' embedded.`);
             } catch (fontError: any) {
-                logger.warn(`[PDF Gen] Warning: Failed to READ bold font file '${boldFontName}' from ${boldFontPath}. Using regular font for bold text. Error: ${fontError.message}`);
+                logger.warn(`[PDF Gen] Warning: Failed to READ bold font '${boldFontName}' from ${boldFontPath}. Using regular for bold. Error: ${fontError.message}`);
                 customBoldFont = customFont; 
             }
         }
 
-        // --- Create PDF Document ---
         let page = pdfDoc.addPage(PageSizes.A4);
         const { width, height } = page.getSize();
         
         const baseFontSize = 10;
         const lineHeight = 14;
-        let currentY = height - margin;
+        let currentY = height - pageMargins;
 
         const sanitizedTitleFileName = originalFileName.replace(/[^\w\s\d.,!?"'%*()\-+=\[\]{};:@#~$&\/\\]/g, "_");
 
         page.drawText(`AI Analysis Report: ${sanitizedTitleFileName}`, {
-            x: margin,
+            x: pageMargins,
             y: currentY,
             font: customBoldFont, 
             size: 16,
@@ -205,19 +211,19 @@ export async function generatePdfFromMarkdownAndSend(
         const lines = markdownContent.split('\n');
 
         for (const line of lines) {
-            if (currentY < margin + lineHeight) { 
+            if (currentY < pageMargins + lineHeight) { 
                 page = pdfDoc.addPage(PageSizes.A4);
-                currentY = height - margin;
-                 page.drawText(`AI Analysis Report: ${sanitizedTitleFileName} (cont.)`, {
-                    x: margin, y: currentY, font: customBoldFont, size: 12, color: rgb(0.2,0.2,0.2)
+                currentY = height - pageMargins;
+                page.drawText(`AI Analysis Report: ${sanitizedTitleFileName} (cont.)`, {
+                    x: pageMargins, y: currentY, font: customBoldFont, size: 12, color: rgb(0.2,0.2,0.2)
                 });
                 currentY -= 20;
             }
 
             if (line.trim() === '---' || line.trim() === '***' || line.trim() === '___') {
                 page.drawLine({
-                    start: { x: margin, y: currentY - (lineHeight / 3) },
-                    end: { x: width - margin, y: currentY - (lineHeight / 3) },
+                    start: { x: pageMargins, y: currentY - (lineHeight / 3) },
+                    end: { x: width - pageMargins, y: currentY - (lineHeight / 3) },
                     thickness: 1,
                     color: rgb(0.7, 0.7, 0.7),
                 });
@@ -226,9 +232,9 @@ export async function generatePdfFromMarkdownAndSend(
                  currentY = await drawMarkdownWrappedText(
                     page,
                     line,
-                    margin,
-                    currentY,
-                    width - 2 * margin,
+                    pageMargins, // x
+                    currentY,    // y
+                    width - (2 * pageMargins), // maxWidth
                     lineHeight,
                     customFont, 
                     customBoldFont,
@@ -239,15 +245,15 @@ export async function generatePdfFromMarkdownAndSend(
         }
 
         const pdfBytes = await pdfDoc.save();
-        debugLogger.log(`[Markdown to PDF Action] PDF generated from Markdown. Size: ${pdfBytes.byteLength} bytes.`);
+        debugLogger.log(`[Markdown to PDF Action] PDF generated. Size: ${pdfBytes.byteLength} bytes.`);
 
         const pdfFileName = `AI_Report_${originalFileName.replace(/[^\w\d_.-]/g, "_").replace(/\.\w+$/, "")}.pdf`;
         
         const sendResult = await sendTelegramDocument(chatId, new Blob([pdfBytes], { type: 'application/pdf' }), pdfFileName);
 
         if (sendResult.success) {
-            logger.info(`[Markdown to PDF Action] PDF "${pdfFileName}" sent successfully to chat ID ${chatId}.`);
-            return { success: true, message: `PDF report "${pdfFileName}" based on AI analysis has been sent to your Telegram chat.` };
+            logger.info(`[Markdown to PDF Action] PDF "${pdfFileName}" sent to chat ID ${chatId}.`);
+            return { success: true, message: `PDF report "${pdfFileName}" sent to Telegram.` };
         } else {
             logger.error(`[Markdown to PDF Action] Failed to send PDF to Telegram for chat ID ${chatId}: ${sendResult.error}`);
             return { success: false, error: `Failed to send PDF to Telegram: ${sendResult.error}` };
@@ -256,6 +262,10 @@ export async function generatePdfFromMarkdownAndSend(
     } catch (error) {
         logger.error('[Markdown to PDF Action] Critical error during PDF generation or sending:', error);
         const errorMsg = error instanceof Error ? error.message : 'An unexpected server error occurred during PDF processing.';
+         // Check if the error is specifically the fontkit registration issue to provide a more specific message
+        if (error instanceof Error && error.message.toLowerCase().includes("registerfontkit is not a function")) {
+             return { success: false, error: "Critical PDF library setup error (fontkit). Please contact support." };
+        }
         return { success: false, error: errorMsg };
     }
 }

--- a/app/topdf/actions.ts
+++ b/app/topdf/actions.ts
@@ -4,44 +4,37 @@ import { sendTelegramDocument } from '@/app/actions';
 import { logger } from '@/lib/logger';
 import { debugLogger } from '@/lib/debugLogger';
 
-// Use require for pdf-lib to ensure stable access to static methods like registerFontkit
-// in Next.js server environments, especially when externalized.
-const { PDFDocument, StandardFonts, rgb, PageSizes, PDFFont } = require('pdf-lib');
+// Use require for pdf-lib to ensure stable access to static methods
+const pdfLib = require('pdf-lib');
+const { PDFDocument, StandardFonts, rgb, PageSizes } = pdfLib;
+// PDFFont type can be tricky with require; using 'any' for broader compatibility in this context.
+type PDFFont = any; 
+
 import fs from 'fs';
 import path from 'path';
-import fontkit from '@pdf-lib/fontkit';
+import fontkitInstance from '@pdf-lib/fontkit'; // Renamed to avoid potential naming conflicts
 
-// Register fontkit with the PDFDocument class obtained via require.
-// This must be done *after* pdf-lib is loaded via require.
-try {
-    PDFDocument.registerFontkit(fontkit);
-    debugLogger.log("[PDF Gen] fontkit registered with PDFDocument successfully (via require).");
-} catch (e: any) {
-    logger.error("[PDF Gen] CRITICAL: Failed to register fontkit with PDFDocument.", e);
-    // This is a critical failure, re-throw or handle appropriately if actions can't proceed.
-    // For now, it will likely cause failures downstream in embedFont.
-}
+// Module-level flag to ensure registration happens only once per server instance lifetime
+let fontkitRegistered = false;
 
-
-// Helper function definitions remain the same.
 async function drawMarkdownWrappedText(
-    page: any, // Should be PDFPage from pdf-lib but require might make types tricky without more setup
+    page: any, // Should be PDFPage from pdf-lib
     text: string,
     x: number,
     y: number,
     maxWidth: number,
     lineHeight: number,
-    baseFont: any, // PDFFont
-    boldFont: any, // PDFFont
+    baseFont: PDFFont, 
+    boldFont: PDFFont, 
     baseFontSize: number,
     color = rgb(0, 0, 0)
 ): Promise<number> {
     const lines = text.split('\n');
     let currentY = y;
-    const margin = 50; // Assuming this is page margin, already accounted for in x, y, maxWidth
+    const margin = 50; 
 
     for (const line of lines) {
-        if (currentY < margin) { // Check against bottom margin
+        if (currentY < margin) {
             debugLogger.warn("[PDF Gen] Content overflowing page, stopping text draw for this line.");
             break;
         }
@@ -65,11 +58,11 @@ async function drawMarkdownWrappedText(
             lineToDraw = line.substring(2);
         } else if (line.startsWith('* ') || line.startsWith('- ')) {
             lineToDraw = `• ${line.substring(2)}`;
-            currentX += 10; // Indent for list items
-        } else if (line.match(/^(\s*)\* /) || line.match(/^(\s*)- /)) { // Nested lists
+            currentX += 10;
+        } else if (line.match(/^(\s*)\* /) || line.match(/^(\s*)- /)) {
             const indentMatch = line.match(/^(\s*)/);
             const indent = indentMatch ? indentMatch[0].length : 0;
-            currentX += 10 + (indent * 5); // Base indent + nested indent
+            currentX += 10 + (indent * 5);
             lineToDraw = `• ${line.replace(/^(\s*)[\*-] /, '')}`;
         }
 
@@ -78,22 +71,18 @@ async function drawMarkdownWrappedText(
         for (const word of words) {
             const testSegment = currentLineSegment + (currentLineSegment ? ' ' : '') + word;
             try {
-                // widthOfTextAtSize might not be available if font is not correctly typed PDFFont
                 const textWidth = effectiveFont.widthOfTextAtSize(testSegment, effectiveSize);
                 if (currentX + textWidth > maxWidth && currentLineSegment) {
                     page.drawText(currentLineSegment, { x: currentX, y: currentY, font: effectiveFont, size: effectiveSize, color });
-                    currentY -= lineHeight * (effectiveSize / baseFontSize); // Adjust line height based on font size changes
+                    currentY -= lineHeight * (effectiveSize / baseFontSize);
                     currentLineSegment = word;
-                    if (currentY < margin) break; // Check again after moving Y
+                    if (currentY < margin) break;
                 } else {
                     currentLineSegment = testSegment;
                 }
             } catch (e: any) {
                 logger.warn(`[PDF Gen] Skipping character/word due to font error: "${word}" in segment "${testSegment}". Error: ${e.message}`);
-                // Attempt to replace problematic characters if any, or just skip.
-                // This usually happens if a character is not in the font's glyph set.
-                // For DejaVuSans, this should be rare for Cyrillic, but good to have fallback.
-                currentLineSegment = currentLineSegment.replace(/[^\x00-\u04FF\u0500-\u052F\s\d\p{P}]/gu, "?"); // Keep ASCII, Cyrillic, spaces, digits, punctuation
+                currentLineSegment = currentLineSegment.replace(/[^\x00-\u04FF\u0500-\u052F\s\d\p{P}]/gu, "?"); 
             }
         }
         if (currentLineSegment && currentY >= margin) {
@@ -103,13 +92,13 @@ async function drawMarkdownWrappedText(
                 logger.warn(`[PDF Gen] Skipping final line segment due to font error: "${currentLineSegment}". Error: ${e.message}`);
                 page.drawText(currentLineSegment.replace(/[^\x00-\u04FF\u0500-\u052F\s\d\p{P}]/gu, "?"), { x: currentX, y: currentY, font: effectiveFont, size: effectiveSize, color });
             }
-            currentY -= lineHeight * (effectiveSize / baseFontSize); // Adjust line height
+            currentY -= lineHeight * (effectiveSize / baseFontSize);
         }
         if (currentY < margin) break;
     }
     return currentY;
 }
-const pageMargins = 50; // Consistent margin definition
+const pageMargins = 50;
 
 export async function generatePdfFromMarkdownAndSend(
     markdownContent: string,
@@ -126,7 +115,26 @@ export async function generatePdfFromMarkdownAndSend(
     }
 
     try {
-        const pdfDoc = await PDFDocument.create();
+        // Attempt to register fontkit if not already done in this server instance's lifetime
+        if (!fontkitRegistered) {
+            debugLogger.log("[PDF Gen] Attempting to register fontkit with PDFDocument...");
+            try {
+                // Explicitly use the PDFDocument class obtained from the 'pdfLib' require object
+                pdfLib.PDFDocument.registerFontkit(fontkitInstance);
+                fontkitRegistered = true; // Mark as registered for this server instance
+                debugLogger.log("[PDF Gen] fontkit registered with PDFDocument successfully.");
+            } catch (e: any) {
+                logger.error("[PDF Gen] CRITICAL: Failed to register fontkit with PDFDocument.", e);
+                return { 
+                    success: false, 
+                    error: `Critical PDF library setup error (fontkit registration failed: ${e.message}). Please verify server environment or contact support.` 
+                };
+            }
+        } else {
+            debugLogger.log("[PDF Gen] fontkit already registered in this server instance.");
+        }
+
+        const pdfDoc = await PDFDocument.create(); // Uses the destructured PDFDocument
 
         const regularFontName = 'DejaVuSans.ttf';
         const boldFontName = 'DejaVuSans-Bold.ttf';
@@ -140,52 +148,53 @@ export async function generatePdfFromMarkdownAndSend(
             logger.error(`[PDF Gen] CRITICAL: Fonts directory NOT FOUND at specified path: ${fontsDir}.`);
             return { success: false, error: `Core fonts directory missing on server. Expected at: ${fontsDir}.` };
         } else {
-            debugLogger.log(`[PDF Gen] Fonts directory found at: ${fontsDir}. Checking contents...`);
+            debugLogger.log(`[PDF Gen] Fonts directory found at: ${fontsDir}. Attempting to list contents...`);
             try {
                 const filesInFontsDir = fs.readdirSync(fontsDir);
-                debugLogger.log(`[PDF Gen] Files in ${fontsDir}: [${filesInFontsDir.join(', ')}]`);
+                debugLogger.log(`[PDF Gen] Files successfully listed in ${fontsDir}: [${filesInFontsDir.join(', ')}]`);
                 if (filesInFontsDir.length === 0) {
                     logger.warn(`[PDF Gen] Warning: Fonts directory ${fontsDir} is empty.`);
                 }
             } catch (readDirError: any) {
-                logger.warn(`[PDF Gen] Warning: Could not read contents of fonts directory ${fontsDir}. Error: ${readDirError.message}`);
+                logger.warn(`[PDF Gen] Warning: Could not read contents of fonts directory ${fontsDir}, though the directory itself exists. Error: ${readDirError.message}`);
             }
         }
         
         const regularFontPath = path.join(fontsDir, regularFontName);
-        debugLogger.log(`[PDF Gen] Attempting to load regular font from: ${regularFontPath}`);
+        debugLogger.log(`[PDF Gen] Attempting to load regular font from absolute path: ${regularFontPath}`);
+        
         if (!fs.existsSync(regularFontPath)) {
-            logger.error(`[PDF Gen] CRITICAL: Regular font file '${regularFontName}' NOT FOUND at: ${regularFontPath}.`);
-            return { success: false, error: `Font file (${regularFontName}) missing. Path: ${regularFontPath}` };
+            logger.error(`[PDF Gen] CRITICAL: Regular font file '${regularFontName}' NOT FOUND at specified path: ${regularFontPath}.`);
+            return { success: false, error: `Core font file (${regularFontName}) for PDF generation is missing on the server. Path checked: ${regularFontPath}` };
         }
         
         let regularFontBytes;
         try {
             regularFontBytes = fs.readFileSync(regularFontPath);
-            debugLogger.log(`[PDF Gen] Read regular font '${regularFontName}'. Size: ${regularFontBytes.byteLength} bytes.`);
+            debugLogger.log(`[PDF Gen] Successfully read regular font file '${regularFontName}'. Size: ${regularFontBytes.byteLength} bytes.`);
         } catch (fontError: any) {
-            logger.error(`[PDF Gen] CRITICAL: Failed to READ regular font '${regularFontName}' from ${regularFontPath}. Error: ${fontError.message}`);
-            return { success: false, error: `Failed to read font file (${regularFontName}). Path: ${regularFontPath}` };
+            logger.error(`[PDF Gen] CRITICAL: Failed to READ regular font file '${regularFontName}' from ${regularFontPath}. Error: ${fontError.message}`);
+            return { success: false, error: `Failed to read core font file (${regularFontName}). Ensure it's not corrupted and server has permissions. Path: ${regularFontPath}` };
         }
         
         const customFont = await pdfDoc.embedFont(regularFontBytes); 
-        debugLogger.log(`[PDF Gen] Custom font '${regularFontName}' embedded.`);
+        debugLogger.log(`[PDF Gen] Custom font '${regularFontName}' embedded successfully into PDF.`);
         
-        let customBoldFont: any; // PDFFont
+        let customBoldFont: PDFFont; 
         const boldFontPath = path.join(fontsDir, boldFontName);
-        debugLogger.log(`[PDF Gen] Attempting to load bold font from: ${boldFontPath}`);
+        debugLogger.log(`[PDF Gen] Attempting to load bold font from absolute path: ${boldFontPath}`);
 
         if (!fs.existsSync(boldFontPath)) {
-            logger.warn(`[PDF Gen] Warning: Bold font '${boldFontName}' NOT FOUND at ${boldFontPath}. Using regular font for bold.`);
+            logger.warn(`[PDF Gen] Warning: Bold font file '${boldFontName}' NOT FOUND at ${boldFontPath}. Falling back to regular font for bold text.`);
             customBoldFont = customFont; 
         } else {
             try {
                 const boldFontBytes = fs.readFileSync(boldFontPath);
-                debugLogger.log(`[PDF Gen] Read bold font '${boldFontName}'. Size: ${boldFontBytes.byteLength} bytes.`);
+                debugLogger.log(`[PDF Gen] Successfully read bold font file '${boldFontName}'. Size: ${boldFontBytes.byteLength} bytes.`);
                 customBoldFont = await pdfDoc.embedFont(boldFontBytes); 
-                debugLogger.log(`[PDF Gen] Custom bold font '${boldFontName}' embedded.`);
+                debugLogger.log(`[PDF Gen] Custom bold font '${boldFontName}' embedded successfully into PDF.`);
             } catch (fontError: any) {
-                logger.warn(`[PDF Gen] Warning: Failed to READ bold font '${boldFontName}' from ${boldFontPath}. Using regular for bold. Error: ${fontError.message}`);
+                logger.warn(`[PDF Gen] Warning: Failed to READ bold font file '${boldFontName}' from ${boldFontPath}. Using regular font for bold text. Error: ${fontError.message}`);
                 customBoldFont = customFont; 
             }
         }
@@ -214,7 +223,7 @@ export async function generatePdfFromMarkdownAndSend(
             if (currentY < pageMargins + lineHeight) { 
                 page = pdfDoc.addPage(PageSizes.A4);
                 currentY = height - pageMargins;
-                page.drawText(`AI Analysis Report: ${sanitizedTitleFileName} (cont.)`, {
+                 page.drawText(`AI Analysis Report: ${sanitizedTitleFileName} (cont.)`, {
                     x: pageMargins, y: currentY, font: customBoldFont, size: 12, color: rgb(0.2,0.2,0.2)
                 });
                 currentY -= 20;
@@ -232,9 +241,9 @@ export async function generatePdfFromMarkdownAndSend(
                  currentY = await drawMarkdownWrappedText(
                     page,
                     line,
-                    pageMargins, // x
-                    currentY,    // y
-                    width - (2 * pageMargins), // maxWidth
+                    pageMargins,
+                    currentY,
+                    width - 2 * pageMargins,
                     lineHeight,
                     customFont, 
                     customBoldFont,
@@ -245,27 +254,31 @@ export async function generatePdfFromMarkdownAndSend(
         }
 
         const pdfBytes = await pdfDoc.save();
-        debugLogger.log(`[Markdown to PDF Action] PDF generated. Size: ${pdfBytes.byteLength} bytes.`);
+        debugLogger.log(`[Markdown to PDF Action] PDF generated from Markdown. Size: ${pdfBytes.byteLength} bytes.`);
 
         const pdfFileName = `AI_Report_${originalFileName.replace(/[^\w\d_.-]/g, "_").replace(/\.\w+$/, "")}.pdf`;
         
         const sendResult = await sendTelegramDocument(chatId, new Blob([pdfBytes], { type: 'application/pdf' }), pdfFileName);
 
         if (sendResult.success) {
-            logger.info(`[Markdown to PDF Action] PDF "${pdfFileName}" sent to chat ID ${chatId}.`);
-            return { success: true, message: `PDF report "${pdfFileName}" sent to Telegram.` };
+            logger.info(`[Markdown to PDF Action] PDF "${pdfFileName}" sent successfully to chat ID ${chatId}.`);
+            return { success: true, message: `PDF report "${pdfFileName}" based on AI analysis has been sent to your Telegram chat.` };
         } else {
             logger.error(`[Markdown to PDF Action] Failed to send PDF to Telegram for chat ID ${chatId}: ${sendResult.error}`);
             return { success: false, error: `Failed to send PDF to Telegram: ${sendResult.error}` };
         }
 
-    } catch (error) {
+    } catch (error: any) {
         logger.error('[Markdown to PDF Action] Critical error during PDF generation or sending:', error);
-        const errorMsg = error instanceof Error ? error.message : 'An unexpected server error occurred during PDF processing.';
-         // Check if the error is specifically the fontkit registration issue to provide a more specific message
-        if (error instanceof Error && error.message.toLowerCase().includes("registerfontkit is not a function")) {
-             return { success: false, error: "Critical PDF library setup error (fontkit). Please contact support." };
+        
+        if (error.constructor && error.constructor.name === 'FontkitNotRegisteredError') {
+             return { 
+                 success: false, 
+                 error: `PDF library error: Font system (fontkit) not available when embedding font. Original message: ${error.message}`
+             };
         }
+        
+        const errorMsg = error instanceof Error ? error.message : 'An unexpected server error occurred during PDF processing.';
         return { success: false, error: errorMsg };
     }
 }

--- a/app/topdf/actions.ts
+++ b/app/topdf/actions.ts
@@ -3,6 +3,8 @@
 import { sendTelegramDocument } from '@/app/actions';
 import { logger } from '@/lib/logger';
 import { debugLogger } from '@/lib/debugLogger';
+import path from 'path'; // Added import
+import fs from 'fs';   // Added import
 
 // Use require for pdf-lib and fontkit
 const pdfLibModule = require('pdf-lib');
@@ -177,7 +179,6 @@ export async function generatePdfFromMarkdownAndSend(
                 return { success: false, error: "Critical PDF library load error (fontkit instance is invalid)." };
             }
 
-
             let registrationSuccess = false;
             // Attempt 1: Standard static call (if logs were misleading or version changed)
             if (typeof PDFD_Class.registerFontkit === 'function') {
@@ -212,7 +213,6 @@ export async function generatePdfFromMarkdownAndSend(
                      debugLogger.warn(`[PDF Gen] Failed pdfLibModule.registerFontkit: ${e.message}`);
                 }
             }
-
 
             if (registrationSuccess) {
                 fontkitRegistered = true;


### PR DESCRIPTION
Fix: Восстановлен `require` для `pdf-lib` для стабильной регистрации `fontkit`

Анализ проблемы:
Ошибка `TypeError: c.PDFDocument.registerFontkit is not a function` указывает на то, что статический метод `registerFontkit` не найден на классе `PDFDocument` в момент его вызова. Это происходит в серверном действии Next.js при попытке сгенерировать PDF с использованием кастомных шрифтов (DejaVuSans для кириллицы), которые требуют регистрации `fontkit` в `pdf-lib`.

Проблема, скорее всего, связана с тем, как `pdf-lib` импортируется и обрабатывается системой сборки Next.js, даже если он помечен как внешний модуль (`externals` в `next.config.mjs`). Использование ESM-импорта (`import { PDFDocument } from 'pdf-lib';`) в сочетании с особенностями сборки серверных компонентов/действий может приводить к тому, что импортируемый объект `PDFDocument` не содержит всех статических методов.

История Pull Request (коммит `0ca727c`) показывает, что ранее эта проблема была решена путем принудительного использования CommonJS-импорта (`const { PDFDocument } = require('pdf-lib');`). Текущий код в `actions.ts` использует ESM-импорт, что, вероятно, и привело к возобновлению ошибки.

Решение:
1.  В файле `/app/topdf/actions.ts` изменен способ импорта `pdf-lib`. Вместо ESM-импорта теперь используется `require('pdf-lib')`.
2.  Вызов `PDFDocument.registerFontkit(fontkit)` размещен сразу после `require('pdf-lib')`, чтобы гарантировать, что `fontkit` регистрируется на корректно инициализированном классе `PDFDocument`.
3.  Конфигурация `next.config.mjs` (с `externals` для `pdf-lib` и `@pdf-lib/fontkit`) и логика загрузки файлов шрифтов остаются без изменений, так как они корректны. `require` будет разрешать `pdf-lib` из `node_modules` во время выполнения благодаря `externals`.

Это изменение должно обеспечить более стабильное разрешение модуля `pdf-lib` в серверном окружении Next.js и устранить ошибку с `registerFontkit`.

**Файлы (1):**
- `app/topdf/actions.ts`