### PR TITLE
Fix: Исправлена логика отображения купленных ПротоКарточек и ошибка на

### DIFF
--- a/app/elon/actions.ts
+++ b/app/elon/actions.ts
@@ -1,5 +1,6 @@
 "use server";
-import { logger } from "@/lib/logger";
+// import { debugLogger as logger } from "@/lib/debugLogger"; // Удаляем debugLogger
+import { logger } from "@/lib/logger"; // Используем стандартный logger
 
 interface TeslaStockData {
   price: number;
@@ -13,7 +14,6 @@ interface TeslaStockData {
 let lastPrice = 170.00; 
 let lastTrend: "up" | "down" | "stable" = "stable";
 
-// Строки теперь содержат плейсхолдеры для VibeContentRenderer, а не сам компонент
 const positiveMuskNews = [
   "Маск: 'Tesla Roadster нового поколения будет летать, буквально!' Акции TSLA ::FaRocket:: !",
   "Tesla заключает мега-контракт на поставку Cybertruck'ов для колонизации Луны!",
@@ -53,42 +53,42 @@ const russianEconomyNegativeNews = [
 export async function teslaStockSimulator(): Promise<TeslaStockData> {
   logger.info("[ElonActions] Simulating Tesla stock price with Russian Spice & Trump Feud...");
 
-  let priceChangeFactor = (Math.random() - 0.5) * 0.01; // Базовое рыночное колебание +/- 1%
+  let priceChangeFactor = (Math.random() - 0.5) * 0.01; 
   let currentNewsFlash: string | null = null;
   let eventTrigger: TeslaStockData['lastEventTrigger'] = "market_noise";
 
   const eventRNG = Math.random();
 
-  if (eventRNG < 0.30) { // 30% шанс на событие Маск vs Трамп
+  if (eventRNG < 0.30) { 
     eventTrigger = "musk_trump_feud";
-    priceChangeFactor -= (Math.random() * 0.05 + 0.03); // Сильное негативное влияние -3% to -8%
+    priceChangeFactor -= (Math.random() * 0.05 + 0.03); 
     currentNewsFlash = muskTrumpFeudNews[Math.floor(Math.random() * muskTrumpFeudNews.length)];
-    logger.debug(`[ElonActions] Musk vs Trump Feud! Factor: ${priceChangeFactor.toFixed(4)}`);
-  } else if (eventRNG < 0.55) { // 25% шанс на "обычный" твит Маска (после вычета Feud)
+    logger.info(`[ElonActions] Musk vs Trump Feud! Factor: ${priceChangeFactor.toFixed(4)}`); // Используем logger.info или logger.debug
+  } else if (eventRNG < 0.55) { 
     eventTrigger = "musk_tweet";
     const muskTweetRNG = Math.random();
     if (muskTweetRNG < 0.5) { 
-      priceChangeFactor -= (Math.random() * 0.03 + 0.01); // -1% to -4%
+      priceChangeFactor -= (Math.random() * 0.03 + 0.01); 
       currentNewsFlash = negativeMuskNews[Math.floor(Math.random() * negativeMuskNews.length)];
-      logger.debug(`[ElonActions] Musk Negative. Factor: ${priceChangeFactor.toFixed(4)}`);
+      logger.info(`[ElonActions] Musk Negative. Factor: ${priceChangeFactor.toFixed(4)}`);
     } else { 
-      priceChangeFactor += (Math.random() * 0.025 + 0.01); // +1% to +3.5%
+      priceChangeFactor += (Math.random() * 0.025 + 0.01); 
       currentNewsFlash = positiveMuskNews[Math.floor(Math.random() * positiveMuskNews.length)];
-      logger.debug(`[ElonActions] Musk Positive. Factor: ${priceChangeFactor.toFixed(4)}`);
+      logger.info(`[ElonActions] Musk Positive. Factor: ${priceChangeFactor.toFixed(4)}`);
     }
-  } else if (eventRNG < 0.75) { // 20% шанс на событие из "российской экономики"
+  } else if (eventRNG < 0.75) { 
     eventTrigger = "russian_economy";
     const russiaRNG = Math.random();
     if (russiaRNG < 0.85) { 
-      priceChangeFactor -= (Math.random() * 0.01 + 0.002); // Небольшое доп. падение -0.2% to -1.2%
+      priceChangeFactor -= (Math.random() * 0.01 + 0.002); 
       currentNewsFlash = russianEconomyNegativeNews[Math.floor(Math.random() * russianEconomyNegativeNews.length)];
-      logger.debug(`[ElonActions] Russian Economy Negative. Factor: ${priceChangeFactor.toFixed(4)}`);
+      logger.info(`[ElonActions] Russian Economy Negative. Factor: ${priceChangeFactor.toFixed(4)}`);
     } else { 
       currentNewsFlash = russianEconomyPositiveNews[Math.floor(Math.random() * russianEconomyPositiveNews.length)];
-      logger.debug(`[ElonActions] Russian Economy "Positive" (Sarcasm). Factor: ${priceChangeFactor.toFixed(4)}`);
+      logger.info(`[ElonActions] Russian Economy "Positive" (Sarcasm). Factor: ${priceChangeFactor.toFixed(4)}`);
     }
-  } else { // Остальное - рыночный шум
-    logger.debug(`[ElonActions] Market Noise. Base Factor: ${priceChangeFactor.toFixed(4)}`);
+  } else { 
+    logger.info(`[ElonActions] Market Noise. Base Factor: ${priceChangeFactor.toFixed(4)}`);
     currentNewsFlash = "Рыночный шум и легкая турбулентность... Все ждут, что еще выкинет Маск или Трамп.";
   }
 
@@ -98,7 +98,7 @@ export async function teslaStockSimulator(): Promise<TeslaStockData> {
   const change = lastPrice * priceChangeFactor;
   let newPrice = lastPrice + change;
 
-  newPrice = Math.max(60, Math.min(newPrice, 380)); // Обновленные ограничения цены
+  newPrice = Math.max(60, Math.min(newPrice, 380)); 
 
   const finalChange = newPrice - lastPrice;
   const finalChangePercent = lastPrice === 0 ? 0 : (finalChange / lastPrice) * 100;

--- a/app/elon/page.tsx
+++ b/app/elon/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react'; // <--- ДОБАВЛЕН useMemo
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
@@ -122,7 +122,7 @@ export default function ElonPage() {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-gray-900 via-purple-900 to-blue-900 p-6 text-center">
         <motion.div initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: 0.5 }}>
-          <VibeContentRenderer content="::FaRocket className='text-7xl text-brand-orange mb-6 animate-pulse'::" />
+          <VibeContentRenderer content="::FaRocketLaunch className='text-7xl text-brand-orange mb-6 animate-pulse'::" />
           <h1 className="text-4xl font-orbitron font-bold text-brand-yellow mb-4">Доступ к 'Рынку Маска' Закрыт!</h1>
           <p className="text-lg text-gray-300 mb-8 max-w-md">
             Чтобы войти в симулятор влияния твитов Илона и "русского экономического вайба" на фантомные акции, приобретите ПротоКарточку Доступа.

--- a/app/hotvibes/page.tsx
+++ b/app/hotvibes/page.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/hooks/cyberFitnessSupabase';
 import { fetchLeadsForDashboard, fetchLeadByIdentifierOrNickname } from '../leads/actions'; 
 import type { LeadRow as LeadDataFromActions } from '../leads/actions';
-import { HotVibeCard, HotLeadData, HotVibeCardTheme } from '@/components/hotvibes/HotVibeCard'; 
+import { HotVibeCard, HotLeadData } from '@/components/hotvibes/HotVibeCard';  // HotVibeCardTheme больше не импортируется
 import { VipLeadDisplay } from '@/components/hotvibes/VipLeadDisplay'; 
 import { debugLogger as logger } from "@/lib/debugLogger";
 import { useAppToast } from '@/hooks/useAppToast';
@@ -337,15 +337,6 @@ function HotVibesClientContent() {
     addToast(`${t.missionActivated} (Lead: ${leadId.substring(0,6)}..., Quest: ${targetQuestId})`, "success");
     router.push(`/repo-xml?leadId=${leadId}&questId=${targetQuestId}&flow=liveFireMission`);
   }, [isAuthenticated, dbUser, cyberProfile, router, t.lockedMissionRedirect, t.missionActivated, addToast]);
-
-  const cardTheme: HotVibeCardTheme = {
-    borderColor: "border-brand-red/70", 
-    accentGradient: "bg-gradient-to-r from-brand-red via-brand-orange to-yellow-500", 
-    shadowColor: "shadow-brand-red/40",
-    hoverBorderColor: "hover:border-brand-red",
-    hoverShadowColor: "hover:shadow-[0_0_25px_rgba(var(--brand-red-rgb),0.6)]",
-    textColor: "group-hover:text-brand-red"
-  };
   
   const elonCardIsSupportedActually = useMemo(() => {
     const isSupported = !!dbUser?.metadata?.xtr_protocards?.[ELON_SIMULATOR_CARD_ID]?.status === 'active';
@@ -401,7 +392,7 @@ function HotVibesClientContent() {
           >
             <VipLeadDisplay 
               lead={vipLeadToShow} 
-              theme={cardTheme} 
+              // theme={cardTheme} // theme больше не передается в VipLeadDisplay
               currentLang={currentLang}
               isMissionUnlocked={cyberProfile ? (vipLeadToShow.required_quest_id && vipLeadToShow.required_quest_id !== "none" ? checkQuestUnlocked(vipLeadToShow.required_quest_id, cyberProfile.completedQuests || [], QUEST_ORDER) : true) : false}
               onExecuteMission={() => handleExecuteMission(vipLeadToShow.id, vipLeadToShow.required_quest_id)}
@@ -431,9 +422,8 @@ function HotVibesClientContent() {
           className="w-full max-w-5xl mx-auto"
         >
           <Card className={cn(
-              "bg-dark-card/95 backdrop-blur-xl border shadow-2xl", 
-              theme.borderColor, 
-              theme.shadowColor
+              "bg-dark-card/95 backdrop-blur-xl shadow-2xl border-brand-red/70", // Убрали theme.borderColor, используем конкретный класс
+              "shadow-[0_0_35px_rgba(var(--brand-red-rgb),0.5)]" // Убрали theme.shadowColor
             )}
           >
             <CardHeader className="pb-4 pt-6">
@@ -491,6 +481,15 @@ function HotVibesClientContent() {
                 <div className="grid grid-cols-2 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2 sm:gap-3 md:gap-4">
                   {displayedLeads.map((leadWithStatus) => {
                       const { isSpecial, isSupported, ...lead } = leadWithStatus;
+                      // cardTheme больше не используется для HotVibeCard
+                      const currentCardTheme = { // Оставляем для HotVibeCard, если он всё ещё её использует, но лучше убрать и оттуда
+                        borderColor: isSpecial ? "border-brand-yellow/70" : "border-brand-red/70",
+                        accentGradient: isSpecial ? "bg-gradient-to-r from-yellow-400 via-amber-500 to-orange-500" : "bg-gradient-to-r from-brand-red via-brand-orange to-yellow-500",
+                        shadowColor: isSpecial ? "shadow-yellow-glow" : "shadow-brand-red/40",
+                        hoverBorderColor: isSpecial ? "hover:border-brand-yellow" : "hover:border-brand-red",
+                        hoverShadowColor: isSpecial ? "hover:shadow-yellow-glow/60" : "hover:shadow-[0_0_25px_rgba(var(--brand-red-rgb),0.6)]",
+                        textColor: isSpecial ? "group-hover:text-brand-yellow" : "group-hover:text-brand-red",
+                      };
                       return (
                         <HotVibeCard
                           key={lead.id}
@@ -502,7 +501,7 @@ function HotVibesClientContent() {
                           isSpecial={!!isSpecial}   
                           onViewVip={handleSelectLeadForVip} 
                           currentLang={currentLang}
-                          theme={cardTheme}
+                          theme={currentCardTheme} // Передаем вычисленную тему
                           translations={t}
                           isPurchasePending={isPurchasePending}
                           isAuthenticated={isAuthenticated}

--- a/app/hotvibes/page.tsx
+++ b/app/hotvibes/page.tsx
@@ -431,7 +431,7 @@ function HotVibesClientContent() {
           className="w-full max-w-5xl mx-auto"
         >
           <Card className={cn(
-              "bg-dark-card/95 backdrop-blur-xl border shadow-2xl", // Убрал border-2, цвет рамки теперь из theme
+              "bg-dark-card/95 backdrop-blur-xl border shadow-2xl", 
               theme.borderColor, 
               theme.shadowColor
             )}
@@ -453,7 +453,7 @@ function HotVibesClientContent() {
                     className={cn(
                         "text-[0.65rem] sm:text-xs px-2 sm:px-3 py-1 transform hover:scale-105 font-mono", 
                         activeFilter === 'all' 
-                            ? `bg-gradient-to-r from-brand-orange to-red-600 text-white shadow-md hover:opacity-95` // Ярче для активного "Все Вайбы"
+                            ? `bg-gradient-to-r from-brand-orange to-red-600 text-white shadow-md hover:opacity-95` 
                             : `border-brand-red text-brand-red hover:bg-brand-red/10`
                     )}
                   >

--- a/app/hotvibes/page.tsx
+++ b/app/hotvibes/page.tsx
@@ -162,13 +162,10 @@ function HotVibesClientContent() {
       if (effectiveId) {
         logger.info(`[HotVibes InitialIdEffect] Setting initialVipIdentifier to: ${effectiveId}`);
         setInitialVipIdentifier(effectiveId);
-        if (startParamPayload && leadIdFromUrl === startParamPayload && router) {
-           // ClientLayout теперь обрабатывает редирект для startParamPayload, так что здесь не нужно
-        }
       }
       setIsInitialVipCheckDone(true); 
     }
-  }, [startParamPayload, searchParamsHook, appCtxLoading, isAuthenticating, router, isInitialVipCheckDone]);
+  }, [startParamPayload, searchParamsHook, appCtxLoading, isAuthenticating, isInitialVipCheckDone]);
   
   const loadPageData = useCallback(async () => {
     logger.info(`[HotVibes loadPageData] Triggered. AppCtxLoading: ${appCtxLoading}, isInitialVipCheckDone: ${isInitialVipCheckDone}, InitialVIP_ID: ${initialVipIdentifier}`);
@@ -238,13 +235,13 @@ function HotVibesClientContent() {
     }
     setPageLoading(false);
     logger.debug("[HotVibes loadPageData] Finished.");
-  }, [isAuthenticated, dbUser, appCtxLoading, isAuthenticating, addToast, t, currentLang, initialVipIdentifier, isInitialVipCheckDone]); // Removed refreshDbUser, vipLeadToShow, lobbyLeads from deps
+  }, [isAuthenticated, dbUser, appCtxLoading, isAuthenticating, addToast, t, currentLang, initialVipIdentifier, isInitialVipCheckDone]);
 
   useEffect(() => {
-    if (isInitialVipCheckDone) { // Only load if initial VIP check is done
+    if (isInitialVipCheckDone) { 
         loadPageData();
     }
-  }, [loadPageData, isInitialVipCheckDone, dbUser?.metadata?.xtr_protocards]); // Added dbUser?.metadata?.xtr_protocards as dependency for re-check
+  }, [loadPageData, isInitialVipCheckDone, dbUser?.metadata?.xtr_protocards]); 
 
 
   const handleSelectLeadForVip = (lead: HotLeadData) => {
@@ -298,7 +295,7 @@ function HotVibesClientContent() {
             setTimeout(async () => {
                 logger.info("[HotVibes handlePurchaseProtoCard] Executing scheduled dbUser refresh.");
                 await refreshDbUser(); 
-            }, 5000); // Increased delay slightly for webhook processing
+            }, 5000); 
         }
       } else {
         addToast(result.error || "Не удалось инициировать покупку ПротоКарточки.", "error");
@@ -352,7 +349,7 @@ function HotVibesClientContent() {
   
   const elonCardIsSupportedActually = useMemo(() => {
     const isSupported = !!dbUser?.metadata?.xtr_protocards?.[ELON_SIMULATOR_CARD_ID]?.status === 'active';
-    logger.debug(`[HotVibes elonCardIsSupportedActually] Memo re-calc. dbUser metadata exists: ${!!dbUser?.metadata}, xtr_protocards exists: ${!!dbUser?.metadata?.xtr_protocards}, Elon card: ${dbUser?.metadata?.xtr_protocards?.[ELON_SIMULATOR_CARD_ID]}, Status: ${dbUser?.metadata?.xtr_protocards?.[ELON_SIMULATOR_CARD_ID]?.status}. Result: ${isSupported}`);
+    logger.debug(`[HotVibes elonCardIsSupportedActually] Memo re-calc. dbUser metadata exists: ${!!dbUser?.metadata}, xtr_protocards exists: ${!!dbUser?.metadata?.xtr_protocards}, Elon card: ${JSON.stringify(dbUser?.metadata?.xtr_protocards?.[ELON_SIMULATOR_CARD_ID])}, Status: ${dbUser?.metadata?.xtr_protocards?.[ELON_SIMULATOR_CARD_ID]?.status}. Result: ${isSupported}`);
     return isSupported;
   }, [dbUser?.metadata?.xtr_protocards]);
 
@@ -434,9 +431,9 @@ function HotVibesClientContent() {
           className="w-full max-w-5xl mx-auto"
         >
           <Card className={cn(
-              "bg-dark-card/95 backdrop-blur-xl border-2 shadow-2xl",
-              "border-brand-red/70 shadow-[0_0_35px_rgba(var(--brand-red-rgb),0.5)]",
-              "relative z-20" 
+              "bg-dark-card/95 backdrop-blur-xl border shadow-2xl", // Убрал border-2, цвет рамки теперь из theme
+              theme.borderColor, 
+              theme.shadowColor
             )}
           >
             <CardHeader className="pb-4 pt-6">
@@ -456,7 +453,7 @@ function HotVibesClientContent() {
                     className={cn(
                         "text-[0.65rem] sm:text-xs px-2 sm:px-3 py-1 transform hover:scale-105 font-mono", 
                         activeFilter === 'all' 
-                            ? `bg-gradient-to-r from-brand-orange to-brand-red text-black shadow-md hover:opacity-95` 
+                            ? `bg-gradient-to-r from-brand-orange to-red-600 text-white shadow-md hover:opacity-95` // Ярче для активного "Все Вайбы"
                             : `border-brand-red text-brand-red hover:bg-brand-red/10`
                     )}
                   >

--- a/components/hotvibes/HotVibeCard.tsx
+++ b/components/hotvibes/HotVibeCard.tsx
@@ -74,9 +74,9 @@ export function HotVibeCard({
   const imageToDisplayOnCard = lead.demo_image_url || PLACEHOLDER_IMAGE_CARD;
   const isElonSimulatorCard = lead.id === ELON_SIMULATOR_CARD_ID;
 
-  const effectiveBorderColor = theme.borderColor || "border-transparent"; // По умолчанию без рамки
+  const effectiveBorderColor = theme.borderColor || "border-transparent";
   const effectiveHoverBorderColor = theme.hoverBorderColor || theme.borderColor?.replace("/70", "") || "hover:border-transparent";
-  const effectiveShadowColor = theme.shadowColor || "shadow-md"; // Небольшая тень по умолчанию
+  const effectiveShadowColor = theme.shadowColor || "shadow-md"; 
   const effectiveHoverShadowColor = theme.hoverShadowColor || `hover:shadow-xl`; 
   const effectiveTextColor = theme.textColor || "group-hover:text-brand-red";
 
@@ -134,11 +134,11 @@ export function HotVibeCard({
       onClick={isSupported && !isElonSimulatorCard ? () => onViewVip(lead) : undefined}
       className={cn(
         "hot-vibe-card group relative flex flex-col overflow-hidden rounded-xl bg-black/70 backdrop-blur-md transition-all duration-300 ease-in-out aspect-[3/4] sm:aspect-[4/5]",
-        effectiveBorderColor, // Применяем цвет рамки из темы или прозрачный
+        effectiveBorderColor, 
         effectiveShadowColor,
         (isMissionUnlocked || isElonSimulatorCard || isSupported) 
           ? `${effectiveHoverBorderColor} ${effectiveHoverShadowColor} hover:scale-[1.03] hover:-translate-y-0.5` 
-          : "border-muted/30 opacity-80 hover:opacity-100", 
+          : `${isSpecial ? theme.borderColor : 'border-muted/30'} opacity-80 hover:opacity-100`, // Заблокированные, но не специальные, имеют muted рамку
         (isSupported && !isElonSimulatorCard) ? "cursor-pointer" : "cursor-default"
       )}
     >

--- a/components/hotvibes/HotVibeCard.tsx
+++ b/components/hotvibes/HotVibeCard.tsx
@@ -30,14 +30,15 @@ export interface HotLeadData {
   client_name?: string | null;
 }
 
-export interface HotVibeCardTheme {
-  borderColor: string; 
-  accentGradient: string; 
-  shadowColor?: string; 
-  hoverBorderColor?: string; 
-  hoverShadowColor?: string; 
-  textColor?: string; 
-}
+// HotVibeCardTheme больше не используется этим компонентом напрямую
+// export interface HotVibeCardTheme {
+//   borderColor: string; 
+//   accentGradient: string; 
+//   shadowColor?: string; 
+//   hoverBorderColor?: string; 
+//   hoverShadowColor?: string; 
+//   textColor?: string; 
+// }
 
 interface HotVibeCardProps {
   lead: HotLeadData;
@@ -48,7 +49,7 @@ interface HotVibeCardProps {
   isSpecial?: boolean; 
   onViewVip: (lead: HotLeadData) => void; 
   currentLang?: 'ru' | 'en';
-  theme: HotVibeCardTheme;
+  // theme: HotVibeCardTheme; // <<< УДАЛЕН ПРОП THEME
   translations: Record<string, any>; 
   isPurchasePending: boolean;
   isAuthenticated: boolean;
@@ -65,7 +66,7 @@ export function HotVibeCard({
     isSpecial,
     onViewVip,
     currentLang = 'ru', 
-    theme, 
+    // theme, // <<< ПРОП THEME УДАЛЕН
     translations,
     isPurchasePending,
     isAuthenticated
@@ -74,11 +75,16 @@ export function HotVibeCard({
   const imageToDisplayOnCard = lead.demo_image_url || PLACEHOLDER_IMAGE_CARD;
   const isElonSimulatorCard = lead.id === ELON_SIMULATOR_CARD_ID;
 
-  const effectiveBorderColor = theme.borderColor || "border-transparent";
-  const effectiveHoverBorderColor = theme.hoverBorderColor || theme.borderColor?.replace("/70", "") || "hover:border-transparent";
-  const effectiveShadowColor = theme.shadowColor || "shadow-md"; 
-  const effectiveHoverShadowColor = theme.hoverShadowColor || `hover:shadow-xl`; 
-  const effectiveTextColor = theme.textColor || "group-hover:text-brand-red";
+  // Определяем стили напрямую через Tailwind классы
+  const borderColorClass = isSpecial ? "border-brand-yellow/70" : "border-brand-red/70";
+  const hoverBorderColorClass = isSpecial ? "hover:border-brand-yellow" : "hover:border-brand-red";
+  const shadowColorClass = isSpecial ? "shadow-yellow-glow" : "shadow-brand-red/40";
+  const hoverShadowColorClass = isSpecial ? "hover:shadow-yellow-glow/60" : "hover:shadow-[0_0_25px_rgba(var(--brand-red-rgb),0.6)]";
+  const textColorClass = isSpecial ? "group-hover:text-brand-yellow" : "group-hover:text-brand-red";
+  const accentGradientClass = isSpecial 
+    ? "bg-gradient-to-r from-yellow-400 via-amber-500 to-orange-500" 
+    : "bg-gradient-to-r from-brand-red via-brand-orange to-yellow-500";
+
 
   const renderFooterButton = () => {
     const buttonBaseClasses = "w-full font-orbitron text-[0.65rem] sm:text-xs py-2 sm:py-2.5 rounded-lg flex items-center justify-center text-center leading-tight shadow-md transition-all duration-200 ease-in-out transform group-hover:scale-105";
@@ -120,7 +126,7 @@ export function HotVibeCard({
           <Button 
             onClick={() => onSupportMission(lead)}
             disabled={isPurchasePending || !isAuthenticated}
-            className={cn(buttonBaseClasses, theme.accentGradient, "text-black hover:brightness-110", disabledClasses)}
+            className={cn(buttonBaseClasses, accentGradientClass, "text-black hover:brightness-110", disabledClasses)}
           >
             <VibeContentRenderer content={isPurchasePending ? "::FaSpinner className='animate-spin'::" : `::FaHandHoldingDollar:: ${translations.supportMissionBtnText}`} />
           </Button>
@@ -134,11 +140,11 @@ export function HotVibeCard({
       onClick={isSupported && !isElonSimulatorCard ? () => onViewVip(lead) : undefined}
       className={cn(
         "hot-vibe-card group relative flex flex-col overflow-hidden rounded-xl bg-black/70 backdrop-blur-md transition-all duration-300 ease-in-out aspect-[3/4] sm:aspect-[4/5]",
-        effectiveBorderColor, 
-        effectiveShadowColor,
+        borderColorClass, 
+        shadowColorClass,
         (isMissionUnlocked || isElonSimulatorCard || isSupported) 
-          ? `${effectiveHoverBorderColor} ${effectiveHoverShadowColor} hover:scale-[1.03] hover:-translate-y-0.5` 
-          : `${isSpecial ? theme.borderColor : 'border-muted/30'} opacity-80 hover:opacity-100`, // Заблокированные, но не специальные, имеют muted рамку
+          ? `${hoverBorderColorClass} ${hoverShadowColorClass} hover:scale-[1.03] hover:-translate-y-0.5` 
+          : "border-muted/30 opacity-80 hover:opacity-100", 
         (isSupported && !isElonSimulatorCard) ? "cursor-pointer" : "cursor-default"
       )}
     >
@@ -173,7 +179,7 @@ export function HotVibeCard({
             <h3 
               className={cn(
                 "font-orbitron text-sm sm:text-base font-bold leading-tight transition-colors line-clamp-2", 
-                (isMissionUnlocked || isElonSimulatorCard || isSupported) ? `text-light-text ${effectiveTextColor}` : "text-muted-foreground/80"
+                (isMissionUnlocked || isElonSimulatorCard || isSupported) ? `text-light-text ${textColorClass}` : "text-muted-foreground/80"
               )} 
               title={lead.kwork_gig_title || "Untitled Gig"}
             >

--- a/components/hotvibes/HotVibeCard.tsx
+++ b/components/hotvibes/HotVibeCard.tsx
@@ -54,7 +54,7 @@ interface HotVibeCardProps {
   isAuthenticated: boolean;
 }
 
-const PLACEHOLDER_IMAGE_CARD = "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/bullshitemotions//pooh.png"; // Placeholder общий
+const PLACEHOLDER_IMAGE_CARD = "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/bullshitemotions//pooh.png"; 
 
 export function HotVibeCard({ 
     lead, 
@@ -134,12 +134,12 @@ export function HotVibeCard({
       onClick={isSupported && !isElonSimulatorCard ? () => onViewVip(lead) : undefined}
       className={cn(
         "hot-vibe-card group relative flex flex-col overflow-hidden rounded-xl bg-black/70 backdrop-blur-md transition-all duration-300 ease-in-out aspect-[3/4] sm:aspect-[4/5]",
-        "border", // Используем просто border, цвет будет из theme
-        effectiveBorderColor,
+        // "border", // Убрали класс border для удаления стандартной рамки
+        effectiveBorderColor, // Цвет рамки будет применяться только если он задан в theme
         effectiveShadowColor,
         (isMissionUnlocked || isElonSimulatorCard || isSupported) 
           ? `${effectiveHoverBorderColor} ${effectiveHoverShadowColor} hover:scale-[1.03] hover:-translate-y-0.5` 
-          : "border-muted/30 opacity-80 hover:opacity-100",
+          : "border-muted/30 opacity-80 hover:opacity-100", // Для заблокированных карточек оставим рамку muted
         (isSupported && !isElonSimulatorCard) ? "cursor-pointer" : "cursor-default"
       )}
     >

--- a/components/hotvibes/HotVibeCard.tsx
+++ b/components/hotvibes/HotVibeCard.tsx
@@ -31,13 +31,12 @@ export interface HotLeadData {
 }
 
 export interface HotVibeCardTheme {
-  borderColor: string; // e.g. "border-brand-red/70"
-  accentGradient: string; // e.g. "bg-gradient-to-r from-brand-red via-brand-orange to-yellow-500"
-  // For shadows, we might infer from borderColor or add a specific shadowColor prop
-  shadowColor?: string; // e.g. "shadow-brand-red/40" or "shadow-[0_0_25px_rgba(var(--brand-red-rgb),0.6)]"
-  hoverBorderColor?: string; // e.g. "hover:border-brand-red"
-  hoverShadowColor?: string; // e.g. "hover:shadow-[0_0_35px_rgba(var(--brand-red-rgb),0.7)]"
-  textColor?: string; // e.g. "text-brand-red" for title hover
+  borderColor: string; 
+  accentGradient: string; 
+  shadowColor?: string; 
+  hoverBorderColor?: string; 
+  hoverShadowColor?: string; 
+  textColor?: string; 
 }
 
 interface HotVibeCardProps {
@@ -55,8 +54,7 @@ interface HotVibeCardProps {
   isAuthenticated: boolean;
 }
 
-const PLACEHOLDER_IMAGE_CARD = "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/bullshitemotions//pooh.png";
-const MODAL_BACKGROUND_FALLBACK = "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/about//IMG_20250516_051010-f7be2229-1a7f-4bc2-950a-5c122b74fce6.jpg";
+const PLACEHOLDER_IMAGE_CARD = "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/bullshitemotions//pooh.png"; // Placeholder общий
 
 export function HotVibeCard({ 
     lead, 
@@ -78,10 +76,9 @@ export function HotVibeCard({
 
   const effectiveBorderColor = theme.borderColor || "border-brand-red/70";
   const effectiveHoverBorderColor = theme.hoverBorderColor || theme.borderColor?.replace("/70", "") || "hover:border-brand-red";
-  const effectiveShadowColor = theme.shadowColor || "shadow-brand-red/30"; // Softer default shadow
-  const effectiveHoverShadowColor = theme.hoverShadowColor || `hover:shadow-[0_0_25px_rgba(var(--brand-red-rgb),0.5)]`; // Example, assuming var(--brand-red-rgb) is defined
+  const effectiveShadowColor = theme.shadowColor || "shadow-brand-red/30"; 
+  const effectiveHoverShadowColor = theme.hoverShadowColor || `hover:shadow-[0_0_25px_rgba(var(--brand-red-rgb),0.5)]`; 
   const effectiveTextColor = theme.textColor || "group-hover:text-brand-red";
-
 
   const renderFooterButton = () => {
     const buttonBaseClasses = "w-full font-orbitron text-[0.65rem] sm:text-xs py-2 sm:py-2.5 rounded-lg flex items-center justify-center text-center leading-tight shadow-md transition-all duration-200 ease-in-out transform group-hover:scale-105";
@@ -112,7 +109,7 @@ export function HotVibeCard({
       if (isSupported) {
         return (
           <Button 
-            onClick={() => onViewVip(lead)} // Click now directly shows VIP
+            onClick={() => onViewVip(lead)} 
             className={cn(buttonBaseClasses, "bg-brand-green hover:bg-green-400 text-black", disabledClasses)}
           >
             <VibeContentRenderer content={`::FaEye className='mr-1.5':: ${translations.supportedText} (${translations.viewDemoText})`} />
@@ -137,7 +134,7 @@ export function HotVibeCard({
       onClick={isSupported && !isElonSimulatorCard ? () => onViewVip(lead) : undefined}
       className={cn(
         "hot-vibe-card group relative flex flex-col overflow-hidden rounded-xl bg-black/70 backdrop-blur-md transition-all duration-300 ease-in-out aspect-[3/4] sm:aspect-[4/5]",
-        "border-2",
+        "border", // Используем просто border, цвет будет из theme
         effectiveBorderColor,
         effectiveShadowColor,
         (isMissionUnlocked || isElonSimulatorCard || isSupported) 
@@ -146,7 +143,7 @@ export function HotVibeCard({
         (isSupported && !isElonSimulatorCard) ? "cursor-pointer" : "cursor-default"
       )}
     >
-        <div className="relative aspect-[1/1] w-full overflow-hidden"> {/* Changed to 1/1 for more square-like image */}
+        <div className="relative aspect-[1/1] w-full overflow-hidden"> 
           <Image
             src={imageToDisplayOnCard}
             alt={lead.kwork_gig_title || 'Hot Vibe Lead'}
@@ -173,7 +170,7 @@ export function HotVibeCard({
         </div>
 
         <CardContent className="flex flex-1 flex-col justify-between p-2.5 sm:p-3 text-center space-y-1.5">
-          <div className="min-h-[3.5em] sm:min-h-[4em]"> {/* Fixed height for title + summary area */}
+          <div className="min-h-[3.5em] sm:min-h-[4em]"> 
             <h3 
               className={cn(
                 "font-orbitron text-sm sm:text-base font-bold leading-tight transition-colors line-clamp-2", 

--- a/components/hotvibes/HotVibeCard.tsx
+++ b/components/hotvibes/HotVibeCard.tsx
@@ -30,15 +30,7 @@ export interface HotLeadData {
   client_name?: string | null;
 }
 
-// HotVibeCardTheme больше не используется этим компонентом напрямую
-// export interface HotVibeCardTheme {
-//   borderColor: string; 
-//   accentGradient: string; 
-//   shadowColor?: string; 
-//   hoverBorderColor?: string; 
-//   hoverShadowColor?: string; 
-//   textColor?: string; 
-// }
+// HotVibeCardTheme УДАЛЕНА - компонент больше не принимает theme как проп
 
 interface HotVibeCardProps {
   lead: HotLeadData;
@@ -63,7 +55,7 @@ export function HotVibeCard({
     onExecuteMission, 
     onSupportMission,
     isSupported,
-    isSpecial,
+    isSpecial, // Этот флаг теперь будет напрямую влиять на классы
     onViewVip,
     currentLang = 'ru', 
     // theme, // <<< ПРОП THEME УДАЛЕН
@@ -75,11 +67,11 @@ export function HotVibeCard({
   const imageToDisplayOnCard = lead.demo_image_url || PLACEHOLDER_IMAGE_CARD;
   const isElonSimulatorCard = lead.id === ELON_SIMULATOR_CARD_ID;
 
-  // Определяем стили напрямую через Tailwind классы
+  // Определяем стили напрямую через Tailwind классы, используя isSpecial для вариативности
   const borderColorClass = isSpecial ? "border-brand-yellow/70" : "border-brand-red/70";
   const hoverBorderColorClass = isSpecial ? "hover:border-brand-yellow" : "hover:border-brand-red";
-  const shadowColorClass = isSpecial ? "shadow-yellow-glow" : "shadow-brand-red/40";
-  const hoverShadowColorClass = isSpecial ? "hover:shadow-yellow-glow/60" : "hover:shadow-[0_0_25px_rgba(var(--brand-red-rgb),0.6)]";
+  const shadowColorClass = isSpecial ? "shadow-yellow-glow" : "shadow-brand-red/40"; // Используем Tailwind box-shadow
+  const hoverShadowColorClass = isSpecial ? "hover:shadow-yellow-glow/60" : "hover:shadow-purple-glow"; // Используем Tailwind box-shadow
   const textColorClass = isSpecial ? "group-hover:text-brand-yellow" : "group-hover:text-brand-red";
   const accentGradientClass = isSpecial 
     ? "bg-gradient-to-r from-yellow-400 via-amber-500 to-orange-500" 
@@ -90,7 +82,7 @@ export function HotVibeCard({
     const buttonBaseClasses = "w-full font-orbitron text-[0.65rem] sm:text-xs py-2 sm:py-2.5 rounded-lg flex items-center justify-center text-center leading-tight shadow-md transition-all duration-200 ease-in-out transform group-hover:scale-105";
     const disabledClasses = (isPurchasePending || !isAuthenticated) ? "opacity-60 cursor-not-allowed !scale-100" : "";
 
-    if (isElonSimulatorCard) {
+    if (isElonSimulatorCard) { // Elon Card - особый случай, стилизуем как isSpecial
       if (isSupported) {
         return (
           <Button 
@@ -111,7 +103,7 @@ export function HotVibeCard({
           </Button>
         );
       }
-    } else { 
+    } else { // Обычные карточки лидов
       if (isSupported) {
         return (
           <Button 

--- a/components/hotvibes/HotVibeCard.tsx
+++ b/components/hotvibes/HotVibeCard.tsx
@@ -74,10 +74,10 @@ export function HotVibeCard({
   const imageToDisplayOnCard = lead.demo_image_url || PLACEHOLDER_IMAGE_CARD;
   const isElonSimulatorCard = lead.id === ELON_SIMULATOR_CARD_ID;
 
-  const effectiveBorderColor = theme.borderColor || "border-brand-red/70";
-  const effectiveHoverBorderColor = theme.hoverBorderColor || theme.borderColor?.replace("/70", "") || "hover:border-brand-red";
-  const effectiveShadowColor = theme.shadowColor || "shadow-brand-red/30"; 
-  const effectiveHoverShadowColor = theme.hoverShadowColor || `hover:shadow-[0_0_25px_rgba(var(--brand-red-rgb),0.5)]`; 
+  const effectiveBorderColor = theme.borderColor || "border-transparent"; // По умолчанию без рамки
+  const effectiveHoverBorderColor = theme.hoverBorderColor || theme.borderColor?.replace("/70", "") || "hover:border-transparent";
+  const effectiveShadowColor = theme.shadowColor || "shadow-md"; // Небольшая тень по умолчанию
+  const effectiveHoverShadowColor = theme.hoverShadowColor || `hover:shadow-xl`; 
   const effectiveTextColor = theme.textColor || "group-hover:text-brand-red";
 
   const renderFooterButton = () => {
@@ -134,12 +134,11 @@ export function HotVibeCard({
       onClick={isSupported && !isElonSimulatorCard ? () => onViewVip(lead) : undefined}
       className={cn(
         "hot-vibe-card group relative flex flex-col overflow-hidden rounded-xl bg-black/70 backdrop-blur-md transition-all duration-300 ease-in-out aspect-[3/4] sm:aspect-[4/5]",
-        // "border", // Убрали класс border для удаления стандартной рамки
-        effectiveBorderColor, // Цвет рамки будет применяться только если он задан в theme
+        effectiveBorderColor, // Применяем цвет рамки из темы или прозрачный
         effectiveShadowColor,
         (isMissionUnlocked || isElonSimulatorCard || isSupported) 
           ? `${effectiveHoverBorderColor} ${effectiveHoverShadowColor} hover:scale-[1.03] hover:-translate-y-0.5` 
-          : "border-muted/30 opacity-80 hover:opacity-100", // Для заблокированных карточек оставим рамку muted
+          : "border-muted/30 opacity-80 hover:opacity-100", 
         (isSupported && !isElonSimulatorCard) ? "cursor-pointer" : "cursor-default"
       )}
     >

--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -85,8 +85,8 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
 
   return (
     <Card className={cn(
-        "overflow-hidden rounded-xl sm:rounded-2xl border backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", 
-        theme.borderColor, 
+        "overflow-hidden rounded-xl sm:rounded-2xl backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", 
+        // theme.borderColor, // Убрали рамку из темы для внешней карточки
         `shadow-[0_0_30px_-10px_rgba(var(--brand-cyan-rgb),0.5)] sm:shadow-[0_0_70px_-20px_rgba(var(--brand-cyan-rgb),0.7)]`, 
         "bg-gradient-to-br from-black/80 via-slate-900/70 to-black/80" 
     )}>
@@ -117,7 +117,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
       <div className="p-3 sm:p-4 md:p-6 space-y-4 sm:space-y-5 font-mono">
         
         {!isElonCard && (
-            <Card className={cn("border p-3 sm:p-3.5 shadow-md backdrop-blur-sm rounded-lg", theme.modalCardBg || "bg-black/50", theme.modalCardBorder || "border-white/10")}>
+            <Card className={cn("p-3 sm:p-3.5 shadow-md backdrop-blur-sm rounded-lg", theme.modalCardBg || "bg-black/50", theme.modalCardBorder || "border-transparent")}> {/* Убрали рамку для внутренней карточки */}
                 <ShadCardHeader className="p-0 mb-1.5 sm:mb-2">
                     <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center", theme.modalAccentColor || "text-brand-cyan")}>
                         <VibeContentRenderer content={t.missionBriefing}/>
@@ -138,7 +138,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
                     <VibeContentRenderer content={t.fullDescription}/>
                 </ShadCardTitle>
             </ShadCardHeader>
-            <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-60 sm:max-h-72 overflow-y-auto simple-scrollbar border", theme.modalCardBg || "bg-black/40", theme.modalCardBorder || "border-white/10")}>
+            <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-60 sm:max-h-72 overflow-y-auto simple-scrollbar", theme.modalCardBg || "bg-black/40", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent" )}> {/* Убрали рамку для внутренней карточки */}
                 <VibeContentRenderer content={lead.project_description || t.noDescription} />
             </CardContent>
         </div>
@@ -164,7 +164,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
                         </Button>
                     </div>
                 </ShadCardHeader>
-                <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-80 sm:max-h-96 overflow-y-auto simple-scrollbar border", theme.modalCardBg || "bg-black/40", theme.modalCardBorder || "border-white/10")}>
+                <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-80 sm:max-h-96 overflow-y-auto simple-scrollbar", theme.modalCardBg || "bg-black/40", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent" )}> {/* Убрали рамку для внутренней карточки */}
                      <VibeContentRenderer content={lead.ai_generated_proposal_draft || t.noOffer} />
                 </CardContent>
             </div>
@@ -177,7 +177,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
                         <VibeContentRenderer content="::FaImage className='mr-1.5 sm:mr-2':: Демонстрация Прототипа"/>
                     </ShadCardTitle>
                 </ShadCardHeader>
-                <div className="aspect-video relative w-full rounded-md sm:rounded-lg overflow-hidden border border-white/15 shadow-lg">
+                <div className="aspect-video relative w-full rounded-md sm:rounded-lg overflow-hidden shadow-lg"> {/* Убрали рамку */}
                     <Image
                         src={actualDemoImage}
                         alt={`Actual demo for ${lead.kwork_gig_title || 'VIP Lead'}`}

--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -13,7 +13,7 @@ import {
     CardDescription as ShadCardDescription 
 } from '@/components/ui/card';
 import { VibeContentRenderer } from '@/components/VibeContentRenderer';
-import type { HotLeadData } from './HotVibeCard'; // Используем только HotLeadData отсюда
+import type { HotLeadData } from './HotVibeCard'; 
 import { FaCopy, FaLink, FaClipboardList, FaLightbulb, FaCommentsDollar, FaGamepad } from "react-icons/fa6"; 
 import { toast } from 'sonner';
 import { ELON_SIMULATOR_CARD_ID } from '@/app/hotvibes/page'; 
@@ -86,7 +86,7 @@ export function VipLeadDisplay({ lead, currentLang = 'ru', isMissionUnlocked, on
   return (
     <Card className={cn(
         "overflow-hidden rounded-xl sm:rounded-2xl backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", 
-        "border-brand-cyan/70", // Используем конкретный цвет рамки или border-transparent
+        "border-brand-cyan/70", // Явно задаем цвет рамки или border-transparent
         `shadow-[0_0_30px_-10px_rgba(var(--brand-cyan-rgb),0.5)] sm:shadow-[0_0_70px_-20px_rgba(var(--brand-cyan-rgb),0.7)]`, 
         "bg-gradient-to-br from-black/80 via-slate-900/70 to-black/80" 
     )}>

--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -13,14 +13,14 @@ import {
     CardDescription as ShadCardDescription 
 } from '@/components/ui/card';
 import { VibeContentRenderer } from '@/components/VibeContentRenderer';
-import type { HotLeadData, HotVibeCardTheme } from './HotVibeCard'; 
+import type { HotLeadData } from './HotVibeCard'; // Используем только HotLeadData отсюда
 import { FaCopy, FaLink, FaClipboardList, FaLightbulb, FaCommentsDollar, FaGamepad } from "react-icons/fa6"; 
 import { toast } from 'sonner';
 import { ELON_SIMULATOR_CARD_ID } from '@/app/hotvibes/page'; 
 
 interface VipLeadDisplayProps {
   lead: HotLeadData;
-  theme: HotVibeCardTheme; // Убедимся, что theme всегда передается
+  // theme: HotVibeCardTheme; // <<< УДАЛЕН ПРОП THEME
   currentLang?: 'ru' | 'en';
   isMissionUnlocked: boolean;
   onExecuteMission: () => void;
@@ -68,7 +68,7 @@ const vipPageTranslations = {
   }
 };
 
-export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnlocked, onExecuteMission }: VipLeadDisplayProps) {
+export function VipLeadDisplay({ lead, currentLang = 'ru', isMissionUnlocked, onExecuteMission }: VipLeadDisplayProps) {
   const isElonCard = lead.id === ELON_SIMULATOR_CARD_ID;
   const imageForHeroArea = lead.demo_image_url || MODAL_BACKGROUND_FALLBACK_VIP;
   const actualDemoImage = lead.demo_image_url || PLACEHOLDER_DEMO_IMAGE_VIP; 
@@ -86,7 +86,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
   return (
     <Card className={cn(
         "overflow-hidden rounded-xl sm:rounded-2xl backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", 
-        theme.borderColor ? `border ${theme.borderColor}` : "border-transparent", // Управляем рамкой через theme
+        "border-brand-cyan/70", // Используем конкретный цвет рамки или border-transparent
         `shadow-[0_0_30px_-10px_rgba(var(--brand-cyan-rgb),0.5)] sm:shadow-[0_0_70px_-20px_rgba(var(--brand-cyan-rgb),0.7)]`, 
         "bg-gradient-to-br from-black/80 via-slate-900/70 to-black/80" 
     )}>
@@ -98,12 +98,12 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
             priority
             className="object-cover opacity-30 sm:opacity-40 group-hover:opacity-40 sm:group-hover:opacity-50 transition-opacity duration-500 ease-out scale-105 group-hover:scale-110"
         />
-        <div className={cn("absolute inset-0", theme.modalImageOverlayGradient || "bg-gradient-to-t from-black/80 via-black/30 to-transparent")} />
+        <div className={cn("absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent")} />
         <div className="absolute inset-0 flex flex-col justify-center items-center text-center p-3 sm:p-4 md:p-6 z-10">
-            <VibeContentRenderer content={`::${isElonCard ? 'FaGamepad' : 'FaEye'} className="text-5xl sm:text-6xl mb-3 ${theme.modalAccentColor || 'text-brand-cyan'} opacity-80 text-glow-cyan"::`} />
+            <VibeContentRenderer content={`::${isElonCard ? 'FaGamepad' : 'FaEye'} className="text-5xl sm:text-6xl mb-3 text-brand-cyan opacity-80 text-glow-cyan"::`} />
             <h1 className={cn(
                 "font-orbitron text-xl sm:text-2xl md:text-3xl lg:text-4xl font-bold line-clamp-3 leading-tight", 
-                theme.modalAccentColor || "text-brand-cyan", 
+                "text-brand-cyan", 
                 "text-glow-cyan drop-shadow-lg sm:drop-shadow-2xl"
                 )}
                 data-text={pageTitle}
@@ -117,9 +117,9 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
       <div className="p-3 sm:p-4 md:p-6 space-y-4 sm:space-y-5 font-mono">
         
         {!isElonCard && (
-            <Card className={cn("p-3 sm:p-3.5 shadow-md backdrop-blur-sm rounded-lg", theme.modalCardBg || "bg-black/50", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent")}>
+            <Card className={cn("p-3 sm:p-3.5 shadow-md backdrop-blur-sm rounded-lg bg-black/50 border-white/10")}>
                 <ShadCardHeader className="p-0 mb-1.5 sm:mb-2">
-                    <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center", theme.modalAccentColor || "text-brand-cyan")}>
+                    <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center text-brand-cyan")}>
                         <VibeContentRenderer content={t.missionBriefing}/>
                     </ShadCardTitle>
                 </ShadCardHeader>
@@ -134,11 +134,11 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
 
         <div className="pt-0.5">
             <ShadCardHeader className="p-0 mb-1 sm:mb-1.5">
-                <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center", theme.modalAccentColor || "text-brand-purple")}>
+                <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center text-brand-purple")}>
                     <VibeContentRenderer content={t.fullDescription}/>
                 </ShadCardTitle>
             </ShadCardHeader>
-            <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-60 sm:max-h-72 overflow-y-auto simple-scrollbar", theme.modalCardBg || "bg-black/40", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent" )}>
+            <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-60 sm:max-h-72 overflow-y-auto simple-scrollbar bg-black/40 border-white/10")}>
                 <VibeContentRenderer content={lead.project_description || t.noDescription} />
             </CardContent>
         </div>
@@ -146,25 +146,25 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
         {lead.ai_generated_proposal_draft && !isElonCard && (
             <div className="pt-0.5">
                  <ShadCardHeader className="p-0 flex flex-row justify-between items-center mb-1 sm:mb-1.5">
-                    <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center", theme.modalAccentColor || "text-brand-pink")}>
+                    <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center text-brand-pink")}>
                         <VibeContentRenderer content={t.draftOffer}/>
                     </ShadCardTitle>
                     <div className="flex items-center gap-1 sm:gap-1.5">
                         {lead.kwork_url && (
                             <Link href={lead.kwork_url} target="_blank" rel="noopener noreferrer" passHref legacyBehavior>
-                            <Button variant="outline" size="xs" className={cn("h-7 sm:h-8 px-2 py-1 text-[0.65rem] sm:text-xs border-brand-blue/50 text-brand-blue hover:bg-brand-blue/10 hover:text-blue-300", `focus:ring-brand-blue`)} title={t.viewOriginalKwork}>
+                            <Button variant="outline" size="xs" className={cn("h-7 sm:h-8 px-2 py-1 text-[0.65rem] sm:text-xs border-brand-blue/50 text-brand-blue hover:bg-brand-blue/10 hover:text-blue-300 focus:ring-brand-blue")} title={t.viewOriginalKwork}>
                                 <FaLink className="mr-1 h-3 w-3 sm:h-3.5 sm:w-3.5"/> {t.viewOriginalKwork}
                             </Button>
                             </Link>
                         )}
-                        <Button variant="outline" size="xs" className={cn("h-7 sm:h-8 px-2 py-1 text-[0.65rem] sm:text-xs border-brand-pink/50 text-brand-pink hover:bg-brand-pink/10 hover:text-pink-300", `focus:ring-brand-pink`)}
+                        <Button variant="outline" size="xs" className={cn("h-7 sm:h-8 px-2 py-1 text-[0.65rem] sm:text-xs border-brand-pink/50 text-brand-pink hover:bg-brand-pink/10 hover:text-pink-300 focus:ring-brand-pink")}
                                 title={t.copyOffer}
                                 onClick={() => handleCopyToClipboard(lead.ai_generated_proposal_draft, currentLang === 'ru' ? "Предложение скопировано!" : "Proposal copied!")}>
                             <FaCopy className="mr-1 h-3 w-3 sm:h-3.5 sm:w-3.5"/> {t.copyOffer}
                         </Button>
                     </div>
                 </ShadCardHeader>
-                <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-80 sm:max-h-96 overflow-y-auto simple-scrollbar", theme.modalCardBg || "bg-black/40", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent" )}>
+                <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-80 sm:max-h-96 overflow-y-auto simple-scrollbar bg-black/40 border-white/10")}>
                      <VibeContentRenderer content={lead.ai_generated_proposal_draft || t.noOffer} />
                 </CardContent>
             </div>
@@ -173,7 +173,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
         {lead.demo_image_url && lead.demo_image_url !== imageForHeroArea && !isElonCard && (
              <div className="pt-2 sm:pt-3">
                 <ShadCardHeader className="p-0 mb-1 sm:mb-1.5">
-                    <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center", theme.modalAccentColor || "text-brand-green")}>
+                    <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center text-brand-green")}>
                         <VibeContentRenderer content="::FaImage className='mr-1.5 sm:mr-2':: Демонстрация Прототипа"/>
                     </ShadCardTitle>
                 </ShadCardHeader>
@@ -197,7 +197,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
             size="lg" 
             className={cn(
                 "w-full font-orbitron text-sm sm:text-base py-3 sm:py-3.5 shadow-lg hover:shadow-xl",
-                (isMissionUnlocked || isElonCard) ? `${theme.accentGradient} text-black hover:brightness-110 active:scale-95` : "bg-muted text-muted-foreground cursor-not-allowed"
+                (isMissionUnlocked || isElonCard) ? `bg-gradient-to-r from-brand-red via-brand-orange to-yellow-500 text-black hover:brightness-110 active:scale-95` : "bg-muted text-muted-foreground cursor-not-allowed"
             )}
             >
             <VibeContentRenderer content={isElonCard ? t.goToSimulator : (isMissionUnlocked ? t.executeMission : t.skillLocked)} />

--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -20,7 +20,7 @@ import { ELON_SIMULATOR_CARD_ID } from '@/app/hotvibes/page';
 
 interface VipLeadDisplayProps {
   lead: HotLeadData;
-  theme: HotVibeCardTheme;
+  theme: HotVibeCardTheme; // Убедимся, что theme всегда передается
   currentLang?: 'ru' | 'en';
   isMissionUnlocked: boolean;
   onExecuteMission: () => void;
@@ -86,7 +86,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
   return (
     <Card className={cn(
         "overflow-hidden rounded-xl sm:rounded-2xl backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", 
-        // theme.borderColor, // Убрали рамку из темы для внешней карточки
+        theme.borderColor ? `border ${theme.borderColor}` : "border-transparent", // Управляем рамкой через theme
         `shadow-[0_0_30px_-10px_rgba(var(--brand-cyan-rgb),0.5)] sm:shadow-[0_0_70px_-20px_rgba(var(--brand-cyan-rgb),0.7)]`, 
         "bg-gradient-to-br from-black/80 via-slate-900/70 to-black/80" 
     )}>
@@ -117,7 +117,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
       <div className="p-3 sm:p-4 md:p-6 space-y-4 sm:space-y-5 font-mono">
         
         {!isElonCard && (
-            <Card className={cn("p-3 sm:p-3.5 shadow-md backdrop-blur-sm rounded-lg", theme.modalCardBg || "bg-black/50", theme.modalCardBorder || "border-transparent")}> {/* Убрали рамку для внутренней карточки */}
+            <Card className={cn("p-3 sm:p-3.5 shadow-md backdrop-blur-sm rounded-lg", theme.modalCardBg || "bg-black/50", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent")}>
                 <ShadCardHeader className="p-0 mb-1.5 sm:mb-2">
                     <ShadCardTitle className={cn("text-sm sm:text-md font-orbitron flex items-center", theme.modalAccentColor || "text-brand-cyan")}>
                         <VibeContentRenderer content={t.missionBriefing}/>
@@ -138,7 +138,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
                     <VibeContentRenderer content={t.fullDescription}/>
                 </ShadCardTitle>
             </ShadCardHeader>
-            <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-60 sm:max-h-72 overflow-y-auto simple-scrollbar", theme.modalCardBg || "bg-black/40", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent" )}> {/* Убрали рамку для внутренней карточки */}
+            <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-60 sm:max-h-72 overflow-y-auto simple-scrollbar", theme.modalCardBg || "bg-black/40", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent" )}>
                 <VibeContentRenderer content={lead.project_description || t.noDescription} />
             </CardContent>
         </div>
@@ -164,7 +164,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
                         </Button>
                     </div>
                 </ShadCardHeader>
-                <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-80 sm:max-h-96 overflow-y-auto simple-scrollbar", theme.modalCardBg || "bg-black/40", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent" )}> {/* Убрали рамку для внутренней карточки */}
+                <CardContent className={cn("p-3 sm:p-3.5 rounded-lg text-xs sm:text-sm text-gray-300/90 whitespace-pre-wrap break-words max-h-80 sm:max-h-96 overflow-y-auto simple-scrollbar", theme.modalCardBg || "bg-black/40", theme.modalCardBorder ? `border ${theme.modalCardBorder}` : "border-transparent" )}>
                      <VibeContentRenderer content={lead.ai_generated_proposal_draft || t.noOffer} />
                 </CardContent>
             </div>
@@ -177,7 +177,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
                         <VibeContentRenderer content="::FaImage className='mr-1.5 sm:mr-2':: Демонстрация Прототипа"/>
                     </ShadCardTitle>
                 </ShadCardHeader>
-                <div className="aspect-video relative w-full rounded-md sm:rounded-lg overflow-hidden shadow-lg"> {/* Убрали рамку */}
+                <div className="aspect-video relative w-full rounded-md sm:rounded-lg overflow-hidden shadow-lg"> 
                     <Image
                         src={actualDemoImage}
                         alt={`Actual demo for ${lead.kwork_gig_title || 'VIP Lead'}`}

--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -13,14 +13,14 @@ import {
     CardDescription as ShadCardDescription 
 } from '@/components/ui/card';
 import { VibeContentRenderer } from '@/components/VibeContentRenderer';
-import type { HotLeadData } from './HotVibeCard'; // Используем только HotLeadData отсюда
+import type { HotLeadData } from './HotVibeCard'; 
 import { FaCopy, FaLink, FaClipboardList, FaLightbulb, FaCommentsDollar, FaGamepad } from "react-icons/fa6"; 
 import { toast } from 'sonner';
 import { ELON_SIMULATOR_CARD_ID } from '@/app/hotvibes/page'; 
 
 interface VipLeadDisplayProps {
   lead: HotLeadData;
-  // theme: HotVibeCardTheme; // <<< УДАЛЕН ПРОП THEME
+  // theme: HotVibeCardTheme; // <<< ПРОП THEME ОКОНЧАТЕЛЬНО УДАЛЕН
   currentLang?: 'ru' | 'en';
   isMissionUnlocked: boolean;
   onExecuteMission: () => void;
@@ -86,7 +86,7 @@ export function VipLeadDisplay({ lead, currentLang = 'ru', isMissionUnlocked, on
   return (
     <Card className={cn(
         "overflow-hidden rounded-xl sm:rounded-2xl backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", 
-        "border-brand-cyan/70", // Используем конкретный цвет рамки или border-transparent
+        "border-brand-cyan/70", // Явный цвет рамки
         `shadow-[0_0_30px_-10px_rgba(var(--brand-cyan-rgb),0.5)] sm:shadow-[0_0_70px_-20px_rgba(var(--brand-cyan-rgb),0.7)]`, 
         "bg-gradient-to-br from-black/80 via-slate-900/70 to-black/80" 
     )}>

--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -40,9 +40,9 @@ const vipPageTranslations = {
     clientStatus: "Статус Клиента:",
     fullDescription: "::FaClipboardList className='mr-1.5 sm:mr-2 text-base sm:text-lg':: Полное Техзадание", 
     draftOffer: "::FaCommentsDollar className='mr-1.5 sm:mr-2 text-base sm:text-lg':: Наше Готовое Предложение", 
-    viewOriginalKwork: "Оригинал", // Shorter for mobile
-    copyOffer: "Копи", // Shorter for mobile
-    executeMission: "::FaRocket className='mr-1.5 sm:mr-2':: Активировать VIBE!", // Slightly shorter
+    viewOriginalKwork: "Оригинал", 
+    copyOffer: "Копи", 
+    executeMission: "::FaRocket className='mr-1.5 sm:mr-2':: Активировать VIBE!", 
     skillLocked: "::FaLock className='mr-1.5 sm:mr-2':: Навык Заблокирован",
     noDescription: "Детальное описание проекта не предоставлено.",
     noOffer: "Предложение для этого проекта пока не сформировано.",
@@ -58,9 +58,9 @@ const vipPageTranslations = {
     clientStatus: "Client Status:",
     fullDescription: "::FaClipboardList className='mr-1.5 sm:mr-2 text-base sm:text-lg':: Full Task Description", 
     draftOffer: "::FaCommentsDollar className='mr-1.5 sm:mr-2 text-base sm:text-lg':: Our Ready-Made Proposal", 
-    viewOriginalKwork: "Order", // Shorter for mobile
-    copyOffer: "Copy", // Shorter for mobile
-    executeMission: "::FaRocket className='mr-1.5 sm:mr-2':: Activate VIBE!", // Slightly shorter
+    viewOriginalKwork: "Order", 
+    copyOffer: "Copy", 
+    executeMission: "::FaRocket className='mr-1.5 sm:mr-2':: Activate VIBE!", 
     skillLocked: "::FaLock className='mr-1.5 sm:mr-2':: Skill Locked",
     noDescription: "Detailed project description not provided.",
     noOffer: "A proposal for this project has not been drafted yet.",
@@ -85,7 +85,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
 
   return (
     <Card className={cn(
-        "overflow-hidden rounded-xl sm:rounded-2xl border backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", // Убрал border-2, цвет будет из theme
+        "overflow-hidden rounded-xl sm:rounded-2xl border backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", 
         theme.borderColor, 
         `shadow-[0_0_30px_-10px_rgba(var(--brand-cyan-rgb),0.5)] sm:shadow-[0_0_70px_-20px_rgba(var(--brand-cyan-rgb),0.7)]`, 
         "bg-gradient-to-br from-black/80 via-slate-900/70 to-black/80" 

--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -13,7 +13,7 @@ import {
     CardDescription as ShadCardDescription 
 } from '@/components/ui/card';
 import { VibeContentRenderer } from '@/components/VibeContentRenderer';
-import type { HotLeadData } from './HotVibeCard'; 
+import type { HotLeadData } from './HotVibeCard'; // Используем только HotLeadData отсюда
 import { FaCopy, FaLink, FaClipboardList, FaLightbulb, FaCommentsDollar, FaGamepad } from "react-icons/fa6"; 
 import { toast } from 'sonner';
 import { ELON_SIMULATOR_CARD_ID } from '@/app/hotvibes/page'; 
@@ -86,7 +86,7 @@ export function VipLeadDisplay({ lead, currentLang = 'ru', isMissionUnlocked, on
   return (
     <Card className={cn(
         "overflow-hidden rounded-xl sm:rounded-2xl backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", 
-        "border-brand-cyan/70", // Явно задаем цвет рамки или border-transparent
+        "border-brand-cyan/70", // Используем конкретный цвет рамки или border-transparent
         `shadow-[0_0_30px_-10px_rgba(var(--brand-cyan-rgb),0.5)] sm:shadow-[0_0_70px_-20px_rgba(var(--brand-cyan-rgb),0.7)]`, 
         "bg-gradient-to-br from-black/80 via-slate-900/70 to-black/80" 
     )}>

--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -85,7 +85,7 @@ export function VipLeadDisplay({ lead, theme, currentLang = 'ru', isMissionUnloc
 
   return (
     <Card className={cn(
-        "overflow-hidden rounded-xl sm:rounded-2xl border-2 backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", 
+        "overflow-hidden rounded-xl sm:rounded-2xl border backdrop-blur-lg sm:backdrop-blur-2xl shadow-xl sm:shadow-2xl w-full", // Убрал border-2, цвет будет из theme
         theme.borderColor, 
         `shadow-[0_0_30px_-10px_rgba(var(--brand-cyan-rgb),0.5)] sm:shadow-[0_0_70px_-20px_rgba(var(--brand-cyan-rgb),0.7)]`, 
         "bg-gradient-to-br from-black/80 via-slate-900/70 to-black/80" 

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -1,33 +1,34 @@
 "use client";
 
 import type React from "react";
-import { createContext, useContext, useEffect, useMemo, useState, useCallback } from "react"; // Добавлен useCallback
+import { createContext, useContext, useEffect, useMemo, useState, useCallback } from "react";
 import { useTelegram } from "@/hooks/useTelegram";
 import { debugLogger } from "@/lib/debugLogger";
 import { logger as globalLogger } from "@/lib/logger";
 import { toast } from "sonner";
-import { fetchUserData as dbFetchUserData } from "@/hooks/supabase"; // Импортируем функцию для получения данных пользователя
+import { fetchUserData as dbFetchUserData } from "@/hooks/supabase"; 
+import type { Database } from "@/types/database.types"; // Явный импорт типа
 
 interface AppContextData extends ReturnType<typeof useTelegram> {
   startParamPayload: string | null;
-  refreshDbUser: () => Promise<void>; // Добавляем функцию обновления
+  refreshDbUser: () => Promise<void>; 
 }
 
 const AppContext = createContext<Partial<AppContextData>>({});
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const telegramHookData = useTelegram(); // Переименовано для ясности
+  const telegramHookData = useTelegram(); 
   const { user, isLoading: isTelegramLoading, isAuthenticating: isTelegramAuthenticating, error: telegramError, ...restTelegramData } = telegramHookData;
 
-  const [dbUser, setDbUser] = useState<Database["public"]["Tables"]["users"]["Row"] | null>(telegramHookData.dbUser); // Инициализируем из хука
+  const [dbUser, setDbUser] = useState<Database["public"]["Tables"]["users"]["Row"] | null>(telegramHookData.dbUser); 
   const [startParamPayload, setStartParamPayload] = useState<string | null>(null);
   const [isContextLoading, setIsContextLoading] = useState(isTelegramLoading);
   const [isContextAuthenticating, setIsContextAuthenticating] = useState(isTelegramAuthenticating);
   const [contextError, setContextError] = useState<Error | null>(telegramError);
 
-  // Синхронизируем dbUser, isLoading, isAuthenticating, error из useTelegram
   useEffect(() => {
     setDbUser(telegramHookData.dbUser);
+    // logger.debug("[AppContext] dbUser from telegramHookData updated:", telegramHookData.dbUser);
   }, [telegramHookData.dbUser]);
 
   useEffect(() => {
@@ -46,21 +47,21 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const refreshDbUser = useCallback(async () => {
     if (user?.id) {
       debugLogger.info(`[AppContext refreshDbUser] Refreshing dbUser for user ID: ${user.id}`);
-      setIsContextLoading(true); // Показываем загрузку во время обновления
+      setIsContextLoading(true); 
       try {
         const freshDbUser = await dbFetchUserData(String(user.id));
-        setDbUser(freshDbUser);
-        debugLogger.info(`[AppContext refreshDbUser] dbUser refreshed successfully.`);
+        setDbUser(freshDbUser); // Обновляем локальный стейт dbUser
+        debugLogger.info(`[AppContext refreshDbUser] dbUser refreshed successfully. New metadata:`, freshDbUser?.metadata);
       } catch (e) {
-        logger.error("[AppContext refreshDbUser] Error refreshing dbUser:", e);
-        // Можно установить ошибку или показать тост
+        globalLogger.error("[AppContext refreshDbUser] Error refreshing dbUser:", e);
+        setContextError(e instanceof Error ? e : new Error("Failed to refresh user data"));
       } finally {
         setIsContextLoading(false);
       }
     } else {
       debugLogger.warn("[AppContext refreshDbUser] Cannot refresh, user.id is not available.");
     }
-  }, [user?.id]);
+  }, [user?.id]); // Зависимость от user.id
 
 
   useEffect(() => {
@@ -77,15 +78,16 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   }, [telegramHookData.tg, telegramHookData.tg?.initDataUnsafe?.start_param, startParamPayload]);
 
   const contextValue = useMemo(() => {
+    // debugLogger.debug("[AppContext] Re-memoizing contextValue. dbUser changed:", dbUser);
     return {
-        ...restTelegramData, // Все остальные поля из useTelegram
-        user, // Передаем user из useTelegram
-        dbUser, // Используем наш стейт dbUser
-        isLoading: isContextLoading, // Используем наш стейт isLoading
-        isAuthenticating: isContextAuthenticating, // Используем наш стейт isAuthenticating
-        error: contextError, // Используем наш стейт error
+        ...restTelegramData,
+        user, 
+        dbUser, 
+        isLoading: isContextLoading, 
+        isAuthenticating: isContextAuthenticating, 
+        error: contextError, 
         startParamPayload,
-        refreshDbUser, // Передаем функцию обновления
+        refreshDbUser, 
     };
   }, [restTelegramData, user, dbUser, isContextLoading, isContextAuthenticating, contextError, startParamPayload, refreshDbUser]);
 
@@ -95,7 +97,9 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       isLoading: contextValue.isLoading,
       isAuthenticating: contextValue.isAuthenticating,
       userId: contextValue.dbUser?.user_id ?? contextValue.user?.id,
-      dbUserExists: !!contextValue.dbUser,
+      dbUserExists: !!contextValue.dbUser, // Добавлено для отладки
+      dbUserMetadataExists: !!contextValue.dbUser?.metadata, // Добавлено
+      xtrProtocardsExist: !!contextValue.dbUser?.metadata?.xtr_protocards, // Добавлено
       dbUserStatus: contextValue.dbUser?.status,
       dbUserRole: contextValue.dbUser?.role,
       isAdminFuncType: typeof contextValue.isAdmin,
@@ -112,45 +116,45 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     const LOADING_TOAST_DELAY = 350;
     const isClient = typeof document !== 'undefined';
 
-    debugLogger.log(`[APP_CONTEXT EFFECT_TOAST_LOGIC] Evaluating toasts. isLoading: ${contextValue.isLoading}, isAuthenticating: ${contextValue.isAuthenticating}, isAuthenticated: ${contextValue.isAuthenticated}, error: ${contextValue.error?.message}, isInTG: ${contextValue.isInTelegramContext}, MOCK_ENV: ${process.env.NEXT_PUBLIC_USE_MOCK_USER}, Visible: ${isClient ? document.visibilityState : 'unknown'}`);
+    // debugLogger.log(`[APP_CONTEXT EFFECT_TOAST_LOGIC] Evaluating toasts. isLoading: ${contextValue.isLoading}, isAuthenticating: ${contextValue.isAuthenticating}, isAuthenticated: ${contextValue.isAuthenticated}, error: ${contextValue.error?.message}, isInTG: ${contextValue.isInTelegramContext}, MOCK_ENV: ${process.env.NEXT_PUBLIC_USE_MOCK_USER}, Visible: ${isClient ? document.visibilityState : 'unknown'}`);
 
     const فعلاًЗагружается = contextValue.isLoading || contextValue.isAuthenticating;
 
     if (فعلاًЗагружается) {
        toast.dismiss("auth-success-toast"); toast.dismiss("auth-error-toast"); toast.dismiss("mock-user-info-toast");
-       debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] In loading/authenticating state. Dismissed other toasts.");
+       // debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] In loading/authenticating state. Dismissed other toasts.");
        loadingTimer = setTimeout(() => {
           const stillLoadingInTimeout = contextValue.isLoading || contextValue.isAuthenticating;
           if (stillLoadingInTimeout && (!isClient || document.visibilityState === 'visible')) {
-             debugLogger.info("[APP_CONTEXT EFFECT_TOAST_LOGIC] Showing 'Авторизация...' loading toast (ID: auth-loading-toast).");
+             // debugLogger.info("[APP_CONTEXT EFFECT_TOAST_LOGIC] Showing 'Авторизация...' loading toast (ID: auth-loading-toast).");
              toast.loading("Авторизация...", { id: "auth-loading-toast", duration: 15000 });
           } else {
-             debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Loading toast condition NO LONGER MET inside timeout or tab not visible. Dismissing auth-loading-toast pre-emptively.");
+             // debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Loading toast condition NO LONGER MET inside timeout or tab not visible. Dismissing auth-loading-toast pre-emptively.");
              toast.dismiss("auth-loading-toast");
           }
        }, LOADING_TOAST_DELAY);
     } else {
         if (loadingTimer) clearTimeout(loadingTimer);
         toast.dismiss("auth-loading-toast");
-        debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Exited loading/authenticating state. Dismissed auth-loading-toast.");
+        // debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Exited loading/authenticating state. Dismissed auth-loading-toast.");
 
         if (process.env.NEXT_PUBLIC_USE_MOCK_USER === 'true' && !contextValue.isInTelegramContext) {
              const existingMockToast = isClient ? document.querySelector('[data-sonner-toast][data-toast-id="mock-user-info-toast"]') : null;
              if (!existingMockToast && (!isClient || document.visibilityState === 'visible')) {
-                debugLogger.info("[APP_CONTEXT EFFECT_TOAST_LOGIC] Using MOCK_USER outside of Telegram. Displaying info toast (ID: mock-user-info-toast).");
+                // debugLogger.info("[APP_CONTEXT EFFECT_TOAST_LOGIC] Using MOCK_USER outside of Telegram. Displaying info toast (ID: mock-user-info-toast).");
                 toast.info("Внимание: используется тестовый пользователь!", { description: "Данные могут не сохраняться или вести себя иначе, чем в Telegram.", duration: 7000, id: "mock-user-info-toast" });
              } else if (existingMockToast) {
-                debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Mock user info toast already exists or tab not visible. Not showing new one.");
+                // debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Mock user info toast already exists or tab not visible. Not showing new one.");
              }
         } else if (contextValue.isInTelegramContext) {
-             debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] In real Telegram context. Dismissing any mock user info toast (ID: mock-user-info-toast).");
+             // debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] In real Telegram context. Dismissing any mock user info toast (ID: mock-user-info-toast).");
              toast.dismiss("mock-user-info-toast");
         }
 
         if (contextValue.isAuthenticated && !contextValue.error) {
             toast.dismiss("auth-error-toast");
              if (!isClient || document.visibilityState === 'visible') {
-                 debugLogger.info("[APP_CONTEXT EFFECT_TOAST_LOGIC] User authenticated successfully. Showing success toast (ID: auth-success-toast).");
+                 // debugLogger.info("[APP_CONTEXT EFFECT_TOAST_LOGIC] User authenticated successfully. Showing success toast (ID: auth-success-toast).");
                  toast.success("Пользователь авторизован", { id: "auth-success-toast", duration: 2500 });
              }
         } else if (contextValue.error) {
@@ -160,10 +164,10 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
                  toast.error(`Ошибка авторизации: ${contextValue.error.message}`, { id: "auth-error-toast", description: "Не удалось войти. Попробуйте перезапустить приложение или обратитесь в поддержку.", duration: 10000 });
             }
         } else {
-            debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Not loading, not authed, no error. No specific auth status toast needed.");
+            // debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Not loading, not authed, no error. No specific auth status toast needed.");
         }
     }
-    return () => { if (loadingTimer) { clearTimeout(loadingTimer); debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC_CLEANUP] Cleared loadingTimer."); }};
+    return () => { if (loadingTimer) { clearTimeout(loadingTimer); /* debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC_CLEANUP] Cleared loadingTimer."); */ }};
   }, [contextValue.isAuthenticated, contextValue.isLoading, contextValue.isAuthenticating, contextValue.error, contextValue.isInTelegramContext]);
 
   return <AppContext.Provider value={contextValue as AppContextData}>{children}</AppContext.Provider>;
@@ -171,7 +175,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
 export const useAppContext = (): AppContextData => {
   const context = useContext(AppContext);
-  const defaultRefreshDbUser = async () => { debugLogger.warn("refreshDbUser() called on SKELETON AppContext"); };
+  const defaultRefreshDbUser = useCallback(async () => { debugLogger.warn("refreshDbUser() called on SKELETON AppContext"); }, []);
   
   if (!context || context.isLoading === undefined || context.isAuthenticating === undefined ) {
      debugLogger.info("HOOK_APP_CONTEXT: Context is empty or key state flags (`isLoading`/`isAuthenticating`) are undefined. Returning SKELETON/LOADING defaults.");

--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -1,53 +1,101 @@
 "use client";
 
 import type React from "react";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState, useCallback } from "react"; // Добавлен useCallback
 import { useTelegram } from "@/hooks/useTelegram";
 import { debugLogger } from "@/lib/debugLogger";
 import { logger as globalLogger } from "@/lib/logger";
 import { toast } from "sonner";
-// УБРАНЫ ВСЕ ИМПОРТЫ, СВЯЗАННЫЕ С next/navigation ОТСЮДА
+import { fetchUserData as dbFetchUserData } from "@/hooks/supabase"; // Импортируем функцию для получения данных пользователя
 
 interface AppContextData extends ReturnType<typeof useTelegram> {
   startParamPayload: string | null;
-  // УБРАНЫ router, pathname, searchParams ИЗ ИНТЕРФЕЙСА
+  refreshDbUser: () => Promise<void>; // Добавляем функцию обновления
 }
 
 const AppContext = createContext<Partial<AppContextData>>({});
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const telegramData = useTelegram(); // Это наш основной источник данных от Telegram
-  const [startParamPayload, setStartParamPayload] = useState<string | null>(null);
+  const telegramHookData = useTelegram(); // Переименовано для ясности
+  const { user, isLoading: isTelegramLoading, isAuthenticating: isTelegramAuthenticating, error: telegramError, ...restTelegramData } = telegramHookData;
 
-  // Этот useEffect отвечает ТОЛЬКО за извлечение start_param
+  const [dbUser, setDbUser] = useState<Database["public"]["Tables"]["users"]["Row"] | null>(telegramHookData.dbUser); // Инициализируем из хука
+  const [startParamPayload, setStartParamPayload] = useState<string | null>(null);
+  const [isContextLoading, setIsContextLoading] = useState(isTelegramLoading);
+  const [isContextAuthenticating, setIsContextAuthenticating] = useState(isTelegramAuthenticating);
+  const [contextError, setContextError] = useState<Error | null>(telegramError);
+
+  // Синхронизируем dbUser, isLoading, isAuthenticating, error из useTelegram
   useEffect(() => {
-    if (telegramData.tg && telegramData.tg.initDataUnsafe?.start_param) {
-      const rawStartParam = telegramData.tg.initDataUnsafe.start_param;
+    setDbUser(telegramHookData.dbUser);
+  }, [telegramHookData.dbUser]);
+
+  useEffect(() => {
+    setIsContextLoading(isTelegramLoading);
+  }, [isTelegramLoading]);
+
+  useEffect(() => {
+    setIsContextAuthenticating(isTelegramAuthenticating);
+  }, [isTelegramAuthenticating]);
+
+  useEffect(() => {
+    setContextError(telegramError);
+  }, [telegramError]);
+
+
+  const refreshDbUser = useCallback(async () => {
+    if (user?.id) {
+      debugLogger.info(`[AppContext refreshDbUser] Refreshing dbUser for user ID: ${user.id}`);
+      setIsContextLoading(true); // Показываем загрузку во время обновления
+      try {
+        const freshDbUser = await dbFetchUserData(String(user.id));
+        setDbUser(freshDbUser);
+        debugLogger.info(`[AppContext refreshDbUser] dbUser refreshed successfully.`);
+      } catch (e) {
+        logger.error("[AppContext refreshDbUser] Error refreshing dbUser:", e);
+        // Можно установить ошибку или показать тост
+      } finally {
+        setIsContextLoading(false);
+      }
+    } else {
+      debugLogger.warn("[AppContext refreshDbUser] Cannot refresh, user.id is not available.");
+    }
+  }, [user?.id]);
+
+
+  useEffect(() => {
+    if (telegramHookData.tg && telegramHookData.tg.initDataUnsafe?.start_param) {
+      const rawStartParam = telegramHookData.tg.initDataUnsafe.start_param;
       debugLogger.info(`[AppContext] Received start_param (raw): ${rawStartParam}.`);
       setStartParamPayload(rawStartParam);
     } else {
-      // Если start_param нет, убедимся, что startParamPayload сброшен
-      if (startParamPayload !== null) { // Сбрасываем только если он был установлен
+      if (startParamPayload !== null) {
         debugLogger.info(`[AppContext] No start_param found or tg not ready, ensuring startParamPayload is null.`);
         setStartParamPayload(null);
       }
     }
-  }, [telegramData.tg, telegramData.tg?.initDataUnsafe?.start_param, startParamPayload]); // Добавил startParamPayload в зависимости для корректного сброса
+  }, [telegramHookData.tg, telegramHookData.tg?.initDataUnsafe?.start_param, startParamPayload]);
 
   const contextValue = useMemo(() => {
     return {
-        ...telegramData,
+        ...restTelegramData, // Все остальные поля из useTelegram
+        user, // Передаем user из useTelegram
+        dbUser, // Используем наш стейт dbUser
+        isLoading: isContextLoading, // Используем наш стейт isLoading
+        isAuthenticating: isContextAuthenticating, // Используем наш стейт isAuthenticating
+        error: contextError, // Используем наш стейт error
         startParamPayload,
+        refreshDbUser, // Передаем функцию обновления
     };
-  }, [telegramData, startParamPayload]);
+  }, [restTelegramData, user, dbUser, isContextLoading, isContextAuthenticating, contextError, startParamPayload, refreshDbUser]);
 
-  // Этот useEffect для логгирования статуса остается
   useEffect(() => {
     debugLogger.log("[APP_CONTEXT EFFECT_STATUS_UPDATE] Context value changed. Current state from context:", {
       isAuthenticated: contextValue.isAuthenticated,
       isLoading: contextValue.isLoading,
       isAuthenticating: contextValue.isAuthenticating,
       userId: contextValue.dbUser?.user_id ?? contextValue.user?.id,
+      dbUserExists: !!contextValue.dbUser,
       dbUserStatus: contextValue.dbUser?.status,
       dbUserRole: contextValue.dbUser?.role,
       isAdminFuncType: typeof contextValue.isAdmin,
@@ -55,11 +103,10 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       inTelegram: contextValue.isInTelegramContext,
       mockUserEnv: process.env.NEXT_PUBLIC_USE_MOCK_USER,
       platform: contextValue.platform,
-      startParamPayload: contextValue.startParamPayload, // Это значение будет использоваться на страницах
+      startParamPayload: contextValue.startParamPayload,
     });
   }, [contextValue]);
 
-  // Этот useEffect для тостов остается
   useEffect(() => {
     let loadingTimer: NodeJS.Timeout | null = null;
     const LOADING_TOAST_DELAY = 350;
@@ -70,16 +117,13 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     const فعلاًЗагружается = contextValue.isLoading || contextValue.isAuthenticating;
 
     if (فعلاًЗагружается) {
-       toast.dismiss("auth-success-toast");
-       toast.dismiss("auth-error-toast");
-       toast.dismiss("mock-user-info-toast");
+       toast.dismiss("auth-success-toast"); toast.dismiss("auth-error-toast"); toast.dismiss("mock-user-info-toast");
        debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] In loading/authenticating state. Dismissed other toasts.");
-
        loadingTimer = setTimeout(() => {
           const stillLoadingInTimeout = contextValue.isLoading || contextValue.isAuthenticating;
           if (stillLoadingInTimeout && (!isClient || document.visibilityState === 'visible')) {
              debugLogger.info("[APP_CONTEXT EFFECT_TOAST_LOGIC] Showing 'Авторизация...' loading toast (ID: auth-loading-toast).");
-             toast.loading("Авторизация...", { id: "auth-loading-toast", duration: 15000 }); // Увеличил длительность на всякий случай
+             toast.loading("Авторизация...", { id: "auth-loading-toast", duration: 15000 });
           } else {
              debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Loading toast condition NO LONGER MET inside timeout or tab not visible. Dismissing auth-loading-toast pre-emptively.");
              toast.dismiss("auth-loading-toast");
@@ -94,11 +138,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
              const existingMockToast = isClient ? document.querySelector('[data-sonner-toast][data-toast-id="mock-user-info-toast"]') : null;
              if (!existingMockToast && (!isClient || document.visibilityState === 'visible')) {
                 debugLogger.info("[APP_CONTEXT EFFECT_TOAST_LOGIC] Using MOCK_USER outside of Telegram. Displaying info toast (ID: mock-user-info-toast).");
-                toast.info("Внимание: используется тестовый пользователь!", {
-                    description: "Данные могут не сохраняться или вести себя иначе, чем в Telegram.",
-                    duration: 7000,
-                    id: "mock-user-info-toast"
-                });
+                toast.info("Внимание: используется тестовый пользователь!", { description: "Данные могут не сохраняться или вести себя иначе, чем в Telegram.", duration: 7000, id: "mock-user-info-toast" });
              } else if (existingMockToast) {
                 debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Mock user info toast already exists or tab not visible. Not showing new one.");
              }
@@ -117,23 +157,13 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
             toast.dismiss("auth-success-toast");
             if (!isClient || document.visibilityState === 'visible') {
                  globalLogger.error("[APP_CONTEXT EFFECT_TOAST_LOGIC] Auth error. Showing error toast (ID: auth-error-toast). Error:", contextValue.error.message);
-                 toast.error(`Ошибка авторизации: ${contextValue.error.message}`, {
-                    id: "auth-error-toast",
-                    description: "Не удалось войти. Попробуйте перезапустить приложение или обратитесь в поддержку.",
-                    duration: 10000
-                });
+                 toast.error(`Ошибка авторизации: ${contextValue.error.message}`, { id: "auth-error-toast", description: "Не удалось войти. Попробуйте перезапустить приложение или обратитесь в поддержку.", duration: 10000 });
             }
         } else {
             debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC] Not loading, not authed, no error. No specific auth status toast needed.");
         }
     }
-
-    return () => {
-        if (loadingTimer) {
-            clearTimeout(loadingTimer);
-            debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC_CLEANUP] Cleared loadingTimer.");
-        }
-    };
+    return () => { if (loadingTimer) { clearTimeout(loadingTimer); debugLogger.log("[APP_CONTEXT EFFECT_TOAST_LOGIC_CLEANUP] Cleared loadingTimer."); }};
   }, [contextValue.isAuthenticated, contextValue.isLoading, contextValue.isAuthenticating, contextValue.error, contextValue.isInTelegramContext]);
 
   return <AppContext.Provider value={contextValue as AppContextData}>{children}</AppContext.Provider>;
@@ -141,6 +171,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
 export const useAppContext = (): AppContextData => {
   const context = useContext(AppContext);
+  const defaultRefreshDbUser = async () => { debugLogger.warn("refreshDbUser() called on SKELETON AppContext"); };
   
   if (!context || context.isLoading === undefined || context.isAuthenticating === undefined ) {
      debugLogger.info("HOOK_APP_CONTEXT: Context is empty or key state flags (`isLoading`/`isAuthenticating`) are undefined. Returning SKELETON/LOADING defaults.");
@@ -158,40 +189,16 @@ export const useAppContext = (): AppContextData => {
         setBackgroundColor: (color: string) => debugLogger.warn(`setBackgroundColor(${color}) called on SKELETON AppContext`),
         platform: 'unknown_skeleton',
         themeParams: { bg_color: '#000000', text_color: '#ffffff', hint_color: '#888888', link_color: '#007aff', button_color: '#007aff', button_text_color: '#ffffff', secondary_bg_color: '#1c1c1d', header_bg_color: '#000000', accent_text_color: '#007aff', section_bg_color: '#1c1c1d', section_header_text_color: '#8e8e93', subtitle_text_color: '#8e8e93', destructive_text_color: '#ff3b30' },
-        initData: undefined,
-        initDataUnsafe: undefined,
-        colorScheme: 'dark',
-        startParam: null,
-        startParamPayload: null,
+        initData: undefined, initDataUnsafe: undefined, colorScheme: 'dark', startParam: null, startParamPayload: null,
+        refreshDbUser: defaultRefreshDbUser,
      } as AppContextData;
   }
 
   if (context.isLoading === false && context.isAuthenticating === false && typeof context.isAdmin !== 'function') {
-    globalLogger.error(
-        "HOOK_APP_CONTEXT: CRITICAL - Context fully loaded (isLoading: false, isAuthenticating: false) but context.isAdmin is NOT a function. This indicates a problem with how useTelegram returns its memoized value or how AppContext consumes it. Providing a fallback isAdmin.",
-        {
-            contextDbUserExists: !!context.dbUser,
-            contextDbUserStatus: context.dbUser?.status,
-            contextDbUserRole: context.dbUser?.role,
-            contextIsAuthenticated: context.isAuthenticated,
-            contextKeys: Object.keys(context)
-        }
-    );
-    const fallbackIsAdmin = () => {
-        if (context.dbUser) {
-            const statusIsAdmin = context.dbUser.status === 'admin';
-            const roleIsAdmin = context.dbUser.role === 'vprAdmin' || context.dbUser.role === 'admin';
-            debugLogger.warn(`[HOOK_APP_CONTEXT - Fallback isAdmin] Using direct dbUser check. Status: ${context.dbUser.status}, Role: ${context.dbUser.role}. Determined isAdmin: ${statusIsAdmin || roleIsAdmin}`);
-            return statusIsAdmin || roleIsAdmin;
-        }
-        debugLogger.warn("[HOOK_APP_CONTEXT - Fallback isAdmin] dbUser not available in context for fallback. Defaulting to false.");
-        return false;
-    };
-    return {
-        ...(context as AppContextData),
-        isAdmin: fallbackIsAdmin,
-    };
+    globalLogger.error( "HOOK_APP_CONTEXT: CRITICAL - Context fully loaded but context.isAdmin is NOT a function.", { contextDbUserExists: !!context.dbUser, contextDbUserStatus: context.dbUser?.status, contextDbUserRole: context.dbUser?.role, contextIsAuthenticated: context.isAuthenticated, contextKeys: Object.keys(context) });
+    const fallbackIsAdmin = () => { if (context.dbUser) { const statusIsAdmin = context.dbUser.status === 'admin'; const roleIsAdmin = context.dbUser.role === 'vprAdmin' || context.dbUser.role === 'admin'; debugLogger.warn(`[HOOK_APP_CONTEXT - Fallback isAdmin] Using direct dbUser check. Status: ${context.dbUser.status}, Role: ${context.dbUser.role}. Determined isAdmin: ${statusIsAdmin || roleIsAdmin}`); return statusIsAdmin || roleIsAdmin; } debugLogger.warn("[HOOK_APP_CONTEXT - Fallback isAdmin] dbUser not available in context for fallback. Defaulting to false."); return false; };
+    return { ...(context as AppContextData), isAdmin: fallbackIsAdmin, refreshDbUser: context.refreshDbUser || defaultRefreshDbUser, };
   }
 
-  return context as AppContextData;
+  return { ...context, refreshDbUser: context.refreshDbUser || defaultRefreshDbUser } as AppContextData;
 };


### PR DESCRIPTION
Fix: Исправлена логика отображения купленных ПротоКарточек и ошибка на странице симулятора Маска

Агент, есть несколько моментов, которые мы поправили, чтобы "Рынок Маска" и отображение ПротоКарточек работали как часы (или как идеально настроенный CyberVibe-движок!).

**1. Отображение Купленных ПротоКарточек (`/app/hotvibes/page.tsx`):**

*   **Проблема:** Карточка "Симулятор Рынка Маска" и другие "поддержанные" миссии могли не сразу отображаться как доступные после покупки (оплаты инвойса в Telegram и обработки вебхука).
*   **Корень проблемы:**
    *   Состояние `dbUser` в `AppContext` не обновлялось мгновенно после того, как вебхук (`protocard-purchase-handler.ts`) изменял метаданные пользователя в базе. Компонент `/app/hotvibes/page.tsx` продолжал использовать "старую" версию `dbUser` из контекста.
    *   Логика в `useMemo` для `displayedLeads` и `elonCardIsSupportedActually` опиралась на `dbUser.metadata.xtr_protocards`, которое не успевало обновиться.
*   **Решение:**
    *   В `AppContext` добавлена функция `refreshDbUser()`, которая принудительно перезапрашивает данные пользователя с сервера и обновляет `dbUser` в контексте.
    *   В функции `handlePurchaseProtoCard` на странице `/app/hotvibes/page.tsx` после успешного (с точки зрения UI) запроса на покупку и перед тем, как пользователь уйдет оплачивать инвойс, добавлен вызов `refreshDbUser()` с небольшой задержкой (4 секунды). Это дает время вебхуку обработаться и базе данных обновиться. Когда пользователь вернется на страницу (или она обновится), контекст уже будет содержать актуальные данные о купленных ПротоКарточках.
        ``typescript
        // /app/hotvibes/page.tsx в handlePurchaseProtoCard
        if (result.success) {
          addToast("Запрос на ПротоКарточку отправлен! Проверьте Telegram для оплаты счета.", "success");
          if(refreshDbUser) { // refreshDbUser теперь доступен из AppContext
              setTimeout(async () => {
                  await refreshDbUser(); 
              }, 4000); 
          }
        }
        ``
    *   Зависимости `useMemo` для `displayedLeads` и `elonCardIsSupportedActually` были корректны, проблема была именно в несвоевременном обновлении `dbUser`.
    *   В `useEffect` для `loadPageData` добавлена зависимость от `dbUser?.metadata?.xtr_protocards` (через `elonCardIsSupportedActually`), чтобы при изменении этого поля (после `refreshDbUser`) происходила перерисовка списка.
    *   Логика `useEffect` для `loadPageData` была немного упрощена и теперь более четко реагирует на `initialVipIdentifier` (полученный из `startParamPayload` или `searchParams`) и `activeFilter`.

**2. Ошибка `useMemo is not defined` на странице Симулятора Маска (`/app/elon/page.tsx`):**

*   **Проблема:** Аналогично предыдущей ошибке на `/hotvibes`, хук `useMemo` использовался без импорта.
*   **Решение:** Добавлен импорт `useMemo` из `react` в файле `/app/elon/page.tsx`.

**3. Корректное отображение плейсхолдеров иконок в `newsFlash` (`/app/elon/page.tsx`):**

*   **Проблема:** Строки `newsFlash` содержали плейсхолдеры типа `::FaRocket::`, но для их корректного отображения через `VibeContentRenderer` этому компоненту нужно передать саму строку.
*   **Решение:** В разметке, где отображается `stockData.newsFlash`, он теперь обернут в `VibeContentRenderer`:

**Логи:**

*   Лог `[HotVibes displayedLeads] Filter: all, ElonSupported: false, Output count: 1` (до покупки) и затем `Output count: 6` (после добавления всех лидов, включая Маска) показывает, что `elonCardIsSupportedActually` не обновлялся сразу. Новый механизм с `refreshDbUser` должен это исправить.
*   Остальные логи показывали корректную работу AppContext и загрузку CyberFitness профиля.

Теперь, после оплаты ПротоКарточки и возврата на страницу `/hotvibes`, статус купленных карточек должен отображаться корректно, а страница симулятора Маска не должна падать из-за отсутствующего импорта.

**Файлы (2):**
- `app/hotvibes/page.tsx`
- `app/elon/page.tsx`