### PR TITLE
Понял! Чтобы кнопка загрузки стала квадратной, как ты просишь, нужно в

### DIFF
--- a/components/stickyChat_components/ImageReplaceTool.tsx
+++ b/components/stickyChat_components/ImageReplaceTool.tsx
@@ -115,11 +115,11 @@ export const ImageReplaceTool: React.FC<ImageReplaceToolProps> = ({ oldImageUrl,
             <div className="flex items-center gap-2">
                 <Button
                     variant="outline"
-                    // size="icon" // Убрали size="icon", чтобы кнопка не была строго квадратной
+                    size="icon" // Возвращаем size="icon"
                     asChild
                     disabled={isUploading}
-                    // Изменили w-8 на px-3 для небольшой горизонтальной подбивки, сохраняя h-8 для высоты
-                    className={`h-8 px-3 flex-shrink-0 ${uploadedFile ? 'border-green-500 hover:bg-green-600/20' : 'border-gray-500 hover:bg-gray-600/20'}`}
+                    // Возвращаем w-8 для квадратной кнопки, h-8 уже был и соответствует полю ввода
+                    className={`h-8 w-8 flex-shrink-0 ${uploadedFile ? 'border-green-500 hover:bg-green-600/20' : 'border-gray-500 hover:bg-gray-600/20'}`}
                 >
                     <label
                         htmlFor="image-upload-input-tool"
@@ -146,7 +146,6 @@ export const ImageReplaceTool: React.FC<ImageReplaceToolProps> = ({ oldImageUrl,
                         setUploadedUrl(null);
                     }}
                     placeholder="Вставьте новый URL..."
-                    // Класс flex-grow здесь уже есть и это правильно, он заполнит оставшееся пространство
                     className="flex-grow p-1.5 text-xs h-8 bg-gray-600 border-gray-500 placeholder-gray-400 focus:border-blue-400 focus:ring-1 focus:ring-blue-400 disabled:opacity-50 text-white"
                     disabled={isUploading || !!uploadedFile}
                 />


### PR DESCRIPTION
Понял! Чтобы кнопка загрузки стала квадратной, как ты просишь, нужно вернуть ей стили, которые делают её квадратной, и отменить мое предыдущее изменение, которое сделало её прямоугольной.

В твоем исходном коде кнопка уже была настроена так, чтобы быть квадратной (`size="icon"` и `h-8 w-8`). Мое предыдущее предложение изменило это. Давай вернем как было для кнопки:

Вот исправленный фрагмент кода для файла `/components/stickyChat_components/ImageReplaceTool.tsx`:

**Ключевые изменения (возврат к исходному состоянию для кнопки):**

1.  Для компонента `Button` (кнопка загрузки):
    *   Возвращен атрибут `size="icon"`.
    *   В `className` класс `px-3` (который я добавил ранее) изменен обратно на `w-8`. Вместе с `h-8` это сделает кнопку квадратной (32x32px, если стандартный масштаб Tailwind). Класс `flex-shrink-0` важен, чтобы кнопка не сжималась.

Поле ввода URL (`Input`) по-прежнему использует `flex-grow`, так что оно должно занимать оставшееся доступное пространство в строке.

Теперь кнопка загрузки должна быть квадратной. Если поле ввода новой ссылки все еще кажется слишком узким, дай знать – возможно, нужно будет посмотреть на общую ширину контейнера или добавить полю ввода минимальную ширину.

**Файлы (1):**
- `components/stickyChat_components/ImageReplaceTool.tsx`