### PR TITLE
MapRiders: Telegram-first GPS, long-press meetup capture, speed-gradient route, UI & reducer updates

### DIFF
--- a/app/franchize/[slug]/map-riders/MapRiders_FixBook.md
+++ b/app/franchize/[slug]/map-riders/MapRiders_FixBook.md
@@ -1807,3 +1807,27 @@ Play sound при:
 8. **Constants over magic numbers** — `DEMO_TICK_MS`, `STALE_MS`, `EVICT_MS` как именованные константы.
 9. **Safety bounds in reducer** — privacy values clamped, no invalid state possible.
 10. **Hybrid location** — Telegram `requestLocation` как primary, browser API как fallback. Автоматический переключение без user intervention.
+
+---
+
+## Progress log — 2026-04-09 (Codex iteration)
+
+### Done in this pass (6)
+- [x] CRIT-1: added `MapInteractionCapture` and wired long-press meetup creation (`contextmenu` + `touchstart/touchend`).
+- [x] CRIT-3: rewrote `useLiveRiders` to Telegram-first (`requestLocation`) with browser geolocation fallback.
+- [x] CRIT-3: added `onPosition` optimistic local reducer updates + `isUsingTelegram` runtime flag.
+- [x] CRIT-3/LOW-1: added haptic pulse on accepted position updates.
+- [x] CRIT-5: hardened `RiderMarker` RAF interpolation with cancellation guard on unmount/restart.
+- [x] HIGH-3b: added standalone `SpeedGradientRoute.tsx` and rendered speed-band route segments + legend in overlay.
+
+### Still open from current FixBook scope
+- [ ] HIGH-5 privacy controls (full UI + server enforcement path still incomplete).
+- [ ] HIGH-6 session form fields expansion.
+- [ ] HIGH-7 meetup creation toast/UX flow polish.
+- [ ] HIGH-8/HIGH-9 clustering polish + drawer handle polish.
+- [ ] Remaining medium/low cleanup phases (mapPoints extraction, event bridge cleanup, audio polish, etc.).
+
+### Progress log — 2026-04-12 (follow-up after review comments)
+- [x] HIGH-6: added editable session form controls in rider panel (`rideName`, `vehicleLabel`, `rideMode`) with reducer-driven actions.
+- [x] HIGH-7: meetup creation UX improved (loading label + explicit success toast + form reset).
+- [x] CRIT-1 polish: touch tap no longer triggers meetup creation accidentally; only long-press creates point on touch.

--- a/components/map-canvas/RiderMarker.tsx
+++ b/components/map-canvas/RiderMarker.tsx
@@ -176,15 +176,17 @@ export const RiderMarker = memo(function RiderMarker({ rider, riderName, isSelec
 
     const start = performance.now();
     const durationMs = 650;
+    let cancelled = false;
 
     const step = (now: number) => {
+      if (cancelled) return;
       const progress = Math.min(1, (now - start) / durationMs);
       const eased = 1 - Math.pow(1 - progress, 3);
       const next: [number, number] = [from[0] + deltaLat * eased, from[1] + deltaLng * eased];
       positionRef.current = next;
       setPosition(next);
 
-      if (progress < 1) {
+      if (progress < 1 && !cancelled) {
         animationRef.current = requestAnimationFrame(step);
       } else {
         animationRef.current = null;
@@ -194,6 +196,7 @@ export const RiderMarker = memo(function RiderMarker({ rider, riderName, isSelec
     animationRef.current = requestAnimationFrame(step);
 
     return () => {
+      cancelled = true;
       if (animationRef.current) {
         cancelAnimationFrame(animationRef.current);
         animationRef.current = null;

--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -10,7 +10,9 @@ import dynamic from "next/dynamic";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { VibeContentRenderer } from "@/components/VibeContentRenderer";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAppContext } from "@/contexts/AppContext";
 import type { FranchizeCrewVM } from "@/app/franchize/actions";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
@@ -22,6 +24,7 @@ import { RiderMarkerLayer } from "@/components/map-riders/RiderMarkerLayer";
 import { RiderFAB } from "@/components/map-riders/RiderFAB";
 import { RidersDrawer } from "@/components/map-riders/RidersDrawer";
 import { StatusOverlay } from "@/components/map-riders/StatusOverlay";
+import { SpeedGradientRoute } from "@/components/map-riders/SpeedGradientRoute";
 import { MapRidersSkeleton } from "@/components/map-riders/LoadingSkeleton";
 
 // Lazy-load map (SSR disabled)
@@ -44,11 +47,26 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
   });
 
   // ── GPS tracking hook ──
-  useLiveRiders({
+  const { isUsingTelegram } = useLiveRiders({
     crewSlug,
     sessionId: state.sessionId,
     userId: dbUser?.user_id || null,
     enabled: state.shareEnabled && Boolean(state.sessionId),
+    onPosition: (point) => {
+      if (!dbUser?.user_id) return;
+      dispatch({
+        type: "rider/moved",
+        payload: {
+          user_id: dbUser.user_id,
+          lat: point.lat,
+          lng: point.lng,
+          speed_kmh: point.speedKmh,
+          heading: point.heading,
+          updated_at: point.capturedAt,
+        },
+        selfUserId: dbUser.user_id,
+      });
+    },
   });
 
   // ── Build map points from state ──
@@ -137,7 +155,9 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
               className="h-full min-h-[78vh] w-full md:min-h-[84vh]"
               tileLayer={mapData?.meta.tileLayer || "cartodb-dark"}
               onMapClick={(coords) => dispatch({ type: "ui/select-meetup-point", payload: coords })}
+              onMapLongPress={(coords) => dispatch({ type: "ui/select-meetup-point", payload: coords })}
             >
+              {state.sessionDetail?.points?.length ? <SpeedGradientRoute points={state.sessionDetail.points} /> : null}
               <RiderMarkerLayer />
             </RacingMap>
           ) : (
@@ -151,7 +171,7 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
         {/* Floating badges */}
         <div className="pointer-events-none relative z-20 flex min-h-[78vh] flex-col justify-between p-3 md:min-h-[84vh] md:p-6">
           <div className="flex flex-wrap gap-2">
-            <Badge className="border bg-black/55 text-white backdrop-blur-md">{useLeafletMap ? "Leaflet" : "VibeMap"}</Badge>
+            <Badge className="border bg-black/55 text-white backdrop-blur-md">{useLeafletMap ? `Leaflet${isUsingTelegram ? " + Telegram GPS" : " + Browser GPS"}` : "VibeMap"}</Badge>
             {mapData?.routes?.length ? <Badge className="border border-sky-300/50 bg-sky-500/20 text-sky-100">{mapData.routes.length} routes</Badge> : null}
             {state.liveRiders.size === 0 && state.sessions.length === 0 ? (
               <Badge className="border border-emerald-300/40 bg-emerald-500/20 text-emerald-100">Demo mode</Badge>
@@ -161,7 +181,7 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
             <div className="rounded-xl border border-white/30 bg-black/50 px-3 py-1 text-xs text-white">
               {state.selectedMeetupPoint
                 ? `Point: ${state.selectedMeetupPoint[0].toFixed(4)}, ${state.selectedMeetupPoint[1].toFixed(4)}`
-                : "Tap map to place meetup"}
+                : "Long-press map to place meetup"}
             </div>
           </div>
         </div>
@@ -200,6 +220,32 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
             {state.shareEnabled ? "Ты сейчас в эфире на карте" : "Геошеринг выключен"}
           </p>
           <div className="mt-4 space-y-3">
+            <div className="space-y-2 rounded-xl border border-white/10 bg-black/20 p-3">
+              <Input
+                value={state.rideName}
+                onChange={(event) => dispatch({ type: "ui/set-ride-name", payload: event.target.value })}
+                placeholder="Название заезда"
+                className="h-9"
+              />
+              <Input
+                value={state.vehicleLabel}
+                onChange={(event) => dispatch({ type: "ui/set-vehicle-label", payload: event.target.value })}
+                placeholder="Мотоцикл"
+                className="h-9"
+              />
+              <Select
+                value={state.rideMode}
+                onValueChange={(value: "rental" | "personal") => dispatch({ type: "ui/set-ride-mode", payload: value })}
+              >
+                <SelectTrigger className="h-9">
+                  <SelectValue placeholder="Режим поездки" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="rental">Rental</SelectItem>
+                  <SelectItem value="personal">Personal</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
             {/* TODO: Wire up session start/stop from useSessionManager */}
             <Button
               type="button"

--- a/components/map-riders/RidersDrawer.tsx
+++ b/components/map-riders/RidersDrawer.tsx
@@ -46,7 +46,8 @@ export function RidersDrawer() {
       });
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.error);
-      toast.success("Meetup сохранён!");
+      toast.success("Meetup сохранён и опубликован в экипаже");
+      setMeetupTitle("Точка сбора");
       setMeetupComment("");
       dispatch({ type: "ui/select-meetup-point", payload: null });
       await fetchSnapshot();
@@ -118,7 +119,7 @@ export function RidersDrawer() {
                     <Label className="mt-2 text-xs text-amber-200">Комментарий</Label>
                     <Input value={meetupComment} onChange={(e) => setMeetupComment(e.target.value)} placeholder="Ориентир" className="mt-1 bg-transparent text-white" />
                     <Button type="button" size="sm" className="mt-2 w-full" disabled={isSubmitting} onClick={handleCreateMeetup}>
-                      Сохранить meetup
+                      {isSubmitting ? "Сохраняем meetup..." : "Сохранить meetup"}
                     </Button>
                   </div>
                 )}

--- a/components/map-riders/SpeedGradientRoute.tsx
+++ b/components/map-riders/SpeedGradientRoute.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Fragment, useMemo } from "react";
+import { Polyline } from "react-leaflet";
+
+type RoutePoint = { lat: number; lon: number; speedKmh: number; capturedAt: string };
+
+function segmentColor(speedKmh: number) {
+  if (speedKmh < 10) return "#38bdf8";
+  if (speedKmh < 25) return "#22c55e";
+  if (speedKmh < 40) return "#f59e0b";
+  return "#ef4444";
+}
+
+export function SpeedGradientRoute({ points }: { points: RoutePoint[] }) {
+  const segments = useMemo(() => {
+    if (points.length < 2) return [];
+    const out: Array<{ id: string; positions: [number, number][]; color: string }> = [];
+    for (let i = 1; i < points.length; i += 1) {
+      const prev = points[i - 1];
+      const current = points[i];
+      out.push({
+        id: `${current.capturedAt}-${i}`,
+        positions: [
+          [prev.lat, prev.lon],
+          [current.lat, current.lon],
+        ],
+        color: segmentColor(current.speedKmh),
+      });
+    }
+    return out;
+  }, [points]);
+
+  if (!segments.length) return null;
+
+  return (
+    <Fragment>
+      {segments.map((segment) => (
+        <Polyline
+          key={segment.id}
+          positions={segment.positions}
+          pathOptions={{
+            color: segment.color,
+            weight: 5,
+            opacity: 0.95,
+            lineCap: "round",
+            lineJoin: "round",
+          }}
+        />
+      ))}
+    </Fragment>
+  );
+}

--- a/components/map-riders/StatusOverlay.tsx
+++ b/components/map-riders/StatusOverlay.tsx
@@ -38,9 +38,10 @@ export function StatusOverlay() {
   const session = state.sessions.find((s) => s.id === state.sessionId);
   const distance = Number(session?.total_distance_km || 0).toFixed(1);
   const speed = Math.round(session?.latest_speed_kmh || 0);
+  const showSpeedLegend = Boolean(state.sessionDetail?.points?.length);
 
   return (
-    <div className="pointer-events-none fixed left-1/2 top-4 z-50 -translate-x-1/2 md:top-6">
+    <div className="pointer-events-none fixed left-1/2 top-4 z-50 -translate-x-1/2 space-y-2 md:top-6">
       <div className="flex items-center gap-3 rounded-2xl border border-white/20 bg-black/60 px-4 py-2 text-white backdrop-blur-xl">
         <div className="flex items-center gap-1.5">
           <span className="relative flex h-2.5 w-2.5">
@@ -65,6 +66,17 @@ export function StatusOverlay() {
           <div className="font-mono text-sm font-semibold">{speed} км/ч</div>
         </div>
       </div>
+      {showSpeedLegend ? (
+        <div className="rounded-xl border border-white/20 bg-black/60 px-3 py-2 text-[10px] text-white backdrop-blur-xl">
+          <div className="mb-1 font-medium text-zinc-300">Route speed legend</div>
+          <div className="flex items-center gap-2">
+            <span className="h-2 w-4 rounded bg-sky-400" /> <span>0-10</span>
+            <span className="h-2 w-4 rounded bg-emerald-500" /> <span>10-25</span>
+            <span className="h-2 w-4 rounded bg-amber-500" /> <span>25-40</span>
+            <span className="h-2 w-4 rounded bg-red-500" /> <span>40+</span>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/components/maps/MapInteractionCapture.tsx
+++ b/components/maps/MapInteractionCapture.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useMap, useMapEvents } from "react-leaflet";
+import type L from "leaflet";
+
+interface MapInteractionCaptureProps {
+  onMapClick?: (coords: [number, number]) => void;
+  onMapLongPress?: (coords: [number, number]) => void;
+  longPressDelay?: number;
+}
+
+export function MapInteractionCapture({
+  onMapClick,
+  onMapLongPress,
+  longPressDelay = 500,
+}: MapInteractionCaptureProps) {
+  const map = useMap();
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTriggeredRef = useRef(false);
+
+  const clearLongPress = useCallback(() => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+    longPressTriggeredRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    const handleContextMenu = (event: L.LeafletMouseEvent) => {
+      event.originalEvent.preventDefault();
+      onMapLongPress?.([event.latlng.lat, event.latlng.lng]);
+      longPressTriggeredRef.current = true;
+    };
+
+    const handleTouchStart = (event: L.LeafletMouseEvent) => {
+      clearLongPress();
+      longPressTimerRef.current = setTimeout(() => {
+        onMapLongPress?.([event.latlng.lat, event.latlng.lng]);
+        longPressTriggeredRef.current = true;
+      }, longPressDelay);
+    };
+
+    const handleTouchMove = () => {
+      clearLongPress();
+    };
+
+    const handleTouchEnd = () => {
+      // Touch tap should not place meetup accidentally.
+      clearLongPress();
+    };
+
+    map.on("contextmenu", handleContextMenu);
+    map.on("touchstart", handleTouchStart);
+    map.on("touchmove", handleTouchMove);
+    map.on("touchend", handleTouchEnd);
+
+    return () => {
+      clearLongPress();
+      map.off("contextmenu", handleContextMenu);
+      map.off("touchstart", handleTouchStart);
+      map.off("touchmove", handleTouchMove);
+      map.off("touchend", handleTouchEnd);
+    };
+  }, [map, onMapClick, onMapLongPress, longPressDelay, clearLongPress]);
+
+  useMapEvents({
+    click(event) {
+      if (typeof window !== "undefined" && !("ontouchstart" in window)) {
+        onMapClick?.([event.latlng.lat, event.latlng.lng]);
+      }
+    },
+  });
+
+  return null;
+}

--- a/components/maps/RacingMap.tsx
+++ b/components/maps/RacingMap.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useMemo, useState, type ReactNode } from 'react';
-import { CircleMarker, GeoJSON, MapContainer, Popup, Polyline, TileLayer, useMapEvents } from 'react-leaflet';
+import { CircleMarker, GeoJSON, MapContainer, Popup, Polyline, TileLayer } from 'react-leaflet';
+import { MapInteractionCapture } from '@/components/maps/MapInteractionCapture';
 import type { PointOfInterest } from '@/lib/map-utils';
 import type { TileLayerPreset } from '@/lib/maps/map-types';
 
@@ -51,21 +52,12 @@ function collectLatLng(points: PointOfInterest[]): Array<[number, number]> {
   return collected;
 }
 
-function MapClickCapture({ onMapClick }: { onMapClick?: (coords: [number, number]) => void }) {
-  useMapEvents({
-    click(event) {
-      onMapClick?.([event.latlng.lat, event.latlng.lng]);
-    },
-  });
-
-  return null;
-}
-
 export function RacingMap({
   points,
   bounds,
   className,
   onMapClick,
+  onMapLongPress,
   tileLayer = 'cartodb-dark',
   children,
 }: {
@@ -73,6 +65,7 @@ export function RacingMap({
   bounds: { top: number; bottom: number; left: number; right: number };
   className?: string;
   onMapClick?: (coords: [number, number]) => void;
+  onMapLongPress?: (coords: [number, number]) => void;
   tileLayer?: TileLayerPreset;
   children?: ReactNode;
 }) {
@@ -182,7 +175,7 @@ export function RacingMap({
         })}
 
         {children}
-        <MapClickCapture onMapClick={onMapClick} />
+        <MapInteractionCapture onMapClick={onMapClick} onMapLongPress={onMapLongPress} />
       </MapContainer>
     </div>
   );

--- a/hooks/useLiveRiders.ts
+++ b/hooks/useLiveRiders.ts
@@ -1,11 +1,22 @@
-// /hooks/useLiveRiders.ts
-// GPS watcher with throttling (3s + 10m) + broadcast + batch queue.
-// Replaces the inline useLiveRiders usage in MapRidersClient.
-
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getSupabaseBrowserClient } from "@/lib/supabase-browser";
+
+type TelegramWebApp = {
+  requestLocation?: (callback?: (location: { latitude: number; longitude: number; altitude?: number | null; course?: number | null; horizontal_accuracy?: number | null; speed?: number | null }) => void) => Promise<unknown> | void;
+  HapticFeedback?: {
+    impactOccurred?: (style: "light" | "medium" | "heavy" | "rigid" | "soft") => void;
+  };
+};
+
+declare global {
+  interface Window {
+    Telegram?: {
+      WebApp?: TelegramWebApp;
+    };
+  }
+}
 
 interface GPSPoint {
   lat: number;
@@ -21,11 +32,9 @@ interface UseLiveRidersOptions {
   sessionId: string | null;
   userId: string | null;
   enabled: boolean;
-  /** Called with each accepted GPS point (for local state + broadcast) */
   onPosition?: (point: GPSPoint) => void;
 }
 
-// Haversine for client-side distance threshold
 function haversineMeters(a: { lat: number; lng: number }, b: { lat: number; lng: number }) {
   const R = 6371000;
   const dLat = ((b.lat - a.lat) * Math.PI) / 180;
@@ -36,9 +45,9 @@ function haversineMeters(a: { lat: number; lng: number }, b: { lat: number; lng:
   return R * 2 * Math.atan2(Math.sqrt(aa), Math.sqrt(1 - aa));
 }
 
-const GPS_INTERVAL_MS = 3000; // 3s minimum between accepted updates
-const GPS_DISTANCE_M = 10;    // 10m minimum distance threshold
-const BATCH_FLUSH_MS = 5000;  // Flush batch every 5s
+const GPS_INTERVAL_MS = 3000;
+const GPS_DISTANCE_M = 10;
+const BATCH_FLUSH_MS = 5000;
 const BATCH_MAX_SIZE = 10;
 
 export function useLiveRiders(options: UseLiveRidersOptions) {
@@ -47,15 +56,20 @@ export function useLiveRiders(options: UseLiveRidersOptions) {
   const lastAcceptedRef = useRef<{ lat: number; lng: number; time: number } | null>(null);
   const batchQueueRef = useRef<GPSPoint[]>([]);
   const flushTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const telegramTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const channelRef = useRef<ReturnType<ReturnType<typeof getSupabaseBrowserClient>["channel"]> | null>(null);
   const [isActive, setIsActive] = useState(false);
+  const [isUsingTelegram, setIsUsingTelegram] = useState(false);
 
-  // ── Broadcast position to Supabase Realtime ──
+  const hapticPulse = useCallback(() => {
+    if (typeof window === "undefined") return;
+    window.Telegram?.WebApp?.HapticFeedback?.impactOccurred?.("light");
+  }, []);
+
   const broadcastPosition = useCallback(
     (point: GPSPoint) => {
-      if (!userId) return;
-      const supabase = getSupabaseBrowserClient();
-      const channel = supabase.channel(`map-riders:${crewSlug}`);
-      channel.send({
+      if (!userId || !channelRef.current) return;
+      channelRef.current.send({
         type: "broadcast",
         event: "rider:move",
         payload: {
@@ -68,10 +82,9 @@ export function useLiveRiders(options: UseLiveRidersOptions) {
         },
       });
     },
-    [crewSlug, userId],
+    [userId],
   );
 
-  // ── Flush batch to server ──
   const flushBatch = useCallback(async () => {
     const points = batchQueueRef.current.splice(0, BATCH_MAX_SIZE);
     if (points.length === 0 || !sessionId || !userId) return;
@@ -82,9 +95,7 @@ export function useLiveRiders(options: UseLiveRidersOptions) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sessionId, userId, crewSlug, points }),
       });
-      if (batchResponse.ok) {
-        return;
-      }
+      if (batchResponse.ok) return;
 
       const lastPoint = points[points.length - 1];
       await fetch("/api/map-riders/location", {
@@ -103,102 +114,181 @@ export function useLiveRiders(options: UseLiveRidersOptions) {
         }),
       });
     } catch {
-      // Re-queue failed points at front
       batchQueueRef.current.unshift(...points);
     }
   }, [sessionId, userId, crewSlug]);
 
-  // ── GPS handler ──
-  const handlePosition = useCallback(
-    (position: GeolocationPosition) => {
+  const acceptPoint = useCallback(
+    (point: GPSPoint) => {
       const now = Date.now();
-      const lat = position.coords.latitude;
-      const lng = position.coords.longitude;
-      const speedKmh = (position.coords.speed || 0) * 3.6;
-      const heading = position.coords.heading ?? null;
-      const accuracyMeters = position.coords.accuracy ?? null;
-      const capturedAt = new Date().toISOString();
-
-      // Throttle: skip if too close in time AND distance
       const last = lastAcceptedRef.current;
       if (last) {
         const elapsed = now - last.time;
-        const dist = haversineMeters({ lat, lng }, { lat: last.lat, lng: last.lng });
+        const dist = haversineMeters({ lat: point.lat, lng: point.lng }, { lat: last.lat, lng: last.lng });
         if (elapsed < GPS_INTERVAL_MS && dist < GPS_DISTANCE_M) return;
       }
 
-      lastAcceptedRef.current = { lat, lng, time: now };
-      const point: GPSPoint = { lat, lng, speedKmh, heading, accuracyMeters, capturedAt };
-
-      // Broadcast for instant map update
+      lastAcceptedRef.current = { lat: point.lat, lng: point.lng, time: now };
       broadcastPosition(point);
-
-      // Add to batch queue
       batchQueueRef.current.push(point);
-
-      // Notify parent hook
       onPosition?.(point);
+      hapticPulse();
     },
-    [broadcastPosition, onPosition],
+    [broadcastPosition, onPosition, hapticPulse],
   );
 
-  const handleError = useCallback((err: GeolocationPositionError) => {
-    console.warn("[MapRiders] GPS error:", err.message);
-  }, []);
+  const handleGeolocationPosition = useCallback(
+    (position: GeolocationPosition) => {
+      const point: GPSPoint = {
+        lat: position.coords.latitude,
+        lng: position.coords.longitude,
+        speedKmh: (position.coords.speed || 0) * 3.6,
+        heading: position.coords.heading ?? null,
+        accuracyMeters: position.coords.accuracy ?? null,
+        capturedAt: new Date().toISOString(),
+      };
+      acceptPoint(point);
+    },
+    [acceptPoint],
+  );
 
-  // ── Start/stop GPS watcher ──
+  const requestTelegramLocation = useCallback(async () => {
+    if (typeof window === "undefined") return false;
+    const webApp = window.Telegram?.WebApp;
+    if (!webApp?.requestLocation) return false;
+
+    let gotPoint = false;
+    const handleLocation = (location: { latitude: number; longitude: number; speed?: number | null; course?: number | null; horizontal_accuracy?: number | null }) => {
+      gotPoint = true;
+      acceptPoint({
+        lat: Number(location.latitude),
+        lng: Number(location.longitude),
+        speedKmh: Number(location.speed || 0) * 3.6,
+        heading: location.course != null ? Number(location.course) : null,
+        accuracyMeters: location.horizontal_accuracy != null ? Number(location.horizontal_accuracy) : null,
+        capturedAt: new Date().toISOString(),
+      });
+    };
+
+    const maybePromise = webApp.requestLocation(handleLocation);
+    if (maybePromise && typeof (maybePromise as Promise<unknown>).then === "function") {
+      try {
+        const resolved = (await maybePromise) as any;
+        if (!gotPoint && resolved?.latitude && resolved?.longitude) {
+          handleLocation(resolved);
+        }
+      } catch {
+        return false;
+      }
+    }
+
+    setIsUsingTelegram(gotPoint);
+    return gotPoint;
+  }, [acceptPoint]);
+
   useEffect(() => {
-    if (!enabled || !navigator.geolocation) {
+    if (!enabled || !userId) {
       setIsActive(false);
+      setIsUsingTelegram(false);
       return;
     }
 
-    // Adjust accuracy based on visibility
-    const highAccuracy = document.visibilityState === "visible";
-
-    watchIdRef.current = navigator.geolocation.watchPosition(handlePosition, handleError, {
-      enableHighAccuracy: highAccuracy,
-      timeout: highAccuracy ? 10000 : 30000,
-      maximumAge: highAccuracy ? 0 : 60000,
-    });
-    setIsActive(true);
+    const supabase = getSupabaseBrowserClient();
+    const channel = supabase.channel(`map-riders:${crewSlug}`);
+    channel.subscribe();
+    channelRef.current = channel;
 
     return () => {
+      channelRef.current = null;
+      supabase.removeChannel(channel);
+    };
+  }, [crewSlug, enabled, userId]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+
+    const start = async () => {
+      const telegramSuccess = await requestTelegramLocation();
+      if (cancelled) return;
+
+      if (telegramSuccess) {
+        setIsActive(true);
+        setIsUsingTelegram(true);
+        telegramTimerRef.current = setInterval(() => {
+          requestTelegramLocation();
+        }, GPS_INTERVAL_MS);
+        return;
+      }
+
+      if (!navigator.geolocation) {
+        setIsActive(false);
+        return;
+      }
+
+      const highAccuracy = document.visibilityState === "visible";
+      watchIdRef.current = navigator.geolocation.watchPosition(
+        handleGeolocationPosition,
+        (error) => {
+          console.warn("[useLiveRiders] Geolocation error:", error.message);
+        },
+        {
+          enableHighAccuracy: highAccuracy,
+          timeout: highAccuracy ? 10000 : 30000,
+          maximumAge: highAccuracy ? 0 : 60000,
+        },
+      );
+      setIsActive(true);
+      setIsUsingTelegram(false);
+    };
+
+    start();
+
+    return () => {
+      cancelled = true;
       if (watchIdRef.current !== null) {
         navigator.geolocation.clearWatch(watchIdRef.current);
         watchIdRef.current = null;
       }
+      if (telegramTimerRef.current) {
+        clearInterval(telegramTimerRef.current);
+        telegramTimerRef.current = null;
+      }
       setIsActive(false);
     };
-  }, [enabled, handlePosition, handleError]);
+  }, [enabled, handleGeolocationPosition, requestTelegramLocation]);
 
-  // ── Visibility change → adjust GPS accuracy ──
-  useEffect(() => {
-    const onVisibility = () => {
-      if (!enabled) return;
-      // Restart watcher with new accuracy settings
-      if (watchIdRef.current !== null) {
-        navigator.geolocation.clearWatch(watchIdRef.current);
-        const highAccuracy = !document.hidden;
-        watchIdRef.current = navigator.geolocation.watchPosition(handlePosition, handleError, {
-          enableHighAccuracy: highAccuracy,
-          timeout: highAccuracy ? 10000 : 30000,
-          maximumAge: highAccuracy ? 0 : 60000,
-        });
-      }
-    };
-    document.addEventListener("visibilitychange", onVisibility);
-    return () => document.removeEventListener("visibilitychange", onVisibility);
-  }, [enabled, handlePosition, handleError]);
-
-  // ── Batch flush timer ──
   useEffect(() => {
     if (!enabled) return;
     flushTimerRef.current = setInterval(flushBatch, BATCH_FLUSH_MS);
     return () => {
-      if (flushTimerRef.current) clearInterval(flushTimerRef.current);
+      if (flushTimerRef.current) {
+        clearInterval(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
     };
   }, [enabled, flushBatch]);
 
-  return { isActive };
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (!enabled || document.visibilityState !== "visible") return;
+      if (isUsingTelegram) {
+        requestTelegramLocation();
+        return;
+      }
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          handleGeolocationPosition,
+          () => {},
+          { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 },
+        );
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [enabled, handleGeolocationPosition, isUsingTelegram, requestTelegramLocation]);
+
+  return { isActive, isUsingTelegram };
 }

--- a/lib/map-riders-reducer.ts
+++ b/lib/map-riders-reducer.ts
@@ -181,6 +181,9 @@ export type MapRidersAction =
   | { type: "ui/select-session"; payload: string | null }
   | { type: "ui/select-meetup-point"; payload: [number, number] | null }
   | { type: "ui/toggle-drawer" }
+  | { type: "ui/set-ride-name"; payload: string }
+  | { type: "ui/set-vehicle-label"; payload: string }
+  | { type: "ui/set-ride-mode"; payload: "rental" | "personal" }
   | { type: "loading"; payload: boolean }
   | { type: "error"; payload: string | null };
 
@@ -338,6 +341,18 @@ export function mapRidersReducer(state: MapRidersState, action: MapRidersAction)
 
     case "ui/toggle-drawer": {
       return { ...state, drawerOpen: !state.drawerOpen };
+    }
+
+    case "ui/set-ride-name": {
+      return { ...state, rideName: action.payload };
+    }
+
+    case "ui/set-vehicle-label": {
+      return { ...state, vehicleLabel: action.payload };
+    }
+
+    case "ui/set-ride-mode": {
+      return { ...state, rideMode: action.payload };
     }
 
     case "loading": {


### PR DESCRIPTION
### Motivation
- Prefer Telegram `requestLocation` as primary geolocation source with browser fallback to improve reliability and privacy handling.
- Prevent accidental meetup placement from touch taps and provide an explicit long-press creation flow with clearer UX and feedback.
- Visualize route speed via colored segments and expose session metadata in the rider control UI driven by reducer state.

### Description
- Added `MapInteractionCapture` and wired it into `RacingMap` to support `contextmenu` and touch long-press detection and prevent taps from creating meetups. 
- Rewrote `useLiveRiders` to be Telegram-first (`requestLocation`) with a browser geolocation fallback, added `isUsingTelegram` runtime flag, supabase channel wiring, haptic pulse on accepted points, periodic Telegram polling, batching/flush logic, and an `onPosition` callback for optimistic local reducer updates. 
- Introduced `SpeedGradientRoute.tsx` to render per-segment colored polylines by speed and added a legend to `StatusOverlay`. 
- Hardened `RiderMarker` animation loop with a cancellation guard to avoid RAF updates after unmount/restart. 
- Extended the map rider UI in `MapRidersClientRefactored` and `map-riders` reducer with editable session form controls (`rideName`, `vehicleLabel`, `rideMode`) and connected actions (`ui/set-ride-name`, `ui/set-vehicle-label`, `ui/set-ride-mode`). 
- Polished meetup UX in `RidersDrawer` to show loading state, reset fields on success, and update success toast copy. 
- Updated docs `MapRiders_FixBook.md` with progress logs describing changes and outstanding work. 

### Testing
- Performed TypeScript typecheck and app build with `next build`, which completed successfully. 
- Ran `yarn lint` and the frontend static checks locally with no errors. 
- No new automated unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7dbab871c8325956f0cfc5c51ae72)