### PR TITLE
Fix MapRiders Telegram location handling and rentals availability query

### DIFF
--- a/app/api/telegramWebhook/route.ts
+++ b/app/api/telegramWebhook/route.ts
@@ -268,9 +268,10 @@ export async function POST(request: Request) {
       await handlePhotoMessage(update.message);
     } else if (update.message?.location) {
       await handleLocationMessage(update.message);
-    // --- ЗАКОММЕНТИРОВАНО: Обработка "живых" геоточек отключена для экономии ресурсов Supabase ---
-    // } else if (update.edited_message?.location) {
-    //   await handleLocationMessage(update.edited_message);
+    } else if (update.edited_message?.location) {
+      // Live-location updates from Telegram arrive as edited_message payloads.
+      // We support them to keep MapRiders location feed in sync for Telegram-first flow.
+      await handleLocationMessage(update.edited_message);
     } else if (update.message?.text || update.callback_query) {
       await handleCommand(update);
     } else {

--- a/app/franchize/[slug]/map-riders/page.tsx
+++ b/app/franchize/[slug]/map-riders/page.tsx
@@ -1,8 +1,13 @@
 import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
-import { MapRidersClient } from "@/app/franchize/components/MapRidersClient";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import dynamic from "next/dynamic";
+
+const MapRidersClient = dynamic(
+  () => import("@/app/franchize/components/MapRidersClient").then((mod) => mod.MapRidersClient),
+  { ssr: false },
+);
 
 export default async function MapRidersPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;

--- a/app/franchize/[slug]/map-riders/todo.md
+++ b/app/franchize/[slug]/map-riders/todo.md
@@ -86,6 +86,21 @@ Port AGI handoff from `./goldmine` into production `MapRiders` in controlled ite
 - Live locations policy drift between local SQL and production RLS.
 - Telegram webview tap reliability when introducing new floating layers.
 
+## Investigation notes (2026-04-17)
+- Reviewed Telegram-first location flow end-to-end:
+  - `useLiveRiders` tries `WebApp.requestLocation` first, then falls back to browser geolocation.
+  - Prior implementation could return `false` too early when Telegram only delivers async callback later.
+  - Updated hook to wait briefly for callback-mode `requestLocation` responses before fallback.
+- Confirmed webhook ingestion path:
+  - regular location comes in `update.message.location`,
+  - live location updates come in `update.edited_message.location`.
+  - We now process `edited_message.location` again in `app/api/telegramWebhook/route.ts` so repeated Telegram live-location updates are ingested.
+- Rentals availability warning root cause:
+  - `getFranchizeBySlug` queried non-existent `rentals.end_date`;
+  - switched to `requested_end_date` fallback with `agreed_end_date` priority.
+- Remaining checklist status:
+  - I5/I6 still have open field QA + screenshot evidence tasks; these are still pending and were not auto-closed in this patch.
+
 ## Definition of done (port stream)
 - Live map remains stable with high rider count.
 - Historical/stat flows remain intact (`sessions`, `points`, `meetups`, replay).

--- a/app/franchize/actions.ts
+++ b/app/franchize/actions.ts
@@ -11,6 +11,13 @@ import { getCrewSensitiveData, getUserSensitiveData, saveCrewSensitiveData } fro
 import { buildFranchizeDocxFromTemplate } from "@/app/franchize/lib/docx-capability";
 
 type UnknownRecord = Record<string, unknown>;
+type RentalAvailabilityRow = {
+  vehicle_id: string | null;
+  status: string | null;
+  agreed_start_date: string | null;
+  agreed_end_date: string | null;
+  requested_end_date: string | null;
+};
 
 type ThemePaletteCandidate = Partial<FranchizeTheme["palette"]> & {
   light?: Partial<FranchizeTheme["palette"]>;
@@ -496,7 +503,7 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
     const { data: activeRentals, error: rentalsError } = vehicleIds.length
       ? await supabaseAdmin
           .from("rentals")
-          .select("vehicle_id, status, agreed_start_date, agreed_end_date, end_date")
+          .select("vehicle_id, status, agreed_start_date, agreed_end_date, requested_end_date")
           .in("vehicle_id", vehicleIds)
           .in("status", ["pending_confirmation", "confirmed", "active"])
       : { data: [], error: null };
@@ -507,15 +514,15 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
 
     const availabilityByVehicle = new Map<string, { status: "available" | "busy"; label: string }>();
     const nowTs = Date.now();
-    for (const rental of activeRentals ?? []) {
+    for (const rental of (activeRentals ?? []) as RentalAvailabilityRow[]) {
       const vehicleId = typeof rental.vehicle_id === "string" ? rental.vehicle_id : "";
       if (!vehicleId) continue;
 
       const startTs = rental.agreed_start_date ? Date.parse(rental.agreed_start_date) : Number.NaN;
       const endTs = rental.agreed_end_date
         ? Date.parse(rental.agreed_end_date)
-        : rental.end_date
-          ? Date.parse(rental.end_date)
+        : rental.requested_end_date
+          ? Date.parse(rental.requested_end_date)
           : Number.NaN;
       const rentalStatus = typeof rental.status === "string" ? rental.status : "pending_confirmation";
 

--- a/hooks/cyberFitnessSupabase.ts
+++ b/hooks/cyberFitnessSupabase.ts
@@ -1,4 +1,3 @@
-"use client"; 
 import {
   adjustKiloVibesRpcAction,
   fetchCyberFitnessUserDataAction,
@@ -180,7 +179,8 @@ export const ALL_ACHIEVEMENTS: Achievement[] = [
     },
 ];
 
-const getDefaultCyberFitnessProfile = (): CyberFitnessProfile => ({
+function getDefaultCyberFitnessProfile(): CyberFitnessProfile {
+  return ({
     level: 0, kiloVibes: 0, focusTimeHours: 0, skillsLeveled: 0,
     activeQuests: [QUEST_ORDER[0]], 
     completedQuests: [], unlockedPerks: [],
@@ -188,9 +188,10 @@ const getDefaultCyberFitnessProfile = (): CyberFitnessProfile => ({
     dailyActivityLog: [], achievements: [],
     totalFilesExtracted: 0, totalTokensProcessed: 0, totalKworkRequestsSent: 0,
     totalPrsCreated: 0, totalBranchesUpdated: 0, featuresUsed: {},
-});
+  });
+}
 
-const getCyberFitnessProfile = (userId: string | null, metadata: UserMetadata | null | undefined): CyberFitnessProfile => {
+function getCyberFitnessProfile(userId: string | null, metadata: UserMetadata | null | undefined): CyberFitnessProfile {
   const defaultProfile = getDefaultCyberFitnessProfile();
   let finalProfile = { ...defaultProfile }; 
 
@@ -232,7 +233,7 @@ const getCyberFitnessProfile = (userId: string | null, metadata: UserMetadata | 
   finalProfile.skillsLeveled = new Set(finalProfile.unlockedPerks || []).size; 
 
   return finalProfile;
-};
+}
 
 export const fetchUserCyberFitnessProfile = async (userId: string): Promise<{ success: boolean; data?: CyberFitnessProfile; error?: string }> => {
   logger.info(`[CyberFitness FetchProfile ENTRY] Attempting to fetch profile for user_id: ${userId}`);

--- a/hooks/useLiveRiders.ts
+++ b/hooks/useLiveRiders.ts
@@ -158,7 +158,13 @@ export function useLiveRiders(options: UseLiveRidersOptions) {
     if (!webApp?.requestLocation) return false;
 
     let gotPoint = false;
-    const handleLocation = (location: { latitude: number; longitude: number; speed?: number | null; course?: number | null; horizontal_accuracy?: number | null }) => {
+    const handleLocation = (location: {
+      latitude: number;
+      longitude: number;
+      speed?: number | null;
+      course?: number | null;
+      horizontal_accuracy?: number | null;
+    }) => {
       gotPoint = true;
       acceptPoint({
         lat: Number(location.latitude),
@@ -180,6 +186,19 @@ export function useLiveRiders(options: UseLiveRidersOptions) {
       } catch {
         return false;
       }
+    } else {
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, 2200);
+        const check = () => {
+          if (gotPoint) {
+            clearTimeout(timeout);
+            resolve();
+            return;
+          }
+          setTimeout(check, 100);
+        };
+        check();
+      });
     }
 
     setIsUsingTelegram(gotPoint);


### PR DESCRIPTION
### Motivation
- Prevent runtime ReferenceError and SSR failures affecting franchize and map-riders pages by ensuring browser-only map and Telegram flows run only on the client.
- Restore robust Telegram-first live-location behavior so `WebApp.requestLocation` callback-mode is awaited before falling back to browser geolocation.
- Fix rentals availability logic which referenced a non-existent `rentals.end_date` column and could log erroneous warnings.

### Description
- Hardened Telegram-first tracking in `hooks/useLiveRiders.ts` by awaiting callback-mode `window.Telegram.WebApp.requestLocation` responses (small wait loop) before declaring failure and falling back to `navigator.geolocation`.
- Re-enabled processing of Telegram live-location updates by handling `update.edited_message.location` in `app/api/telegramWebhook/route.ts` so repeated live updates from Telegram are ingested.
- Aligned rentals availability query in `app/franchize/actions.ts` to the actual schema by selecting `requested_end_date` (fallback) and `agreed_end_date` (primary) instead of the non-existent `end_date`, and added a typed `RentalAvailabilityRow` to reduce future schema drift.
- Avoided server-rendering client-only map stacks by dynamically importing `MapRidersClient` with `dynamic(..., { ssr: false })` in `app/franchize/[slug]/map-riders/page.tsx` to prevent `window is not defined` errors.
- Stabilized CyberFitness helpers in `hooks/cyberFitnessSupabase.ts` by removing the erroneous client-only directive and converting the profile helpers to function declarations (`getDefaultCyberFitnessProfile`, `getCyberFitnessProfile`) to fix `getCyberFitnessProfile is not defined` runtime errors.
- Documented investigation findings and remaining MapRiders backlog notes in `app/franchize/[slug]/map-riders/todo.md`.
- No DB migration was added because code was adjusted to the existing production schema (uses `requested_end_date` / `agreed_end_date`).

### Testing
- Ran linting: `npx eslint app/franchize/actions.ts app/franchize/[slug]/map-riders/page.tsx hooks/useLiveRiders.ts hooks/cyberFitnessSupabase.ts app/api/telegramWebhook/route.ts` and it completed without errors.
- Ran MapRiders QA smoke: `npm run -s qa:map-riders` and the smoke checks passed (`map-page`, `api-overview`, `api-leaderboard`, `api-health`, `api-legacy` all returned 200).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e17b66284c8324a24cbf9797a38436)