### PR TITLE
Okay, I've analyzed the issues based on your description, the video, a

### DIFF
--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -24,7 +24,7 @@ interface VipLeadDisplayProps {
   onExecuteMission: () => void;
   onSupportMission: (lead: HotLeadData) => void; 
   isSupported: boolean; 
-  isPurchasePending: boolean; 
+  isProcessingThisCard: boolean; // Changed from isPurchasePending
   translations: Record<string, any>; 
   isAuthenticated: boolean; 
 }
@@ -108,7 +108,7 @@ export function VipLeadDisplay({
     onExecuteMission,
     onSupportMission, 
     isSupported,      
-    isPurchasePending,
+    isProcessingThisCard, // Changed from isPurchasePending
     translations: parentTranslations, 
     isAuthenticated   
 }: VipLeadDisplayProps) {
@@ -133,39 +133,42 @@ export function VipLeadDisplay({
 
   const renderActionButton = () => {
     const buttonBaseClasses = "w-full font-orbitron text-sm sm:text-base py-3 sm:py-3.5 shadow-lg hover:shadow-xl active:scale-95 transition-all";
-    const disabledClasses = (isPurchasePending || !isAuthenticated) ? "opacity-70 cursor-not-allowed !scale-100" : "hover:brightness-110";
     
     let iconName = "";
     let buttonText = "";
     let specificStyling = "";
+    let isDisabled = false;
 
     if (isSpecialCard) {
-        if (isSupported) { 
+        if (isSupported) { // "Go to..." button
             iconName = isElonCard ? t.goToSimulatorIcon.replace(/::/g, '') : t.goToPdfGeneratorIcon.replace(/::/g, '');
             buttonText = isElonCard ? t.goToSimulator : t.goToPdfGenerator;
-            specificStyling = "bg-gradient-to-r from-brand-green via-lime-500 to-emerald-600 text-black";
+            specificStyling = "bg-gradient-to-r from-brand-green via-lime-500 to-emerald-600 text-black hover:brightness-110";
+            isDisabled = !isAuthenticated; // Only disable if not authenticated
             return (
-                <Button onClick={onExecuteMission} variant="default" size="lg" className={cn(buttonBaseClasses, specificStyling, disabledClasses)} >
+                <Button onClick={onExecuteMission} disabled={isDisabled} variant="default" size="lg" className={cn(buttonBaseClasses, specificStyling, isDisabled && "opacity-70 cursor-not-allowed !scale-100")} >
                     <VibeContentRenderer content={`::${iconName}::`} className="mr-1.5 sm:mr-2" /> {buttonText}
                 </Button>
             );
-        } else { 
-            iconName = isPurchasePending ? "FaSpinner" : t.purchaseAccessIcon.replace(/::/g, '');
-            buttonText = isPurchasePending ? "" : t.purchaseAccess;
+        } else { // "Purchase Access" button
+            iconName = isProcessingThisCard ? "FaSpinner" : t.purchaseAccessIcon.replace(/::/g, '');
+            buttonText = isProcessingThisCard ? "" : t.purchaseAccess;
             const priceText = isElonCard ? ` ${parentTranslations.elonSimulatorAccessBtnText.split('за ')[1]}` : ` ${parentTranslations.pdfGeneratorAccessBtnText.split('за ')[1]}`;
-            specificStyling = "bg-gradient-to-r from-brand-orange via-red-500 to-pink-600 text-white";
+            specificStyling = "bg-gradient-to-r from-brand-orange via-red-500 to-pink-600 text-white hover:brightness-110";
+            isDisabled = isProcessingThisCard || !isAuthenticated;
              return (
-                 <Button onClick={() => onSupportMission(lead)} disabled={isPurchasePending || !isAuthenticated} variant="default" size="lg" className={cn(buttonBaseClasses, specificStyling, disabledClasses)} >
-                    <VibeContentRenderer content={`::${iconName}::`} className={cn("mr-1.5 sm:mr-2", isPurchasePending && "animate-spin")} /> {buttonText} {!isPurchasePending && priceText}
+                 <Button onClick={() => onSupportMission(lead)} disabled={isDisabled} variant="default" size="lg" className={cn(buttonBaseClasses, specificStyling, isDisabled && "opacity-70 cursor-not-allowed !scale-100")} >
+                    <VibeContentRenderer content={`::${iconName}::`} className={cn("mr-1.5 sm:mr-2", isProcessingThisCard && "animate-spin")} /> {buttonText} {!isProcessingThisCard && priceText}
                 </Button>
             );
         }
-    } else { 
+    } else { // Regular mission leads
         iconName = isMissionUnlocked ? t.executeMissionIcon.replace(/::/g, '') : t.skillLockedIcon.replace(/::/g, '');
         buttonText = isMissionUnlocked ? t.executeMission : t.skillLocked;
         specificStyling = isMissionUnlocked ? `bg-gradient-to-r from-brand-red via-brand-orange to-yellow-500 text-black hover:brightness-110` : "bg-muted text-muted-foreground cursor-not-allowed";
+        isDisabled = !isMissionUnlocked; // Disable if skill is locked
         return (
-            <Button onClick={onExecuteMission} disabled={!isMissionUnlocked} variant="default" size="lg" className={cn(buttonBaseClasses, specificStyling)} >
+            <Button onClick={onExecuteMission} disabled={isDisabled} variant="default" size="lg" className={cn(buttonBaseClasses, specificStyling, isDisabled && "opacity-70 cursor-not-allowed !scale-100")} >
                  <VibeContentRenderer content={`::${iconName}::`} className="mr-1.5 sm:mr-2" /> {buttonText}
             </Button>
         );


### PR DESCRIPTION
Okay, I've analyzed the issues based on your description, the video, and the provided logs and code. Here's a breakdown of the problems and the plan to address them:

**Summary of Issues & Solutions:**

1.  **Slow VIP View Opening & "Back to Lobby" Malfunction:**
    *   **Cause:** A suspected infinite loop or frequent re-runs of the `loadPageData` function, likely due to how `cyberProfile` state updates were managed within its `useCallback` dependencies, and how `dbUser.metadata.xtr_protocards` reference changes (e.g., after logging a feature use like opening sticky chat) trigger re-fetches. The "Back to Lobby" issue likely stems from `targetVipIdentifier` not being robustly cleared or `loadPageData` re-processing an old identifier due to these rapid re-runs.
    *   **Solution:**
        *   Refactor `cyberProfile` fetching into its own `useEffect` hook, separate from the main data loading logic for leads/VIP view.
        *   The main `useEffect` for loading page data will now depend on a memoized `loadPageDataCore` function and `JSON.stringify(dbUser?.metadata?.xtr_protocards)` to prevent re-runs from mere reference changes if the content of protocards is the same.
        *   In `handleBackToLobby`, use `router.replace(pathname, { shallow: true })` to reliably clear URL parameters like `lead_identifier`.
        *   These changes will stabilize `loadPageData` calls, making VIP view opening faster and "Back to Lobby" more reliable.

2.  **Card Title Visibility (Black Title on Dark/Transparent Background):**
    *   **Cause:** The `CardContent` area of `HotVibeCard` (below the image) appears semi-transparent in the video, allowing the page's dark background to show through. The title text itself is rendering as black, creating poor contrast.
    *   **Solution:**
        *   Modify `HotVibeCard.tsx`. Add an explicit, opaque background to the `CardContent` div. This background color will be a solid, slightly darker shade appropriate to the card's theme (derived from its `cardGradientClass`). For example, if the card has a yellow gradient, the content background could be `bg-yellow-700/90` or a generic `bg-neutral-800/90`.
        *   Ensure the title text color (from `titleTextColorClass`) is consistently light (e.g., `text-white` or `text-gray-200`) and has high contrast against the new opaque `CardContent` background. The existing `titleTextColorClass` values are already light, so the primary fix is the opaque background for `CardContent`.

3.  **Simultaneous Loading State for ProtoCard Purchase:**
    *   **Cause:** A single `isPurchasePending` state variable in `HotVibesClientContent` is used for all cards.
    *   **Solution:**
        *   Change `isPurchasePending` state to `processingCardId: string | null`.
        *   When a purchase is initiated for a card, set `processingCardId` to that card's ID. Reset to `null` when done.
        *   Pass `isProcessingThisCard={processingCardId === lead.id}` to `HotVibeCard` and `VipLeadDisplay`. These components will then show loading/disabled states only for the specific card being processed.

4.  **"Simple Leads" Button in VIP View:**
    *   **Cause:** This button or text doesn't appear to exist in the provided `VipLeadDisplay.tsx` code.
    *   **Solution:** This is likely a misunderstanding or refers to an older/different feature. I will not add or modify a "Simple Leads" button as it's not present in the current UI structure provided. The main action button in the VIP view (`renderActionButton`) has clear, context-dependent labels (e.g., "Activate VIBE!", "Go to Simulator", "Purchase Access").

5.  **Delayed Navigation on PDF Generator Card (and similar "Go to..." buttons):**
    *   **Cause:** In `VipLeadDisplay.tsx`, the "Go to Simulator" or "Go to PDF Generator" buttons (when the tool is already supported/purchased) were incorrectly being affected by the global `isPurchasePending` state (now `processingCardId`). If another card's purchase was pending, these navigation buttons became semi-disabled.
    *   **Solution:**
        *   In `VipLeadDisplay.tsx`'s `renderActionButton` function, the `disabled` state for buttons that navigate to already-accessed special tools (like PDF Generator or Elon Simulator when `isSupported` is true) will be modified to *not* depend on `processingCardId`. They should generally not be disabled if access is granted, or only disabled if `!isAuthenticated`.

I will now proceed to implement these changes in the relevant files.

**Файлы (3):**
- `app/hotvibes/page.tsx`
- `components/hotvibes/HotVibeCard.tsx`
- `components/hotvibes/VipLeadDisplay.tsx`