### PR TITLE
[Acknowledged. Live fire testing initiated. Analyzing real-time failur

### DIFF
--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -64,13 +64,15 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         return;
       }
       
-      const { data: ownedCrew } = await supabaseAdmin.from('crews').select('id, slug, name, logo_url').eq('owner_id', dbUser.user_id).single();
+      // FIX: Use .maybeSingle() to gracefully handle cases where the user is not an owner.
+      const { data: ownedCrew } = await supabaseAdmin.from('crews').select('id, slug, name, logo_url').eq('owner_id', dbUser.user_id).maybeSingle();
       if (ownedCrew) {
         setUserCrewInfo({ ...ownedCrew, is_owner: true });
         return;
       }
       
-      const { data: memberCrew } = await supabaseAdmin.from('crew_members').select('crews(id, slug, name, logo_url)').eq('user_id', dbUser.user_id).eq('status', 'active').single();
+      // FIX: Use .maybeSingle() to gracefully handle cases where the user is not a member.
+      const { data: memberCrew } = await supabaseAdmin.from('crew_members').select('crews(id, slug, name, logo_url)').eq('user_id', dbUser.user_id).eq('status', 'active').maybeSingle();
       if (memberCrew && memberCrew.crews) {
         setUserCrewInfo({ ...(memberCrew.crews as any), is_owner: false });
       } else {
@@ -123,7 +125,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       dbUserExists: !!contextValue.dbUser,
       isAdmin: typeof contextValue.isAdmin === 'function' ? contextValue.isAdmin() : 'N/A',
       startParamPayload: contextValue.startParamPayload,
-      userCrewInfo: contextValue.userCrewInfo ? { name: contextValue.userCrewInfo.name, is_owner: contextValue.userCrewInfo.is_owner } : null
+      userCrewInfo: contextValue.userCrewInfo ? { name: contextValue.userCrewInfo.name, is_owner: contextValue.userCrewInfo.is_owner } : null,
     });
   }, [contextValue.isAuthenticated, contextValue.isLoading, contextValue.isAuthenticating, contextValue.dbUser, contextValue.user, contextValue.startParamPayload, contextValue.isAdmin, contextValue.userCrewInfo]);
 
@@ -155,7 +157,7 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
              toast.dismiss("mock-user-info-toast");
         }
 
-        if (telegramHookData.isAuthenticated && !error) { // Используем isAuthenticated из хука
+        if (telegramHookData.isAuthenticated && !error) {
             toast.dismiss("auth-error-toast");
              if (!isClient || document.visibilityState === 'visible') {
                  toast.success("Пользователь авторизован", { id: "auth-success-toast", duration: 2500 });
@@ -183,12 +185,12 @@ export const useAppContext = (): AppContextData => {
      return {
         tg: null, user: null, dbUser: null, isInTelegramContext: false, isAuthenticated: false,
         isLoading: true, isAuthenticating: true, error: null,
-        isAdmin: () => { return false; },
+        isAdmin: () => false,
         openLink: (url: string) => {},
         close: () => {},
         showPopup: (params: any) => {},
         sendData: (data: string) => {},
-        getInitData: () => { return null; },
+        getInitData: () => null,
         expand: () => {},
         setHeaderColor: (color: string) => {},
         setBackgroundColor: (color: string) => {},


### PR DESCRIPTION
[Acknowledged. Live fire testing initiated. Analyzing real-time failure log. Status 406: "Not Acceptable". This is a PostgREST error. The database is rejecting our request format. The Architect is online.]

Captain,

Excellent. The system is under fire, and it's showing us its weak points. This is exactly what we wanted. A `406 Not Acceptable` error from Supabase is a classic signature of a PostgREST negotiation failure. It means our front-end is asking for data in a format the back-end isn't configured to provide for that specific query.

I've analyzed the log. The query is `GET /rest/v1/crews?select=...&owner_id=eq...`. The key part is that it's asking for a list of crews, but the `.single()` method in our `AppContext` is forcing Supabase to expect only one result. When Supabase finds zero results (as your new testers don't own any crews yet), the `.single()` call throws this specific error instead of returning an empty list.

This is a rookie mistake on my part. A fragile piece of code that breaks under expected conditions. It has been corrected.

### **PR: Fortify AppContext Against "Zero Result" Failures**

#### **Описание изменений:**

Это критическое исправление, повышающее отказоустойчивость всей системы. Предыдущая версия `AppContext` падала с ошибкой, если пользователь не был владельцем или членом экипажа, что блокировало загрузку для новых пользователей.

1.  **Усилен `AppContext.tsx`:**
    *   Запросы на получение информации об экипаже (`ownedCrew`, `memberCrew`) теперь используют метод `.maybeSingle()` вместо `.single()`.
    *   Это позволяет коду **корректно обрабатывать ситуацию**, когда пользователь не состоит ни в одном экипаже (результат `null`), вместо того чтобы вызывать сбой.
    *   Теперь приложение будет стабильно работать для всех пользователей, независимо от их статуса в экипаже.

---

### **The Fortified `AppContext.tsx`**

Here is the corrected code. This small change from `.single()` to `.maybeSingle()` makes the entire application more resilient and welcoming to new users who haven't joined a crew yet.

This correction should resolve the failure for new users and make the `/shift` command accessible to them once they join a crew. The live fire test is proving invaluable. Let the chaos continue.

**Файлы (1):**
- `contexts/AppContext.tsx`