### PR TITLE
Chore: Плановая оптимизация систем

### DIFF
--- a/supabase/migrations/YYYYMMDD_fix_crew_details_rpc.sql
+++ b/supabase/migrations/YYYYMMDD_fix_crew_details_rpc.sql
@@ -1,0 +1,56 @@
+-- Run this code in your Supabase SQL Editor to make the RPC resilient to empty relations.
+
+CREATE OR REPLACE FUNCTION get_public_crew_details(p_slug TEXT)
+RETURNS TABLE (
+    id UUID,
+    name TEXT,
+    description TEXT,
+    logo_url TEXT,
+    hq_location TEXT,
+    owner json,
+    members json,
+    vehicles json
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        c.id,
+        c.name,
+        c.description,
+        c.logo_url,
+        c.hq_location,
+        json_build_object('user_id', u.user_id, 'username', u.username) AS owner,
+        COALESCE(
+            (SELECT json_agg(json_build_object(
+                'user_id', m.user_id,
+                'username', mu.username,
+                'avatar_url', mu.avatar_url,
+                'role', m.role,
+                'status', m.status
+             ))
+             FROM public.crew_members m
+             JOIN public.users mu ON m.user_id = mu.user_id
+             WHERE m.crew_id = c.id),
+            '[]'::json
+        ) AS members,
+        COALESCE(
+            (SELECT json_agg(json_build_object(
+                'id', v.id,
+                'make', v.make,
+                'model', v.model,
+                'image_url', v.image_url
+             ))
+             FROM public.cars v
+             WHERE v.crew_id = c.id),
+            '[]'::json
+        ) AS vehicles
+    FROM
+        public.crews c
+    JOIN
+        public.users u ON c.owner_id = u.user_id
+    WHERE
+        lower(c.slug) = lower(p_slug);
+END;
+$$;


### PR DESCRIPTION
⚡:**[АНАЛИЗ УГРОЗЫ. ПРОВОЖУ ТРАССИРОВКУ ПОТОКА ДАННЫХ... ОБНАРУЖЕН РАЗРЫВ КОНТРАКТА.]**

Капитан.

Я проанализировал телеметрию сбоя, предоставленные тобой файлы и лог событий. Диагноз однозначен. Это классический случай нарушения цифрового контракта между слоями системы.

### Анализ Потока Сбоя

1.  **Источник Данных (База данных `Supabase`)**: Наша функция `get_public_crew_details` использует `json_agg` для сборки списков `members` и `vehicles`. **Ключевая уязвимость:** когда у команды нет участников или машин, `json_agg` для пустого набора данных возвращает `NULL`, а не пустой JSON-массив `[]`.
2.  **Слой Логики (Серверный Экшен `getPublicCrewInfo`)**: Этот экшен вызывает RPC, получает данные с `NULL` в полях `members` и/или `vehicles` и, не проводя санацию, передает их дальше клиенту в "сыром" виде. Он доверяет, что база данных вернет массив, но база данных нарушает это негласное соглашение.
3.  **Слой Представления (Клиент `/crews/[slug]/page.tsx`)**: Клиент получает объект `crew`, в котором `crew.members` или `crew.vehicles` могут быть `undefined` или `null` вместо ожидаемого массива. Хотя ты и предпринял попытки защитного программирования (`Array.isArray(...)`), в одном из путей рендеринга или обработки происходит попытка получить `.length` от этого самого `null`. Лог ошибки `Cannot read properties of undefined (reading 'length')` — это крик React о том, что он пытался измерить длину пустоты.

Проблема не в клиенте. Проблема в хрупкости потока данных. Мы не должны позволять "грязным" данным доходить до фронтенда. Мы должны обеззараживать их у источника.

### Стратегия Ликвидации Угрозы

Мы применим самый надежный метод: исправим контракт на уровне базы данных. Мы заставим RPC-функцию **гарантировать** возврат пустого массива, даже если данных нет.

Я модифицирую функцию `get_public_crew_details`, используя `COALESCE`. Эта функция проверяет первое значение, и если оно `NULL`, подставляет второе. В нашем случае, если `json_agg` вернет `NULL`, `COALESCE` подставит пустой JSON-массив `'[]'::json`.

Это — броня на уровне данных.

### PULL REQUEST

fix: Устранить сбой на странице команды из-за NULL в данных

Капитан, страница команды падала с ошибкой `Cannot read... (reading 'length')`, когда у команды не было участников или транспортных средств.

**Проблема:**
RPC-функция `get_public_crew_details` в Supabase использовала `json_agg`, которая возвращала `NULL` для пустых списков, а не пустой массив `[]`. Клиентский код, ожидая массив, падал при попытке доступа к свойству `.length` у `NULL`.

**Решение:**
Модифицирована SQL-функция `get_public_crew_details`. Поля `members` и `vehicles` обернуты в `COALESCE(..., '[]'::json)`. Это гарантирует, что функция всегда будет возвращать пустой массив `[]` вместо `NULL`, делая контракт данных с клиентом нерушимым и систему — более отказоустойчивой.

**Файлы (1):**
- `supabase/migrations/YYYYMMDD_fix_crew_details_rpc.sql`