### PR TITLE
**[ДЕБАГ-РЕЖИМ АКТИВИРОВАН. СКАНИРУЮ КОД НА АНОМАЛИИ. ВАЙБ: БЕСПОЩАДНЫ

### DIFF
--- a/app/api/my/bookings/route.ts
+++ b/app/api/my/bookings/route.ts
@@ -17,16 +17,18 @@ export async function GET(request: Request) {
   }
 
   try {
+    logger.info('[GET /api/my/bookings] Fetching for userId:', userId);
     const { data, error } = await supabaseAnon.rpc('get_user_rentals_dashboard_new', { p_user_id: userId, p_minimal: false });
     
     if (error) {
-      logger.error('[GET /api/my/bookings] RPC error:', error);
+      logger.error('[GET /api/my/bookings] RPC error details:', { code: error.code, message: error.message, hint: error.hint, details: error.details });
       return NextResponse.json({ error: 'Failed to fetch bookings: ' + error.message }, { status: 500 });
     }
 
+    logger.info('[GET /api/my/bookings] Data fetched successfully, length:', data?.length);
     return NextResponse.json(data || []);
   } catch (error) {
-    logger.error('[GET /api/my/bookings] Unexpected error:', error);
+    logger.error('[GET /api/my/bookings] Unexpected error details:', { message: error.message, stack: error.stack });
     return NextResponse.json({ error: 'Failed to fetch bookings' }, { status: 500 });
   }
 }

--- a/app/api/rules/rule-cube-basic/calendar/route.ts
+++ b/app/api/rules/rule-cube-basic/calendar/route.ts
@@ -1,0 +1,31 @@
+import { supabaseAnon } from '@/hooks/supabase'; // Используем anon для чтения
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+
+export async function GET() {
+  if (!supabaseAnon) {
+    logger.error('[GET /api/rules/rule-cube-basic/calendar] Supabase anon client unavailable.');
+    return NextResponse.json({ error: 'Database unavailable' }, { status: 500 });
+  }
+
+  try {
+    logger.info('[GET /api/rules/rule-cube-basic/calendar] Fetching calendar for vehicle_id: rule-cube-basic');
+    const { data, error } = await supabaseAnon
+      .from('rentals')
+      .select('rental_id, requested_start_date, requested_end_date, status, metadata')
+      .eq('vehicle_id', 'rule-cube-basic')
+      .order('requested_start_date', { ascending: true });
+
+    if (error) {
+      logger.error('[GET /api/rules/rule-cube-basic/calendar] Query error:', { message: error.message, details: error.details });
+      return NextResponse.json({ error: 'Failed to fetch calendar: ' + error.message }, { status: 500 });
+    }
+
+    logger.info('[GET /api/rules/rule-cube-basic/calendar] Calendar data fetched, length:', data?.length);
+    // Можно добавить логику для агрегации слотов, но для MVP возвращаем raw bookings
+    return NextResponse.json(data || []);
+  } catch (error) {
+    logger.error('[GET /api/rules/rule-cube-basic/calendar] Unexpected error:', { message: error.message, stack: error.stack });
+    return NextResponse.json({ error: 'Failed to fetch calendar' }, { status: 500 });
+  }
+}

--- a/app/rules/page.tsx
+++ b/app/rules/page.tsx
@@ -57,16 +57,27 @@ export default function RulesPage() {
 
       setIsFetching(true);
       try {
+        console.log('[CLIENT DEBUG] Starting fetch for calendar: /api/rules/rule-cube-basic/calendar');
         const calRes = await fetch('/api/rules/rule-cube-basic/calendar');
-        if (!calRes.ok) throw new Error('Не удалось загрузить календарь');
+        if (!calRes.ok) {
+          console.error('[CLIENT DEBUG] Calendar fetch failed with status:', calRes.status, 'body:', await calRes.text());
+          throw new Error('Не удалось загрузить календарь');
+        }
         const calData = await calRes.json();
+        console.log('[CLIENT DEBUG] Calendar data loaded:', calData);
         setCalendar(calData || []);
 
+        console.log('[CLIENT DEBUG] Starting fetch for bookings: /api/my/bookings?userId=', dbUser.user_id);
         const bookRes = await fetch(`/api/my/bookings?userId=${dbUser.user_id}`);
-        if (!bookRes.ok) throw new Error('Не удалось загрузить бронирования');
+        if (!bookRes.ok) {
+          console.error('[CLIENT DEBUG] Bookings fetch failed with status:', bookRes.status, 'body:', await bookRes.text());
+          throw new Error('Не удалось загрузить бронирования');
+        }
         const bookData = await bookRes.json();
+        console.log('[CLIENT DEBUG] Bookings data loaded:', bookData);
         setBookings(bookData || []);
       } catch (err) {
+        console.error('[CLIENT DEBUG] Fetch data error:', err.message, err.stack);
         setError('Ошибка загрузки данных. Попробуйте позже.');
       } finally {
         setIsFetching(false);


### PR DESCRIPTION
**[ДЕБАГ-РЕЖИМ АКТИВИРОВАН. СКАНИРУЮ КОД НА АНОМАЛИИ. ВАЙБ: БЕСПОЩАДНЫЙ, КАК ЛАЗЕРНЫЙ СКАЛЬПЕЛЬ. НАХОДИМ И УНИЧТОЖАЕМ БАГИ, КАПИТАН.]**

### Заголовок PR: Add debug logs to client and server for rules page data loading issue

### Описание
Капитан, привет! Проанализировал код и контекст. Ошибка "ошибка при загрузке данных" вылазит в клиенте на /app/rules/page.tsx в блоке catch внутри fetchData (useEffect). Это происходит, если один из fetch'ей фейлится: либо '/api/rules/rule-cube-basic/calendar', либо '/api/my/bookings?userId=...'. 

Что пытается загрузить страница:
- **Календарь (/api/rules/rule-cube-basic/calendar)**: Это для доступных слотов в 'rule-cube-basic'. Но в предоставленном коде **нет такого роута**! Вероятно, это опечатка или недостающий эндпоинт. Если он не существует, fetch вернёт 404, и это упадёт в catch без логов в Vercel/Supabase (потому что клиентский фетч). В Supabase должно быть что-то вроде RPC или таблицы для календаря (возможно, на основе rentals для vehicle_id='rule-cube-basic'). Проверь в Supabase: есть ли записи в 'rentals' с vehicle_id='rule-cube-basic'? Если роут не реализован, это и есть причина — добавь его на основе /api/cars или создай новый для календаря (фильтр по rentals).
- **Бронирования (/api/my/bookings?userId=...)**: Загружает пользовательские брони через RPC 'get_user_rentals_dashboard_new'. Ты изменил имя RPC на _new — проверь в Supabase, что функция именно так называется (не старое имя без _new). В коде /app/api/my/bookings/route.ts всё ссылается на _new, но если в других местах (например, в старом коде или Supabase) осталось старое, может быть несоответствие. В Supabase логи пусты, потому что если RPC не существует или параметры неверны, ошибка в RPC, но logger в роуте ловит и логирует. Проверь параметры: p_user_id и p_minimal=false. В rentals должны быть записи с metadata.type='rule' для твоего userId.

Общие проблемы:
- Нет роута для календаря — primary suspect.
- В Supabase: правила (rules) и мастер (rule-master-default) добавлены в 'cars' (из cars.csv), но для bookings это rentals. Убедись, что в 'cars' есть id='rule-cube-basic' и 'rule-master-default', owner_id правильный.
- Логи: Серверный logger.ts используется в /api/my/bookings и /api/rules/book, но для несуществующего роута Vercel может не логировать ничего (404 от Next.js). Клиентский: добавим console.error в page.tsx для детализации.
- Другие: В /api/rules/book есть создание booking в rentals с vehicle_id='rule-cube-basic' — если это работает, то rentals заполняются. Но для загрузки — проверь overlaps в rentals.

Чтобы продебажить: Добавляю логи в клиент (console.log/error) и сервер (logger). В page.tsx: логируем перед/после каждого fetch, и детали ошибки. В /api/my/bookings: больше деталей в logger. Также предлагаю stub-роут для календаря (если его нет) — простой GET, который дергает rentals для vehicle_id='rule-cube-basic' и возвращает слоты (на основе start/end dates). После теста: закоммить в Supabase, если RPC ок, и проверь данные в таблицах cars/rentals/users.

Если после логов увидишь конкретную ошибку (например, RPC not found), фиксим targeted. Давай, Капитан — это наш следующий трофей в войне с багами.

**Файлы (3):**
- `app/rules/page.tsx`
- `app/api/my/bookings/route.ts`
- `app/api/rules/rule-cube-basic/calendar/route.ts`