### PR TITLE
Feat: Polished DOCX Generator card into a "showcase" example

### DIFF
--- a/app/hotvibes/HotVibesClientContent.tsx
+++ b/app/hotvibes/HotVibesClientContent.tsx
@@ -32,9 +32,15 @@ export const ELON_SIMULATOR_ACCESS_PRICE_XTR = 13;
 export const ELON_SIMULATOR_ACCESS_PRICE_KV = 100;
 export const MISSION_SUPPORT_PRICE_XTR = 13; 
 export const MISSION_SUPPORT_PRICE_KV = 100;
+
 export const PERSONALITY_REPORT_PDF_CARD_ID = "personality_pdf_generator_v1";
 export const PERSONALITY_REPORT_PDF_ACCESS_PRICE_XTR = 7;
 export const PERSONALITY_REPORT_PDF_ACCESS_PRICE_KV = 50;
+
+export const DOCX_GENERATOR_CARD_ID = "docx_generator_v1";
+export const DOCX_GENERATOR_ACCESS_PRICE_XTR = 7;
+export const DOCX_GENERATOR_ACCESS_PRICE_KV = 50;
+
 export const RUB_TO_XTR_RATE = 1 / 4.2; 
 
 const pageTranslations = {
@@ -52,10 +58,12 @@ const pageTranslations = {
         supportMissionBtnText: `Поддержать за ${MISSION_SUPPORT_PRICE_XTR} XTR / ${MISSION_SUPPORT_PRICE_KV} KV`,
         elonSimulatorAccessBtnText: `Доступ: ${ELON_SIMULATOR_ACCESS_PRICE_XTR} XTR / ${ELON_SIMULATOR_ACCESS_PRICE_KV} KV`,
         pdfGeneratorAccessBtnText: `Доступ: ${PERSONALITY_REPORT_PDF_ACCESS_PRICE_XTR} XTR / ${PERSONALITY_REPORT_PDF_ACCESS_PRICE_KV} KV`,
+        docxGeneratorAccessBtnText: `Доступ: ${DOCX_GENERATOR_ACCESS_PRICE_XTR} XTR / ${DOCX_GENERATOR_ACCESS_PRICE_KV} KV`,
         supportedText: "Поддержано",
         viewDemoText: "Смотреть Демо",
         goToSimulatorText: "К Симулятору Маска",
         goToPdfGeneratorText: "К PDF Генератору",
+        goToDocxGeneratorText: "К DOCX Генератору",
         filterAll: "Все Вайбы",
         filterSupported: "Мои ПротоКарты",
         backToLobby: "::FaArrowLeft:: К Лобби Вайбов",
@@ -76,10 +84,12 @@ const pageTranslations = {
         supportMissionBtnText: `Support for ${MISSION_SUPPORT_PRICE_XTR} XTR / ${MISSION_SUPPORT_PRICE_KV} KV`,
         elonSimulatorAccessBtnText: `Access: ${ELON_SIMULATOR_ACCESS_PRICE_XTR} XTR / ${ELON_SIMULATOR_ACCESS_PRICE_KV} KV`,
         pdfGeneratorAccessBtnText: `Access: ${PERSONALITY_REPORT_PDF_ACCESS_PRICE_XTR} XTR / ${PERSONALITY_REPORT_PDF_ACCESS_PRICE_KV} KV`,
+        docxGeneratorAccessBtnText: `Access: ${DOCX_GENERATOR_ACCESS_PRICE_XTR} XTR / ${DOCX_GENERATOR_ACCESS_PRICE_KV} KV`,
         supportedText: "Supported",
         viewDemoText: "View Demo",
         goToSimulatorText: "To Musk Simulator",
         goToPdfGeneratorText: "To PDF Generator",
+        goToDocxGeneratorText: "To DOCX Generator",
         filterAll: "All Vibes",
         filterSupported: "My ProtoCards",
         backToLobby: "::FaArrowLeft:: Back to Lobby",
@@ -166,6 +176,19 @@ const personalityPdfGeneratorCardData: HotLeadData = {
     notes: "/topdf" 
 };
 
+const docxGeneratorCardData: HotLeadData = {
+    id: DOCX_GENERATOR_CARD_ID,
+    kwork_gig_title: "DOCX Генератор с Колонтитулом",
+    client_name: "CyberVibe Tools",
+    ai_summary: "От идеи до покупки за день, прямо с телефона. Загрузи DOCX, и система сама разберет его, сохранит текст, картинки, списки и форматирование, добавит ГОСТ-колонтитул и отправит результат в Telegram. Это — следующий шаг эволюции, и он уже здесь.",
+    demo_image_url: "https://images.unsplash.com/photo-1583521214690-73421a1829a9?q=80&w=2070&auto=format&fit=crop",
+    potential_earning: `${DOCX_GENERATOR_ACCESS_PRICE_XTR} XTR / ${DOCX_GENERATOR_ACCESS_PRICE_KV} KV`,
+    required_quest_id: "none",
+    project_type_guess: "Tool/Utility",
+    status: "active_tool",
+    notes: "/todoc"
+};
+
 export default function HotVibesClientContent() {
   const router = useRouter();
   const pathname = usePathname(); 
@@ -220,6 +243,9 @@ export default function HotVibesClientContent() {
       if (startParamPayload === 'topdf_psycho' || startParamPayload === 'AlexandraSergeevna') {
         effectiveId = PERSONALITY_REPORT_PDF_CARD_ID; 
         logger.info(`[HotVibes InitialIdEffect] 'topdf_psycho' or 'AlexandraSergeevna' startParam detected, targeting PDF Generator card.`);
+      } else if (startParamPayload === 'todoc') {
+          effectiveId = DOCX_GENERATOR_CARD_ID;
+          logger.info(`[HotVibes InitialIdEffect] 'todoc' startParam detected, targeting DOCX Generator card.`);
       }
       
       if (effectiveId) {
@@ -256,6 +282,8 @@ export default function HotVibesClientContent() {
             foundVip = elonSimulatorProtoCardData;
         } else if (targetVipIdentifier === PERSONALITY_REPORT_PDF_CARD_ID) {
             foundVip = personalityPdfGeneratorCardData;
+        } else if (targetVipIdentifier === DOCX_GENERATOR_CARD_ID) {
+            foundVip = docxGeneratorCardData;
         } else {
             foundVip = allFetchedLeads.find(l => l.id === targetVipIdentifier || l.client_name === targetVipIdentifier) || null;
             if (!foundVip) {
@@ -333,6 +361,13 @@ export default function HotVibesClientContent() {
         specificMetadata = { page_link: "/topdf", tool_name: "AI Генератор PDF Отчетов" };
         cardTitle = personalityPdfGeneratorCardData.kwork_gig_title!;
         cardDescription = personalityPdfGeneratorCardData.ai_summary!;
+    } else if (cardToPurchase.id === DOCX_GENERATOR_CARD_ID) {
+        priceXTR = DOCX_GENERATOR_ACCESS_PRICE_XTR;
+        priceKV = DOCX_GENERATOR_ACCESS_PRICE_KV;
+        cardType = "tool_access";
+        specificMetadata = { page_link: "/todoc", tool_name: "DOCX Генератор с Колонтитулом", demo_link_param: 'todoc' };
+        cardTitle = docxGeneratorCardData.kwork_gig_title!;
+        cardDescription = docxGeneratorCardData.ai_summary!;
     } else { 
         priceXTR = MISSION_SUPPORT_PRICE_XTR;
         priceKV = MISSION_SUPPORT_PRICE_KV;
@@ -383,6 +418,7 @@ export default function HotVibesClientContent() {
 
     if (leadId === PERSONALITY_REPORT_PDF_CARD_ID) navTarget = "/topdf";
     else if (leadId === ELON_SIMULATOR_CARD_ID) navTarget = "/elon";
+    else if (leadId === DOCX_GENERATOR_CARD_ID) navTarget = "/todoc";
     
     if (typeof navTarget === 'string' && navTarget.startsWith('/')) {
         logger.info(`[HotVibes ExecuteMission] Navigating directly to internal path: ${navTarget} for lead ${leadId}`);
@@ -426,14 +462,16 @@ export default function HotVibesClientContent() {
   const displayedLeads = useMemo(() => {
     const elonCardWithStatus = { ...elonSimulatorProtoCardData, isSpecial: true, isSupported: getIsSupported(ELON_SIMULATOR_CARD_ID) };
     const pdfGenCardWithStatus = { ...personalityPdfGeneratorCardData, isSpecial: true, isSupported: getIsSupported(PERSONALITY_REPORT_PDF_CARD_ID) };
+    const docxGenCardWithStatus = { ...docxGeneratorCardData, isSpecial: true, isSupported: getIsSupported(DOCX_GENERATOR_CARD_ID) };
 
     let currentLobbyLeads = lobbyLeads.map(lead => ({ ...lead, isSpecial: false, isSupported: getIsSupported(lead.id) }));
 
     let filteredForDisplay: Array<HotLeadData & {isSpecial?:boolean, isSupported?:boolean}> = [];
-    const specialCardIds = [ELON_SIMULATOR_CARD_ID, PERSONALITY_REPORT_PDF_CARD_ID];
+    const specialCardIds = [ELON_SIMULATOR_CARD_ID, PERSONALITY_REPORT_PDF_CARD_ID, DOCX_GENERATOR_CARD_ID];
 
     if (activeFilter === 'supported') {
         filteredForDisplay = currentLobbyLeads.filter(l => l.isSupported && !specialCardIds.includes(l.id));
+        if (docxGenCardWithStatus.isSupported) filteredForDisplay.unshift(docxGenCardWithStatus);
         if (pdfGenCardWithStatus.isSupported) filteredForDisplay.unshift(pdfGenCardWithStatus);
         if (elonCardWithStatus.isSupported) filteredForDisplay.unshift(elonCardWithStatus);
     } else { 
@@ -442,7 +480,7 @@ export default function HotVibesClientContent() {
             : isAuthenticated ? [] : currentLobbyLeads;
         
         const lobbyWithoutSpecial = baseFilteredLobby.filter(l => !specialCardIds.includes(l.id));
-        filteredForDisplay = [elonCardWithStatus, pdfGenCardWithStatus, ...lobbyWithoutSpecial];
+        filteredForDisplay = [elonCardWithStatus, pdfGenCardWithStatus, docxGenCardWithStatus, ...lobbyWithoutSpecial];
     }
     
     logger.info(`[HotVibes displayedLeads] Memo re-calc. Filter: ${activeFilter}, Lobby size: ${lobbyLeads.length}, Output count: ${filteredForDisplay.length}`);

--- a/components/hotvibes/HotVibeCard.tsx
+++ b/components/hotvibes/HotVibeCard.tsx
@@ -1,4 +1,3 @@
-// /components/hotvibes/HotVibeCard.tsx
 "use client";
 
 import React from 'react';
@@ -14,12 +13,15 @@ import { VibeContentRenderer } from '@/components/VibeContentRenderer';
 import { 
     ELON_SIMULATOR_CARD_ID, 
     PERSONALITY_REPORT_PDF_CARD_ID,
+    DOCX_GENERATOR_CARD_ID,
     ELON_SIMULATOR_ACCESS_PRICE_KV,
     PERSONALITY_REPORT_PDF_ACCESS_PRICE_KV,
     MISSION_SUPPORT_PRICE_KV,
     ELON_SIMULATOR_ACCESS_PRICE_XTR,
     PERSONALITY_REPORT_PDF_ACCESS_PRICE_XTR,
-    MISSION_SUPPORT_PRICE_XTR
+    MISSION_SUPPORT_PRICE_XTR,
+    DOCX_GENERATOR_ACCESS_PRICE_KV,
+    DOCX_GENERATOR_ACCESS_PRICE_XTR
 } from '@/app/hotvibes/HotVibesClientContent';
 
 export interface HotLeadData {
@@ -73,11 +75,12 @@ export function HotVibeCard({
   const imageToDisplayOnCard = lead.demo_image_url || PLACEHOLDER_IMAGE_CARD;
   const isElonSimulatorCard = lead.id === ELON_SIMULATOR_CARD_ID;
   const isPdfGeneratorCard = lead.id === PERSONALITY_REPORT_PDF_CARD_ID;
+  const isDocxGeneratorCard = lead.id === DOCX_GENERATOR_CARD_ID;
 
   let cardClass = "border-slate-700 bg-slate-800";
   let titleClass = "text-slate-100 group-hover:text-brand-cyan";
   
-  if (isSpecial || isElonSimulatorCard || isPdfGeneratorCard) {
+  if (isSpecial || isElonSimulatorCard || isPdfGeneratorCard || isDocxGeneratorCard) {
     cardClass = "border-amber-500/50 bg-gradient-to-br from-yellow-500 via-amber-600 to-orange-700";
     titleClass = "text-white group-hover:text-yellow-200";
   } else if (isSupported) {
@@ -117,19 +120,25 @@ export function HotVibeCard({
     } else if (isPdfGeneratorCard) {
         priceKV = PERSONALITY_REPORT_PDF_ACCESS_PRICE_KV;
         priceXTR = PERSONALITY_REPORT_PDF_ACCESS_PRICE_XTR;
+    } else if (isDocxGeneratorCard) {
+        priceKV = DOCX_GENERATOR_ACCESS_PRICE_KV;
+        priceXTR = DOCX_GENERATOR_ACCESS_PRICE_XTR;
     } else {
         priceKV = MISSION_SUPPORT_PRICE_KV;
         priceXTR = MISSION_SUPPORT_PRICE_XTR;
     }
 
     if (isSupported) {
-        buttonIconName = isSpecial ? "::FaCaretRight::" : "::FaEye::";
-        buttonText = isSpecial ? (translations.goToSimulatorText || "Enter") : (translations.viewDemoText || "View");
         buttonAction = () => onViewVip(lead); 
         buttonSpecificClass = "bg-brand-green text-black hover:brightness-110";
+
+        if (isElonSimulatorCard) { buttonText = translations.goToSimulatorText; buttonIconName = "::FaGamepad::"; }
+        else if (isPdfGeneratorCard) { buttonText = translations.goToPdfGeneratorText; buttonIconName = "::FaFilePdf::"; }
+        else if (isDocxGeneratorCard) { buttonText = translations.goToDocxGeneratorText; buttonIconName = "::FaFileWord::"; }
+        else { buttonText = translations.viewDemoText; buttonIconName = "::FaEye::"; }
+        
     } else {
         buttonIconName = isProcessingThisCard ? "::FaSpinner className='animate-spin'::" : "::FaUnlockKeyhole::";
-        // Compact button text using icons
         buttonText = `::FaBolt:: ${priceKV} / ::FaStar:: ${priceXTR}`;
         buttonSpecificClass = "bg-brand-orange text-white hover:brightness-110";
     }

--- a/components/hotvibes/VipLeadDisplay.tsx
+++ b/components/hotvibes/VipLeadDisplay.tsx
@@ -1,4 +1,3 @@
-// /components/hotvibes/VipLeadDisplay.tsx
 "use client";
 
 import React from 'react';
@@ -18,12 +17,15 @@ import { toast } from 'sonner';
 import { 
     ELON_SIMULATOR_CARD_ID, 
     PERSONALITY_REPORT_PDF_CARD_ID,
+    DOCX_GENERATOR_CARD_ID,
     ELON_SIMULATOR_ACCESS_PRICE_KV,
     PERSONALITY_REPORT_PDF_ACCESS_PRICE_KV,
     MISSION_SUPPORT_PRICE_KV,
     ELON_SIMULATOR_ACCESS_PRICE_XTR,
     PERSONALITY_REPORT_PDF_ACCESS_PRICE_XTR,
-    MISSION_SUPPORT_PRICE_XTR
+    MISSION_SUPPORT_PRICE_XTR,
+    DOCX_GENERATOR_ACCESS_PRICE_KV,
+    DOCX_GENERATOR_ACCESS_PRICE_XTR,
 } from '@/app/hotvibes/HotVibesClientContent';
 import { useAppContext } from '@/contexts/AppContext';
 import { CyberFitnessProfile } from '@/hooks/cyberFitnessSupabase';
@@ -38,10 +40,9 @@ interface VipLeadDisplayProps {
   isSupported: boolean; 
   isProcessingThisCard: boolean; 
   translations: Record<string, any>; 
-  isAuthenticated: boolean; 
+  isAuthenticated: boolean;   
 }
 
-// Using a more abstract/cool background from Unsplash
 const MODAL_BACKGROUND_FALLBACK_VIP = "https://images.unsplash.com/photo-1534796636912-3b95b3ab5986?q=80&w=2071&auto=format&fit=crop";
 
 const vipPageTranslations = { 
@@ -49,6 +50,7 @@ const vipPageTranslations = {
     pageTitleBase: "VIP-Доступ:",
     elonPageTitle: "Симулятор 'Рынка Маска'",
     pdfGenPageTitle: "Генератор PDF: Расшифровка Личности",
+    docxGenPageTitle: "DOCX Генератор с Колонтитулом",
     missionBriefing: "Брифинг Миссии",
     budget: "Потенциал", 
     taskType: "Тип Задачи", 
@@ -69,6 +71,7 @@ const vipPageTranslations = {
     pageTitleBase: "VIP Access:",
     elonPageTitle: "Musk Market Simulator",
     pdfGenPageTitle: "PDF Generator: Personality Insights",
+    docxGenPageTitle: "DOCX Generator w/ Title Block",
     missionBriefing: "Mission Briefing",
     budget: "Potential", 
     taskType: "Task Type", 
@@ -102,7 +105,8 @@ export function VipLeadDisplay({
   const { openLink } = useAppContext();
   const isElonCard = lead.id === ELON_SIMULATOR_CARD_ID;
   const isPdfGeneratorCard = lead.id === PERSONALITY_REPORT_PDF_CARD_ID;
-  const isSpecialCard = isElonCard || isPdfGeneratorCard;
+  const isDocxGeneratorCard = lead.id === DOCX_GENERATOR_CARD_ID;
+  const isSpecialCard = isElonCard || isPdfGeneratorCard || isDocxGeneratorCard;
 
   const imageForHeroArea = lead.demo_image_url || MODAL_BACKGROUND_FALLBACK_VIP;
 
@@ -117,13 +121,14 @@ export function VipLeadDisplay({
   let pageTitle = `${t.pageTitleBase} ${lead.kwork_gig_title || (currentLang === 'ru' ? 'Миссия' : 'Mission')}`;
   if (isElonCard) pageTitle = t.elonPageTitle;
   if (isPdfGeneratorCard) pageTitle = t.pdfGenPageTitle;
+  if (isDocxGeneratorCard) pageTitle = t.docxGenPageTitle;
 
   const renderActionButtons = () => {
     const buttonBaseClasses = "w-full font-orbitron text-sm sm:text-base py-3 shadow-lg hover:shadow-xl active:scale-95 transition-all duration-200 ease-in-out flex items-center justify-center gap-2 rounded-lg";
     
     // --- STATE 1: ALREADY OWNED ---
     if (isSupported) {
-        let iconName = isElonCard ? "::FaGamepad::" : isPdfGeneratorCard ? "::FaFilePdf::" : "::FaRocket::";
+        let iconName = isElonCard ? "::FaGamepad::" : isPdfGeneratorCard ? "::FaFilePdf::" : isDocxGeneratorCard ? "::FaFileWord::" : "::FaRocket::";
         return (
             <Button type="button" onClick={onExecuteMission} disabled={!isAuthenticated || isProcessingThisCard} variant="default" size="lg" className={cn(buttonBaseClasses, "bg-gradient-to-r from-brand-green to-emerald-500 text-black hover:brightness-110", (!isAuthenticated || isProcessingThisCard) && "opacity-70 cursor-not-allowed")}>
                 <VibeContentRenderer content={isProcessingThisCard ? "::FaSpinner className='animate-spin'::" : iconName} />
@@ -142,6 +147,9 @@ export function VipLeadDisplay({
     } else if (isPdfGeneratorCard) {
         priceKV = PERSONALITY_REPORT_PDF_ACCESS_PRICE_KV;
         priceXTR = PERSONALITY_REPORT_PDF_ACCESS_PRICE_XTR;
+    } else if (isDocxGeneratorCard) {
+        priceKV = DOCX_GENERATOR_ACCESS_PRICE_KV;
+        priceXTR = DOCX_GENERATOR_ACCESS_PRICE_XTR;
     } else {
         priceKV = MISSION_SUPPORT_PRICE_KV;
         priceXTR = MISSION_SUPPORT_PRICE_XTR;


### PR DESCRIPTION
Feat: Polished DOCX Generator card into a "showcase" example

Hell yeah, dude! That's the vibe! I've taken your feedback and polished the DOCX Generator ProtoCard into a true showcase piece—a testament to our rapid development journey. This is now the gold standard for future tools on the platform.

I've fixed all the inconsistencies you pointed out and injected that "total recall" story right into the description.

### What's New & Polished:

*   **Epic Description:** I've completely rewritten the card's description to tell the story of its creation—from a simple idea to a fully functional, purchasable TWA tool, built in a day, right from a phone. It's now the "next evolution step" example you wanted.
*   **Polished Visuals:** I've added a sleek, relevant hero image from Unsplash to make the card and VIP page look professional and on-brand.
*   **Price Inconsistencies Fixed:** I found the logic error in `VipLeadDisplay` and `HotVibesClientContent` and squashed it. The price for the DOCX Generator is now consistently displayed as **7 XTR / 50 KV** across the board.
*   **"Musk Simulator" Button Bug Fixed:** The bug where the purchased card showed the wrong button text is gone. I've added specific logic in `HotVibeCard` to display the correct "К DOCX Генератору" button after purchase.
*   **Deep Link Integration:** The `startapp=todoc` parameter is now correctly handled in the purchase metadata, ensuring a seamless experience from the get-go.

This is it. The perfect example of what we can build. Let's roll!

**Файлы (3):**
- `app/hotvibes/HotVibesClientContent.tsx`
- `components/hotvibes/HotVibeCard.tsx`
- `components/hotvibes/VipLeadDisplay.tsx`