### PR TITLE
Feat: Добавил страницу `/todoc` для обработки Word-документов

### DIFF
--- a/app/todoc/actions.ts
+++ b/app/todoc/actions.ts
@@ -1,0 +1,135 @@
+"use server";
+
+import { logger } from '@/lib/logger';
+import { debugLogger } from '@/lib/debugLogger';
+import { addColontitulToDocx } from './docProcessor';
+
+// Re-using Telegram logic structure from the provided example
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+
+interface TelegramApiResponse {
+  ok: boolean;
+  result?: any;
+  description?: string;
+  error_code?: number;
+}
+
+// A generic function to send a document to Telegram
+async function sendTelegramDocument( 
+  chatId: string,
+  fileBlob: Blob,
+  fileName: string,
+  caption?: string 
+): Promise<{ success: boolean; data?: any; error?: string }> {
+   if (!TELEGRAM_BOT_TOKEN && process.env.NODE_ENV !== 'test') {
+    logger.error("[todoc/actions.ts sendTelegramDocument] Telegram bot token not configured");
+    return { success: false, error: "Telegram bot token not configured" };
+  }
+   if (process.env.NODE_ENV === 'test' && !TELEGRAM_BOT_TOKEN) { 
+     logger.warn("[todoc/actions.ts sendTelegramDocument] TEST MODE: Telegram bot token not configured, simulating success.");
+     return { success: true, data: { message_id: 12345 } };
+   }
+
+  try {
+    const formData = new FormData();
+    formData.append("chat_id", chatId);
+    formData.append("document", fileBlob, fileName);
+
+    if (caption) {
+      // Basic markdown escape for caption
+      const charsToEscape = /[_*[\]()~`>#+\-=|{}.!]/g;
+      const escapedCaption = caption.replace(charsToEscape, '\\$&');
+      formData.append("caption", escapedCaption); 
+      formData.append("parse_mode", "MarkdownV2"); 
+    }
+
+    const response = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument`, {
+      method: "POST",
+      body: formData, 
+    });
+
+    const data: TelegramApiResponse = await response.json();
+    if (!data.ok) {
+       logger.error(`[todoc/actions.ts sendTelegramDocument] Telegram API error: ${data.description || "Unknown error"}`, { chatId, errorCode: data.error_code });
+      throw new Error(data.description || "Failed to send document");
+    }
+
+    logger.info(`[todoc/actions.ts sendTelegramDocument] Successfully sent document "${fileName}" to chat ${chatId}`);
+    return { success: true, data: data.result };
+  } catch (error) {
+     logger.error(`[todoc/actions.ts sendTelegramDocument] Error (chatId: ${chatId}, fileName: ${fileName}):`, error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unexpected error occurred while sending document",
+    };
+  }
+}
+
+export async function processAndSendDocumentAction(
+    formData: FormData,
+    chatId: string
+): Promise<{ success: boolean; message?: string; error?: string }> {
+    debugLogger.log(`[processAndSendDocumentAction] Initiated for Chat ID: ${chatId}`);
+
+    if (!chatId) {
+        return { success: false, error: "User chat ID not provided." };
+    }
+
+    const file = formData.get("document") as File | null;
+    if (!file) {
+        return { success: false, error: "No document file provided." };
+    }
+
+    // Basic validation
+    if (file.size > 10 * 1024 * 1024) { // 10 MB limit
+        return { success: false, error: "File size exceeds 10MB limit." };
+    }
+    if (!file.name.endsWith('.docx') && !file.name.endsWith('.doc')) {
+        return { success: false, error: "Invalid file type. Please upload a .doc or .docx file." };
+    }
+    
+    try {
+        // In a real app with .doc support, you would first convert .doc to .docx
+        // using a tool like LibreOffice/unoconv on the server.
+        if (file.name.endsWith('.doc')) {
+            logger.warn(`[processAndSendDocumentAction] Received a .doc file. Real implementation would require conversion to .docx first. Proceeding with simulation.`);
+        }
+
+        const fileBuffer = Buffer.from(await file.arrayBuffer());
+
+        // These are placeholder details that could be filled in by the user on the page in a future version.
+        const docDetails = {
+            docCode: "РК.ТТ-761.102 ПЗ",
+            razrab: "Иванов И.И.",
+            prov: "Петров П.П.",
+            nkontr: "Сидоров С.С.",
+            utv: "Смирнов А.А.",
+            lit: "У",
+            list: "3",
+            listov: "33",
+            orgName: "ВНУ им. В. Даля"
+        };
+        
+        const modifiedDocBytes = await addColontitulToDocx(fileBuffer, docDetails);
+        
+        const originalFileNameWithoutExt = file.name.replace(/\.[^/.]+$/, "");
+        const newFileName = `PROCESSED_${originalFileNameWithoutExt}.docx`; // Always output .docx
+        
+        const caption = `📄 Ваш обработанный документ готов: *${newFileName}*\n\nВ него был добавлен стандартный колонтитул (основная надпись) согласно ГОСТ\\.`;
+        
+        const blob = new Blob([modifiedDocBytes], { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
+
+        const sendResult = await sendTelegramDocument(chatId, blob, newFileName, caption);
+
+        if (sendResult.success) {
+            return { success: true, message: `Документ "${newFileName}" успешно обработан и отправлен.` };
+        } else {
+            return { success: false, error: `Не удалось отправить документ: ${sendResult.error}` };
+        }
+
+    } catch (error: any) {
+        logger.error('[processAndSendDocumentAction] Critical error during document processing or sending:', error);
+        const errorMsg = error instanceof Error ? error.message : 'Unexpected server error during document processing.';
+        return { success: false, error: errorMsg };
+    }
+}

--- a/app/todoc/docProcessor.ts
+++ b/app/todoc/docProcessor.ts
@@ -1,0 +1,96 @@
+"use server";
+
+import { logger } from '@/lib/logger';
+// In a real scenario, you would import a library like 'docx'
+// import { Document, Packer, Paragraph, Table, TableCell, TableRow, Footer, WidthType, BorderStyle } from 'docx';
+
+/**
+ * Simulates adding a GOST-style footer (колонтитул) to a DOCX document.
+ * A real implementation would use a library like `docx` for Node.js to parse the
+ * input file buffer and programmatically add the footer table.
+ * 
+ * @param originalFileBuffer The buffer of the original .docx file.
+ * @param docDetails An object with details to fill in the title block.
+ * @returns A promise that resolves with the Uint8Array of the modified .docx file.
+ */
+export async function addColontitulToDocx(
+    originalFileBuffer: Buffer,
+    docDetails: {
+        razrab?: string;
+        prov?: string;
+        nkontr?: string;
+        utv?: string;
+        docCode: string;
+        lit: string;
+        list: string;
+        listov: string;
+        orgName: string;
+    }
+): Promise<Uint8Array> {
+    logger.info(`[docProcessor] Simulating adding colontitul to document for code: ${docDetails.docCode}`);
+
+    // REAL IMPLEMENTATION WOULD LOOK SOMETHING LIKE THIS:
+    /*
+    import { Document, Packer, Paragraph, Table, TableCell, TableRow, Footer, WidthType, BorderStyle, TextRun, VerticalAlign, AlignmentType } from 'docx';
+
+    try {
+        // The 'docx' library can load from a buffer, which is great.
+        // For .doc files, a pre-conversion step using unoconv/LibreOffice would be needed.
+        const doc = await Document.load(originalFileBuffer);
+
+        // Create the complex GOST title block table for the footer
+        const table = new Table({
+            width: { size: 100, type: WidthType.PERCENTAGE },
+            rows: [
+                new TableRow({
+                    children: [
+                        new TableCell({ children: [new Paragraph("Изм.")], width: { size: 10, type: WidthType.PERCENTAGE } }),
+                        new TableCell({ children: [new Paragraph("Лист")], width: { size: 10, type: WidthType.PERCENTAGE } }),
+                        // ... other cells
+                        new TableCell({
+                            children: [new Paragraph(docDetails.docCode)],
+                            columnSpan: 3,
+                        }),
+                    ],
+                }),
+                // ... other rows for "Разраб.", "Пров.", etc.
+            ],
+        });
+
+        // Add the table to a new footer for each section of the document
+        doc.sections.forEach(section => {
+            section.properties.footers.default = new Footer({
+                children: [table],
+            });
+        });
+
+        // Pack the document back into a buffer to be sent to the user
+        const buffer = await Packer.toBuffer(doc);
+        return new Uint8Array(buffer);
+
+    } catch (error) {
+        logger.error('[docProcessor] Real implementation would have failed here:', error);
+        throw new Error("Failed to process DOCX file.");
+    }
+    */
+
+    // MOCK IMPLEMENTATION:
+    // We will return a dummy file buffer with a message.
+    // In a real app, this would be the buffer of the processed .docx file.
+    const mockContent = `This is a mock DOCX file.
+    
+    Original file processing was simulated.
+    
+    Details for Colontitul:
+    - Document Code: ${docDetails.docCode}
+    - Developed by: ${docDetails.razrab || 'N/A'}
+    - Checked by: ${docDetails.prov || 'N/A'}
+    - Organization: ${docDetails.orgName}
+    
+    In a real implementation, this file would be the original document with a GOST-style footer added.
+    This requires a server-side library like 'docx' for Node.js or 'python-docx' for Python.
+    `;
+    
+    const mockFileBuffer = Buffer.from(mockContent, 'utf-8');
+    return new Uint8Array(mockFileBuffer);
+}

--- a/app/todoc/page.tsx
+++ b/app/todoc/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import React, { useState, useRef, useCallback } from 'react';
+import { useAppContext } from '@/contexts/AppContext';
+import { processAndSendDocumentAction } from '@/app/todoc/actions';
+import { logger } from '@/lib/logger';
+import { Toaster, toast } from 'sonner';
+import { cn } from "@/lib/utils";
+import { VibeContentRenderer } from '@/components/VibeContentRenderer';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+
+const MAX_FILE_SIZE_MB = 10;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+
+export default function ToDocPage() {
+    const { user, isAuthenticated, isLoading: appContextLoading } = useAppContext();
+    const [selectedFile, setSelectedFile] = useState<File | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [statusMessage, setStatusMessage] = useState<string>('Выберите .doc или .docx файл для обработки.');
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (!file) {
+            setSelectedFile(null);
+            setStatusMessage('Файл не выбран. Пожалуйста, попробуйте снова.');
+            return;
+        }
+
+        if (file.size > MAX_FILE_SIZE_BYTES) {
+            toast.error(`Файл слишком большой. Максимальный размер: ${MAX_FILE_SIZE_MB}MB.`);
+            setSelectedFile(null);
+            if (event.target) event.target.value = "";
+            return;
+        }
+
+        if (!file.name.endsWith('.docx') && !file.name.endsWith('.doc')) {
+            toast.error('Неверный тип файла. Принимаются только .doc и .docx файлы.');
+            setSelectedFile(null);
+            if (event.target) event.target.value = "";
+            return;
+        }
+        
+        setSelectedFile(file);
+        setStatusMessage(`Выбран файл: ${file.name}`);
+    };
+
+    const triggerFileSelect = useCallback(() => {
+        if (!isLoading) {
+            fileInputRef.current?.click();
+        }
+    }, [isLoading]);
+
+    const handleProcessAndSend = async () => {
+        if (!selectedFile) {
+            toast.error('Пожалуйста, сначала выберите файл.');
+            return;
+        }
+        if (!user?.id) {
+            toast.error('Информация о пользователе недоступна. Убедитесь, что вы авторизованы через Telegram.');
+            return;
+        }
+
+        setIsLoading(true);
+        setStatusMessage('Загрузка и обработка документа...');
+        toast.loading('Обработка файла...', { id: 'doc-processing-toast' });
+
+        try {
+            const formData = new FormData();
+            formData.append('document', selectedFile);
+
+            const result = await processAndSendDocumentAction(formData, String(user.id));
+
+            if (result.success) {
+                toast.success(result.message || 'Документ успешно обработан и отправлен в Telegram!', { id: 'doc-processing-toast' });
+                setStatusMessage('Готово! Проверьте свой чат в Telegram.');
+                setSelectedFile(null);
+                if(fileInputRef.current) fileInputRef.current.value = "";
+            } else {
+                toast.error(result.error || 'Произошла неизвестная ошибка.', { id: 'doc-processing-toast', duration: 8000 });
+                setStatusMessage(`Ошибка: ${result.error}`);
+            }
+        } catch (error) {
+            logger.error('[ToDocPage] Error calling action:', error);
+            const errorMessage = error instanceof Error ? error.message : 'Непредвиденная ошибка на клиенте.';
+            toast.error(errorMessage, { id: 'doc-processing-toast', duration: 8000 });
+            setStatusMessage(`Критическая ошибка: ${errorMessage}`);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    if (appContextLoading) {
+        return (
+            <div className="flex flex-col justify-center items-center min-h-screen bg-background text-foreground">
+                <VibeContentRenderer content="::FaSpinner className='animate-spin text-brand-purple text-4xl'::" />
+                <span className="mt-4 text-lg font-mono">Загрузка данных пользователя...</span>
+            </div>
+        );
+    }
+    
+    if (!isAuthenticated) {
+        return (
+             <div className="min-h-screen flex flex-col items-center justify-center bg-background p-6 text-center text-foreground">
+                <VibeContentRenderer content="::FaLock className='text-7xl text-brand-red mb-6'::" />
+                <h1 className="text-3xl sm:text-4xl font-orbitron font-bold text-brand-red mb-4">Доступ закрыт</h1>
+                <p className="text-md sm:text-lg text-muted-foreground mb-8 max-w-md">Пожалуйста, авторизуйтесь через Telegram, чтобы использовать этот инструмент.</p>
+                <Link href="/hotvibes">
+                    <Button variant="outline" className="border-brand-blue text-brand-blue hover:bg-brand-blue/10">
+                        <VibeContentRenderer content="::FaArrowLeft:: Назад в Хаб" />
+                    </Button>
+                </Link>
+            </div>
+        );
+    }
+
+    return (
+        <div className={cn("min-h-screen flex flex-col items-center justify-center pt-10 sm:pt-12 pb-10", "bg-gradient-to-br from-gray-900 via-blue-900/50 to-gray-900 text-foreground px-4 font-sans")}>
+            <Toaster position="bottom-center" richColors theme="dark" toastOptions={{ className: '!font-mono !shadow-lg' }} />
+            <div className="w-full max-w-lg mx-auto p-6 md:p-8 space-y-8 bg-card rounded-xl shadow-xl border border-border/50">
+                <div className="text-center">
+                    <VibeContentRenderer content="::FaFileWord className='text-5xl text-brand-blue mx-auto mb-4'::" />
+                    <h1 className="text-3xl font-orbitron font-bold text-foreground">DOCX Колонтитул-Инжектор</h1>
+                    <p className="text-muted-foreground mt-2">Загрузите `.doc` или `.docx` файл, чтобы добавить стандартный колонтитул (основную надпись).</p>
+                </div>
+
+                <div className="space-y-4">
+                    <div
+                      onClick={triggerFileSelect}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') triggerFileSelect(); }}
+                      role="button"
+                      tabIndex={0}
+                      className={cn(
+                        "w-full flex flex-col items-center justify-center px-6 py-10 border-2 border-dashed rounded-lg cursor-pointer transition-all duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
+                        "border-input-border hover:border-brand-blue text-muted-foreground hover:text-brand-blue",
+                        isLoading ? "opacity-50 cursor-not-allowed animate-pulse" : "hover:bg-brand-blue/10",
+                        selectedFile ? "border-green-500 hover:border-green-400 text-green-400" : ""
+                      )}
+                    >
+                        <VibeContentRenderer content={selectedFile ? "::FaCheckCircle className='text-3xl mb-3'::" : "::FaUpload className='text-3xl mb-3'::"} />
+                        <span className="font-semibold text-center">{statusMessage}</span>
+                        {!selectedFile && <span className="text-xs mt-1">(Макс. {MAX_FILE_SIZE_MB}MB)</span>}
+                        <input
+                            id="doc-file-upload"
+                            ref={fileInputRef}
+                            type="file"
+                            accept=".doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                            onChange={handleFileChange}
+                            className="sr-only"
+                            disabled={isLoading}
+                        />
+                    </div>
+
+                    <Button 
+                        onClick={handleProcessAndSend} 
+                        disabled={isLoading || !selectedFile}
+                        size="lg" 
+                        className="w-full bg-brand-gradient-purple-blue text-white font-semibold py-3 text-lg shadow-md hover:opacity-90 transition-opacity"
+                    >
+                        {isLoading 
+                            ? <><VibeContentRenderer content="::FaSpinner className='animate-spin mr-2'::"/> Обработка...</> 
+                            : <><VibeContentRenderer content="::FaMagicWandSparkles className='mr-2'::"/> Обработать и отправить в Telegram</>
+                        }
+                    </Button>
+                </div>
+                 <div className="text-center text-xs text-muted-foreground/80 pt-4 border-t border-border/30">
+                     <p><VibeContentRenderer content="::FaInfoCircle::" /> Этот инструмент симулирует добавление колонтитула. Реальная обработка DOC/DOCX требует сложных серверных библиотек.</p>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Feat: Добавил страницу `/todoc` для обработки Word-документов

Хей, бро! Добавил новую фичу — страницу `/todoc`, которая позволяет пользователям творить магию с `.doc` и `.docx` файлами. Эта страница является аналогом `/topdf` и реализует функционал по добавлению "колонтитула" (основной надписи по ГОСТ) в документы.

### Что сделано:

*   **Новый роут `/app/todoc`**: Создал полный набор файлов для новой страницы:
    *   `/app/todoc/page.tsx`: Клиентский компонент с интерфейсом для загрузки файлов. Включает в себя валидацию по типу и размеру, отображение статусов загрузки и обработку ошибок.
    *   `/app/todoc/actions.ts`: Серверные экшены для обработки запроса. Принимает файл, вызывает процессор и отправляет результат в Telegram.
    *   `/app/todoc/docProcessor.ts`: Модуль, отвечающий за саму обработку документа.
*   **Логика обработки**:
    *   Пользователь загружает `.doc` или `.docx` файл.
    *   Серверный экшен вызывает `docProcessor`, который добавляет в документ колонтитул, как на скриншоте.
    *   Обработанный файл отправляется пользователю в Telegram-чат.
*   **Важный момент**: Сама манипуляция с `.docx` файлом **симулируется**. Для реальной работы потребуется установка серверной библиотеки, например `npm install docx`. Я оставил подробные комментарии в коде (`/app/todoc/docProcessor.ts`), как это будет выглядеть в реальном проекте. Сейчас процессор возвращает текстовый файл с описанием симуляции.
*   **UI/UX**: Страница стилизована в духе остального приложения, с использованием `VibeContentRenderer` для иконок <Fa6Icons.FaFileWord />, проверкой аутентификации и асинхронными уведомлениями через `sonner`.

Погнали тестить! 🚀

**Файлы (3):**
- `app/todoc/docProcessor.ts`
- `app/todoc/actions.ts`
- `app/todoc/page.tsx`