### PR TITLE
Chore: Плановая оптимизация систем

### DIFF
--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -24,6 +24,7 @@ import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next"; 
 import { checkAndUnlockFeatureAchievement } from '@/hooks/cyberFitnessSupabase';
 import { useAppToast } from "@/hooks/useAppToast";
+import { useTelegramBackButton } from '@/hooks/useTelegramBackButton'; // ИМПОРТ НОВОГО ХУКА
 import Image from "next/image";
 import { Loading } from "@/components/Loading";
 import { cn } from "@/lib/utils";
@@ -67,6 +68,9 @@ function AppInitializers() {
   const { dbUser, isAuthenticated } = useAppContext();
   const { addToast } = useAppToast();
   const scrollAchievementUnlockedRef = useRef(false);
+
+  // ВЫЗЫВАЕМ ХУК ДЛЯ УПРАВЛЕНИЯ НАТИВНОЙ КНОПКОЙ "НАЗАД" В TELEGRAM
+  useTelegramBackButton();
   
   useFocusTimeTracker({
     inactiveTimeout: 60 * 1000, 

--- a/hooks/useTelegramBackButton.ts
+++ b/hooks/useTelegramBackButton.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useAppContext } from '@/contexts/AppContext';
+import { debugLogger as logger } from '@/lib/debugLogger';
+
+export function useTelegramBackButton() {
+  const { tg, isInTelegramContext } = useAppContext();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!isInTelegramContext || !tg?.BackButton) {
+      // Если мы не в Telegram или объект кнопки недоступен, ничего не делаем
+      return;
+    }
+
+    const backButton = tg.BackButton;
+
+    const handleBackClick = () => {
+      logger.info('[Telegram BackButton] Back button clicked. Navigating back.');
+      router.back();
+    };
+
+    // Показываем кнопку на всех страницах, кроме главной ('/')
+    if (pathname !== '/') {
+      if (!backButton.isVisible) {
+        logger.debug(`[Telegram BackButton] Path is "${pathname}". Showing button.`);
+        backButton.show();
+      }
+      // Устанавливаем или обновляем обработчик
+      backButton.onClick(handleBackClick);
+    } else {
+      // Скрываем кнопку на главной странице
+      if (backButton.isVisible) {
+        logger.debug(`[Telegram BackButton] Path is "/". Hiding button.`);
+        backButton.hide();
+      }
+    }
+
+    // Очистка при размонтировании компонента или изменении пути
+    return () => {
+      if (isInTelegramContext && tg?.BackButton) {
+        logger.debug(`[Telegram BackButton] Cleanup: removing onClick handler for path "${pathname}".`);
+        // Важно убирать обработчик, чтобы избежать утечек памяти или вызова старых функций
+        tg.BackButton.offClick(handleBackClick);
+      }
+    };
+  }, [pathname, router, tg, isInTelegramContext]); // Перезапускаем эффект при смене пути
+}


### PR DESCRIPTION
⚡:[АНАЛИЗ ЗАВЕРШЕН. ЗАДАЧА: ИНТЕГРАЦИЯ НАТИВНОЙ КНОПКИ "НАЗАД" TELEGRAM. ВЕКТОР: УПРАВЛЕНИЕ СОСТОЯНИЕМ НАВИГАЦИИ. СТАТУС: ГОТОВ К РЕАЛИЗАЦИИ.]

Капитан, я понял. Интеграция с нативной средой Telegram — это ключевой аспект нашего Вайба. Пользователь должен чувствовать, что приложение — это естественное продолжение мессенджера. Кнопка "Назад" — это не просто UI-элемент, это фундаментальный паттерн взаимодействия.

Вот план по ее внедрению:

1.  **Создание Хука `useTelegramBackButton`:** Мы создадим новый хук, который будет полностью инкапсулировать логику работы с `BackButton` Telegram. Он будет автоматически показывать кнопку на любой странице, кроме главной, и скрывать ее на главной.
2.  **Интеграция в `ClientLayout`:** Мы внедрим этот хук в наш главный компонент-обертку `ClientLayoutWrapper`, чтобы он работал на всех страницах приложения.
3.  **Логика Навигации:** Кнопка будет выполнять `router.back()`, обеспечивая стандартное и предсказуемое поведение "Назад".

Приступаем.

### 1. Создание Хука `useTelegramBackButton`

Создай новый файл `/hooks/useTelegramBackButton.ts`. Этот хук будет нашим централизованным контроллером для нативной кнопки.

### 2. Интеграция в `ClientLayout`

Теперь мы имплантируем наш новый хук в `ClientLayoutWrapper`. Он должен быть внутри `AppProvider`, чтобы иметь доступ к контексту Telegram. Лучшее место для этого — компонент `AppInitializers`, который уже существует для подобных глобальных инициализаций.

**Файл для изменения: `/components/layout/ClientLayout.tsx`**

[ПРИКАЗ ПРИНЯТ. ПРОТОКОЛ "ПОЛНОЕ РАЗВЕРТЫВАНИЕ" АКТИВИРОВАН. ВЫВОЖУ КОД БЕЗ СОКРАЩЕНИЙ.]

Капитан, твое требование ясно. Никаких сокращений, никаких "остальной код без изменений". Только полная, готовая к бою версия файла.

Я интегрировал новый хук `useTelegramBackButton` непосредственно в компонент `AppInitializers` внутри `ClientLayout.tsx`. Это гарантирует, что логика кнопки "Назад" будет инициализироваться один раз на глобальном уровне, как только контекст приложения будет готов.

Вот полная версия файла `/components/layout/ClientLayout.tsx` с внедренным функционалом.

### /components/layout/ClientLayout.tsx (полная версия)

### Итог

1.  **Хук `useTelegramBackButton`** создан и инкапсулирует всю логику.
2.  Хук интегрирован в **`ClientLayoutWrapper`** через `AppInitializers`, что обеспечивает его глобальную работу.
3.  Теперь при переходе на любую страницу, кроме главной (`/`), в интерфейсе Telegram Mini App появится нативная кнопка "Назад". При нажатии на нее будет выполнена стандартная навигация `назад`. На главной странице кнопка будет автоматически скрываться.

Задача выполнена. Система готова к следующей итерации.

**Файлы (2):**
- `hooks/useTelegramBackButton.ts`
- `components/layout/ClientLayout.tsx`