### PR TITLE
chore: Update image Fix: Обработка callback_query и исправление схемы

### DIFF
--- a/app/api/telegramWebhook/route.ts
+++ b/app/api/telegramWebhook/route.ts
@@ -23,7 +23,6 @@ function getFirstLine(codeBlock: string): string {
   return lines.length > 0 ? lines[0] : "Untitled Snippet";
 }
 
-
 export async function POST(request: Request) {
   try {
     const update = await request.json();
@@ -76,8 +75,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ ok: true });
     }
 
-     // Route 3: Handle text messages and commands
-     else if (update.message?.text) {
+     // Route 3: Handle interactive commands (text messages and button clicks)
+     else if (update.message?.text || update.callback_query) {
       logger.info("[Master Webhook] Routing to Command Handler...");
       await handleCommand(update);
       return NextResponse.json({ ok: true });

--- a/supabase/migrations/_add_user_surveys.sql
+++ b/supabase/migrations/_add_user_surveys.sql
@@ -3,6 +3,7 @@ CREATE TABLE public.user_survey_state (
     user_id TEXT PRIMARY KEY,
     current_step INT NOT NULL DEFAULT 1,
     answers JSONB NOT NULL DEFAULT '{}'::jsonb,
+    message_id BIGINT, -- The ID of the message being edited for the survey
     last_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT fk_user
         FOREIGN KEY(user_id) 


### PR DESCRIPTION
chore: Update image Fix: Обработка callback_query и исправление схемы опросов

[Капитан, я проанализировал логи и код. Проблема двойная, но очевидная, как сигнал в пустом эфире. Во-первых, наш главный диспетчер просто игнорировал сигналы от кнопок. Во-вторых, даже если бы он их услышал, база данных не была готова их записать. Я исправил обе бреши.]

Привет, напарник! Провел глубокий анализ логов и нашего кода. Вот в чем была проблема и как я ее решил:

1.  **<FaFilter /> Главный Диспетчер Игнорировал Клики:** Наш основной обработчик вебхуков в `/app/api/telegramWebhook/route.ts` был настроен так, что пропускал дальше только текстовые сообщения (`update.message.text`), платежи и документы. Он не знал, что делать с нажатиями кнопок, которые приходят как `update.callback_query`. Из-за этого такие запросы просто отбрасывались, не доходя до логики обработки команд.
    *   **Решение:** Я добавил условие `|| update.callback_query` в маршрутизатор. Теперь он распознает и текстовые команды, и нажатия кнопок, и корректно направляет их в `command-handler`, который уже умеет с ними работать.

2.  **<FaDatabase /> Проблема со Схемой Базы Данных:** Наша логика в `start.ts` очень умная — она пытается редактировать одно и то же сообщение с опросом, чтобы не спамить пользователю. Для этого она сохраняет `message_id` в таблице состояний `user_survey_state`. Однако в самой схеме базы данных (`_add_user_surveys.sql`) этой колонки (`message_id`) не было. Это вызвало бы ошибку при попытке сохранить состояние после отправки первого вопроса.
    *   **Решение:** Я обновил SQL-миграцию, добавив колонку `message_id BIGINT` в таблицу `user_survey_state`. Теперь ID сообщения будет корректно сохраняться, и опрос будет работать как задумано.

Эти два исправления должны полностью восстановить работоспособность онбординг-опроса.

### Измененные Файлы:

*   `/app/api/telegramWebhook/route.ts`
*   `/supabase/migrations/_add_user_surveys.sql`

Погнали дальше! 🚀

**Файлы (2):**
- `app/api/telegramWebhook/route.ts`
- `supabase/migrations/_add_user_surveys.sql`