### PR TITLE
⚡: Okay, here's a refactored version of your startCommand handler, inc

### DIFF
--- a/app/webhook-handlers/commands/content/start_survey_questions.ts
+++ b/app/webhook-handlers/commands/content/start_survey_questions.ts
@@ -1,0 +1,37 @@
+export interface SurveyQuestion {
+  step: number;
+  key: string;
+  question: string;
+  answers?: { text: string }[]; // Optional predefined answers
+  free_answer?: boolean; // Flag to allow free-form answers
+}
+
+export const answerTexts: Record<string, string> = {
+  purpose: "Цель",
+  experience: "Опыт",
+  motive: "Мотивация",
+}
+
+export const surveyQuestions: SurveyQuestion[] = [
+  {
+    step: 1,
+    key: "purpose",
+    question: "👋 Привет, Агент! Рад видеть тебя в штабе CyberVibe. Чтобы я мог помочь тебе максимально эффективно, скажи, **какая твоя основная цель здесь?**",
+    answers: [{ text: "👨‍💻 Хочу кодить/контрибьютить" }, { text: "🚀 У меня есть идея/проект" }, { text: "🤔 Просто изучаю, что за Vibe" }],
+    free_answer: true, // Allow free-form answers
+  },
+  {
+    step: 2,
+    key: "experience",
+    question: "Отлично! А какой у тебя **опыт в разработке**, если не секрет? Это поможет подобрать задачи по твоему скиллу.",
+    answers: [{ text: "👶 Я нуб, но хочу учиться" }, { text: "😎 Кое-что умею (Junior/Middle)" }, { text: "🤖 Я и есть машина (Senior+)" }, { text: "💡 Я не кодер, я идеолог" }],
+    free_answer: true, // Allow free-form answers
+  },
+  {
+    step: 3,
+    key: "motive",
+    question: "Понял. И последний вопрос: **что для тебя самое важное в проекте?**",
+    answers: [{ text: "💸 Заработать" }, { text: "🎓 Научиться новому" }, { text: "🕹️ Получить фан и погонять AI" }, { text: "🌍 Изменить мир, очевидно" }],
+    free_answer: true, // Allow free-form answers
+  },
+];

--- a/app/webhook-handlers/commands/start.ts
+++ b/app/webhook-handlers/commands/start.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger";
 import { getBaseUrl } from "@/lib/utils";
 import { howtoCommand } from "./howto";
 import { sendComplexMessage, deleteTelegramMessage, KeyboardButton } from "../actions/sendComplexMessage";
+import { surveyQuestions, SurveyQuestion, answerTexts } from "./content/start_survey_questions"; // Import the questions
 
 interface SurveyState {
   user_id: string;
@@ -12,23 +13,25 @@ interface SurveyState {
   message_id?: number | null;
 }
 
-const surveyQuestions = [
-  { step: 1, key: "purpose", question: "👋 Привет, Агент! Рад видеть тебя в штабе CyberVibe. Чтобы я мог помочь тебе максимально эффективно, скажи, **какая твоя основная цель здесь?**", answers: [ { text: "👨‍💻 Хочу кодить/контрибьютить" }, { text: "🚀 У меня есть идея/проект" }, { text: "🤔 Просто изучаю, что за Vibe" } ]},
-  { step: 2, key: "experience", question: "Отлично! А какой у тебя **опыт в разработке**, если не секрет? Это поможет подобрать задачи по твоему скиллу.", answers: [ { text: "👶 Я нуб, но хочу учиться" }, { text: "😎 Кое-что умею (Junior/Middle)" }, { text: "🤖 Я и есть машина (Senior+)" }, { text: "💡 Я не кодер, я идеолог" } ]},
-  { step: 3, key: "motive", question: "Понял. И последний вопрос: **что для тебя самое важное в проекте?**", answers: [ { text: "💸 Заработать" }, { text: "🎓 Научиться новому" }, { text: "🕹️ Получить фан и погонять AI" }, { text: "🌍 Изменить мир, очевидно" } ]},
-];
-
 const handleSurveyCompletion = async (chatId: number, state: SurveyState, username?: string) => {
   const { answers, user_id } = state;
 
   await supabaseAdmin.from("user_surveys").insert({ user_id, username: username || "unknown", survey_data: answers });
   await supabaseAdmin.from("user_survey_state").delete().eq('user_id', user_id);
 
-  const adminSummary = `🚨 **Новый Агент прошел онбординг!**\n- **User:** @${username || user_id} (${user_id})\n- **Цель:** ${answers.purpose || 'не указана'}\n- **Опыт:** ${answers.experience || 'не указан'}\n- **Мотивация:** ${answers.motive || 'не указан'}`;
+  let adminSummary = `🚨 **Новый Агент прошел онбординг!**\n- **User:** @${username || user_id} (${user_id})\n`;
+  for (const key in answers) {
+    adminSummary += `- **${answerTexts[key] || key}:** ${answers[key] || 'не указана'}\n`;
+  }
   await notifyAdmin(adminSummary);
 
-  const summary = `✅ **Опрос Завершен!**\nТвои ответы записаны. Спасибо! Теперь клавиатура убрана. Используй /howto, чтобы получить рекомендованные гайды, или /help для списка всех команд.`;
-  
+
+  let summary = `✅ **Опрос Завершен!**\nТвои ответы записаны. Спасибо!\n`;
+  for (const key in answers) {
+    summary += `- **${answerTexts[key] || key}:** ${answers[key] || 'не указана'}\n`;
+  }
+  summary += `Теперь клавиатура убрана. Используй /howto, чтобы получить рекомендованные гайды, или /help для списка всех команд.`;
+
   await sendComplexMessage(chatId, summary, [], { removeKeyboard: true });
 };
 
@@ -41,19 +44,19 @@ export async function startCommand(chatId: number, userId: number, username?: st
     await supabaseAdmin.from("user_surveys").delete().eq('user_id', userIdStr);
 
     const { data: newState, error } = await supabaseAdmin
-        .from("user_survey_state")
-        .insert({ user_id: userIdStr, current_step: 1, answers: {} })
-        .select().single();
-    
+      .from("user_survey_state")
+      .insert({ user_id: userIdStr, current_step: 1, answers: {} })
+      .select().single();
+
     if (error || !newState) {
-        logger.error('[StartCommand V4] Failed to create new survey state', error);
-        return;
+      logger.error('[StartCommand V4] Failed to create new survey state', error);
+      return;
     }
 
     const question = surveyQuestions.find(q => q.step === newState.current_step)!;
-    const buttons = question.answers.map(a => ([{ text: a.text }]));
+    const buttons = question.answers ? question.answers.map(a => ([{ text: a.text }])) : [];  // Handle no predefined answers
 
-    await sendComplexMessage(chatId, question.question, buttons, { keyboardType: 'reply' });
+    await sendComplexMessage(chatId, question.question, buttons, { keyboardType: question.answers ? 'reply' : 'remove' }); // Conditionally show keyboard
 
   } else {
     // This is not a /start command, so it must be an answer to a question.
@@ -66,18 +69,21 @@ export async function startCommand(chatId: number, userId: number, username?: st
     }
 
     const currentQuestion = surveyQuestions.find(q => q.step === currentState.current_step)!;
-    const isValidAnswer = currentQuestion.answers.some(a => a.text === text);
 
-    if (!isValidAnswer) {
-      logger.warn(`[StartCommand V4] Invalid answer "${text}" for step ${currentState.current_step}. Resending question.`);
-      const buttons = currentQuestion.answers.map(a => ([{ text: a.text }]));
-      await sendComplexMessage(chatId, `Неверный ответ. Пожалуйста, выбери один из вариантов на клавиатуре.\n\n${currentQuestion.question}`, buttons, { keyboardType: 'reply' });
-      return;
+    if (currentQuestion.answers && !currentQuestion.free_answer) { // Validate only if predefined answers exist AND free answer is not allowed
+      const isValidAnswer = currentQuestion.answers.some(a => a.text === text);
+
+      if (!isValidAnswer) {
+        logger.warn(`[StartCommand V4] Invalid answer "${text}" for step ${currentState.current_step}. Resending question.`);
+        const buttons = currentQuestion.answers.map(a => ([{ text: a.text }]));
+        await sendComplexMessage(chatId, `Неверный ответ. Пожалуйста, выбери один из вариантов или введи свой ответ.\n\n${currentQuestion.question}`, buttons, { keyboardType: 'reply' });
+        return;
+      }
     }
 
     const newAnswers = { ...currentState.answers, [currentQuestion.key]: text };
     const nextStep = currentState.current_step + 1;
-    
+
     if (nextStep > surveyQuestions.length) {
       // Survey is complete
       await handleSurveyCompletion(chatId, { ...currentState, answers: newAnswers }, username);
@@ -85,8 +91,24 @@ export async function startCommand(chatId: number, userId: number, username?: st
       // Move to the next question
       await supabaseAdmin.from("user_survey_state").update({ current_step: nextStep, answers: newAnswers }).eq('user_id', userIdStr);
       const nextQuestion = surveyQuestions.find(q => q.step === nextStep)!;
-      const buttons = nextQuestion.answers.map(a => ([{ text: a.text }]));
-      await sendComplexMessage(chatId, nextQuestion.question, buttons, { keyboardType: 'reply' });
+      const buttons = nextQuestion.answers ? nextQuestion.answers.map(a => ([{ text: a.text }])) : [];
+
+      // Remove keyboard if no answers, otherwise show reply keyboard
+      await sendComplexMessage(chatId, nextQuestion.question, buttons, { keyboardType: nextQuestion.answers ? 'reply' : 'remove' });
     }
   }
 }
+/*
+Key improvements and explanations:
+
+• start_survey_questions.ts: Holds the surveyQuestions array and the SurveyQuestion interface, making the survey definition separate and manageable. Includes the free_answer boolean on each question.
+• Import: The startCommand function now imports surveyQuestions from the separate file.
+• free_answer Flag: The SurveyQuestion interface now includes a free_answer: boolean field. If this is true for a question, the answer validation is skipped, allowing the user to enter any text.
+• Conditional Answer Validation: The code now checks if (currentQuestion.answers && !currentQuestion.free_answer) before validating the answer. This makes sure the validation is only done when there are predefined answers AND the question doesn't allow a free answer.
+• Dynamic Keyboards: The sendComplexMessage call now includes the check keyboardType: nextQuestion.answers ? 'reply' : 'remove'. This means that if a question doesn't have predefined answers (and therefore nextQuestion.answers is undefined), the keyboard will be removed automatically.
+• Handling No Predefined Answers: The code now handles questions without predefined answers by checking if question.answers exists before mapping to buttons. If it doesn't exist, an empty array is used.
+• Clearer Logic: The logic for determining whether to validate the answer and whether to show the keyboard is now clearer and more concise.
+• Dynamic Result Message: The handleSurveyCompletion function now dynamically builds the summary message using a loop that iterates through the answers object. The keys from the survey questions are used as labels in the summary.
+• answerTexts map Added a map to provide verbose names for survey keys, used in summary to show user readable text
+• Error Handling & Logging: The logging statements remain, which are crucial for debugging.
+• Typescript: Maintained strong typing.


### PR DESCRIPTION
⚡: Okay, here's a refactored version of your startCommand handler, incorporating the changes you requested: loading survey questions from a separate file, allowing free-form answers, and using keys for dynamic result message phrasing.

1. Create start_survey_questions.ts:

2. Refactor start.ts:

How to Use:

1. Create /app/webhook-handlers/commands/start_survey_questions.ts and paste the code. Modify the survey questions there. Set free_answer: true for questions where you want to allow free-form input. If you want to remove predefined answers entirely, just remove the answers property from the question object.
2. Update /app/webhook-handlers/commands/start.ts with the refactored code.
3. Deploy: Deploy your changes.

Example Question without Predefined Answers:

To make the first question completely open-ended, change it in start_survey_questions.ts to:
`
  {
    step: 1,
    key: "purpose",
    question: "👋 Привет, Агент! Рад видеть тебя в штабе CyberVibe. Чтобы я мог помочь тебе максимально эффективно, скажи, **какая твоя основная цель здесь?**",
    free_answer: true,
  },
`
This will remove the keyboard for that question and allow the user to type in whatever they want.

This refactored code provides a much more flexible and maintainable survey system. Remember to adjust the questions in start_survey_questions.ts to fit your specific needs.

**Файлы (2):**
- `app/webhook-handlers/commands/content/start_survey_questions.ts`
- `app/webhook-handlers/commands/start.ts`