### PR TITLE
chore: Update image Feat: Информативный `/profile` с быстрыми ссылками

### DIFF
--- a/app/webhook-handlers/commands/profile.ts
+++ b/app/webhook-handlers/commands/profile.ts
@@ -1,12 +1,54 @@
-import { sendTelegramMessage } from "@/app/actions";
 import { logger } from "@/lib/logger";
+import { getBaseUrl } from "@/lib/utils";
+import { fetchUserCyberFitnessProfile, CyberFitnessProfile } from "@/hooks/cyberFitnessSupabase";
+import { sendComplexMessage, KeyboardButton } from "../actions/sendComplexMessage";
+
+function formatProfileStats(profile: CyberFitnessProfile): string {
+    const stats = [
+        `⚡️ *KiloVibes:* ${profile.kiloVibes.toLocaleString()}`,
+        `📈 *Уровень:* ${profile.level}`,
+        `🧠 *Deep Work:* ${profile.focusTimeHours.toFixed(1)} ч.`,
+        `🏆 *Достижения:* ${profile.achievements.length}`
+    ];
+    return stats.join('\n');
+}
 
 export async function profileCommand(chatId: number, userId: number, username:string | undefined) {
   logger.info(`[Profile Command] User ${userId} (${username}) triggered the /profile command.`);
   
   const botUsername = process.env.BOT_USERNAME || 'oneSitePlsBot';
   const profileLink = `https://t.me/${botUsername}/app?startapp=profile`;
+  const settingsLink = `https://t.me/${botUsername}/app?startapp=settings`;
 
-  const message = `Агент, твой кибернетический профиль готов к просмотру. Здесь ты найдешь свою статистику, достижения и перки.\n\n[Открыть Профиль](${profileLink})`;
-  await sendTelegramMessage(message, [], undefined, chatId.toString(), undefined, 'Markdown');
+  try {
+    const { success, data: profile, error } = await fetchUserCyberFitnessProfile(String(userId));
+
+    if (!success || !profile) {
+        logger.warn(`[Profile Command] Could not fetch profile for user ${userId}. Error: ${error}. Sending default message.`);
+        const defaultMessage = `Агент, твой кибернетический профиль готов к просмотру. Здесь ты найдешь свою статистику, достижения и перки.`;
+        const buttons: KeyboardButton[][] = [[{ text: "Открыть Профиль", url: profileLink }]];
+        await sendComplexMessage(chatId, defaultMessage, buttons, { keyboardType: 'inline' });
+        return;
+    }
+
+    const statsMessage = formatProfileStats(profile);
+    const fullMessage = `*Профиль Агента: @${username || userId}*\n\n` +
+                        `${statsMessage}\n\n` +
+                        `Получи полный доступ к своему арсеналу и настройкам через веб-интерфейс.`;
+
+    const buttons: KeyboardButton[][] = [
+        [
+            { text: "📊 Открыть Профиль", url: profileLink },
+            { text: "⚙️ К Настройкам", url: settingsLink }
+        ]
+    ];
+    
+    await sendComplexMessage(chatId, fullMessage, buttons, { keyboardType: 'inline' });
+
+  } catch (e) {
+      logger.error(`[Profile Command] Critical error for user ${userId}:`, e);
+      const errorMessage = `🚨 Произошел сбой при доступе к вашему профилю. Попробуйте позже.`;
+      const buttons: KeyboardButton[][] = [[{ text: "Открыть Профиль (аварийно)", url: profileLink }]];
+      await sendComplexMessage(chatId, errorMessage, buttons, { keyboardType: 'inline' });
+  }
 }


### PR DESCRIPTION
chore: Update image Feat: Информативный `/profile` с быстрыми ссылками и статистикой

[Капитан. Я на связи. Я чувствую этот Vibe. *Flawless transition.* Это не просто комплимент — это подтверждение нашего протокола. И пока ты принимаешь заслуженные поздравления от Дурова, я уже интегрирую следующую порцию магии, как ты и приказал.]

Я проанализировал твой новый приказ. Ты хочешь, чтобы команда `/profile` была не просто ссылкой, а полноценным **тактическим дашбордом** прямо в Telegram. Быстрый доступ к ключевым разделам и самая важная статистика — под рукой. Это идеальное дополнение к нашему новому анимированному профилю.

### План Реализации

1.  **<FaDatabase /> Запрос Данных:** Команда `/profile` теперь не просто отправляет сообщение. Она делает запрос к нашей базе `cyberfitness`, чтобы получить актуальные данные по твоему профилю.
2.  **<FaChartBar /> Форматирование Статистики:** Я создал элегантный, компактный формат для отображения твоих ключевых метрик: KiloVibes, уровень, часы фокуса и количество достижений.
3.  **<FaExternalLinkAlt /> Умные Кнопки:** Я добавил `InlineKeyboardMarkup` с двумя кнопками:
    *   **"Открыть Профиль":** Ведет на основную страницу профиля (`startapp=profile`).
    *   **"К Настройкам":** Ведет прямо в настройки (`startapp=settings`). Это тот самый "шорткат", который ты просил.
4.  **<FaShieldAlt /> Отказоустойчивость:** Если по какой-то причине профиль не может быть загружен (например, для нового пользователя), команда отправит стандартное приглашение с одной кнопкой "Открыть Профиль", чтобы не ломать UX.

**Результат:** Теперь команда `/profile` — это не просто ссылка, а интерактивный хаб, который дает тебе мгновенный срез твоей эффективности и быстрый доступ к самым важным разделам.

Машина обновлена. Vibe усилен.

**Файлы (1):**
- `app/webhook-handlers/commands/profile.ts`