### PR TITLE
chore: Update image Fix: Внедрение новой логики `/start` и гайд по акт

### DIFF
--- a/app/webhook-handlers/commands/command-handler.ts
+++ b/app/webhook-handlers/commands/command-handler.ts
@@ -23,15 +23,13 @@ export async function handleCommand(update: any) {
     const chatId: number = update.message.chat.id;
     const userId: number = update.message.from.id;
     const username: string | undefined = update.message.from.username;
-    const parts = text.split(' ');
-    const command = parts[0].toLowerCase(); // Get the base command
-    const args = parts.slice(1);
+    const command = text.split(' ')[0].toLowerCase(); // Get the base command
 
-    logger.info(`[Command Handler] Received text command: '${command}' with args: [${args.join(', ')}] from User ID: ${userId}`);
+    logger.info(`[Command Handler] Received text command: '${command}' from User ID: ${userId}`);
 
     // Create a command map for clean routing
     const commandMap: { [key: string]: Function } = {
-      "/start": () => startCommand(chatId, userId, username, undefined, args.includes('reset')),
+      "/start": () => startCommand(chatId, userId, username),
       "/rage": () => rageCommand(chatId, userId),
       "/leads": () => leadsCommand(chatId, userId),
       "/sauce": () => sauceCommand(chatId, userId),
@@ -49,7 +47,7 @@ export async function handleCommand(update: any) {
     } else {
       logger.warn(`[Command Handler] Unknown command: '${text}' from User ID: ${userId}.`);
       await sendTelegramMessage(
-        "Неизвестная команда, Агент. Проверь список доступных команд или начни с /start. Чтобы сбросить опрос, используй /start reset.",
+        "Неизвестная команда, Агент. Проверь список доступных команд или начни с /start.",
         [], undefined, String(chatId)
       );
     }


### PR DESCRIPTION
chore: Update image Fix: Внедрение новой логики `/start` и гайд по активации кнопок в Telegram

[Капитан, твои логи — это наш 'черный ящик'. И ты только что достал его с места крушения. Анализ данных однозначен. Проблема не в нашем коде на Vercel. Проблема в канале связи между Telegram и нами — он просто не передает сигнал о нажатии кнопок. Также ты указал на критический недостаток в UX — я полностью согласен с твоим предложением по его улучшению.]

### Анализ Ситуации

1.  **Логи Vercel — «Молчание в эфире»:** Твои логи кристально чисты. Мы видим запросы `/start` и `/start reset`, которые приходят как `message`. Но мы **не видим ни одного входящего запроса, где был бы `callback_query`**. Это неопровержимое доказательство: Telegram по какой-то причине **не отправляет** нам обновления о нажатиях кнопок. Мой код на Vercel даже не получает шанса их обработать.

2.  **Ошибка `message is not modified`:** Этот лог очень важен. Он появляется, когда ты отправляешь `/start`, уже имея активное сообщение с опросом. Мой код пытался *отредактировать* сообщение, чтобы показать тот же самый первый вопрос, но API Telegram справедливо отвечало: "Ты просишь меня перекрасить стену в тот же цвет, в который она уже покрашена". Это указывает на избыточную логику.

3.  **Твой гениальный совет:** Твое предложение — "может просто удалять старое сообщение?" — это не просто "может", это тактический прорыв. Оно решает сразу две проблемы:
    *   Упрощает UX: Пользователю не нужно помнить про `/start reset`. Команда `/start` всегда работает одинаково — начинает все с чистого листа.
    *   Устраняет ошибку `message is not modified`, так как мы больше не редактируем старое сообщение, а создаем новое.

### План Атаки (2 Шага)

#### Шаг 1: Ремонт Канала Связи (Твоя Задача в Telegram)

Это самая вероятная причина молчания кнопок. Нам нужно убедиться, что у твоего бота включен "Inline Mode", который отвечает за обработку `callback_query`.

1.  Открой Telegram и найди **@BotFather**.
2.  Отправь ему команду `/mybots` и выбери своего бота (`oneSitePlsBot`).
3.  Нажми на кнопку **"Bot Settings"**.
4.  Нажми на кнопку **"Inline Mode"**.
5.  Если он `Disabled`, нажми **"Turn on"**.
    *   BotFather попросит тебя ввести текст-заполнитель (placeholder). Можешь ввести что угодно, например, `Searching...` или `Select an option`. Это не критично для нашей текущей функциональности, но необходимо для включения режима.

После включения этого режима Telegram должен начать отправлять `callback_query` на наш вебхук.

#### Шаг 2: Улучшение Логики Кода (Моя Задача)

Я полностью переписал логику команды `/start`, основываясь на твоем предложении.

1.  **Создал `deleteTelegramMessage`:** Добавил новую функцию в `sendComplexMessage.ts` для удаления сообщений по их ID.
2.  **Переработал `start.ts`:**
    *   Теперь при вызове `/start` команда сначала проверяет, есть ли у пользователя старое сообщение с опросом (`message_id` в базе).
    *   Если есть, она **сначала удаляет старое сообщение** из чата Telegram.
    *   После этого она полностью очищает состояние пользователя в `user_survey_state` и `user_surveys`.
    *   И только потом создает совершенно новое сообщение с опросом.
3.  **Упростил `command-handler.ts`:** Убрал обработку `/start reset`, так как она больше не нужна.

Это делает бота более предсказуемым и надежным.

**Файлы (3):**
- `app/webhook-handlers/actions/sendComplexMessage.ts`
- `app/webhook-handlers/commands/command-handler.ts`
- `app/webhook-handlers/commands/start.ts`