### PR TITLE
Fix MapRiders Telegram polling leak, long-press UX, demo pins and mobile map layout

### DIFF
--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -31,6 +31,7 @@ import { MapRidersSkeleton } from "@/components/map-riders/LoadingSkeleton";
 const RacingMap = dynamic(() => import("@/components/maps/RacingMap").then((mod) => mod.RacingMap), { ssr: false });
 
 const DEFAULT_BOUNDS = { top: 56.42, bottom: 56.08, left: 43.66, right: 44.12 };
+const HOME_BASE: [number, number] = [56.2041281, 43.7986412];
 
 // ── Inner component (uses context) ──
 function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
@@ -97,7 +98,7 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
               type: "point" as const,
               icon: "image:https://placehold.co/56x56/111827/ffffff?text=SB",
               color: "#60a5fa",
-              coords: [[56.1864, 43.7851]] as [number, number][],
+              coords: [HOME_BASE],
             },
           ];
 
@@ -146,13 +147,13 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
       }}
     >
       {/* ── MAP (fullscreen hero) ── */}
-      <section className="relative overflow-hidden rounded-3xl border" style={{ borderColor: `${crew.theme.palette.borderSoft}aa` }}>
+      <section className="relative -mx-4 overflow-hidden border md:mx-0 md:rounded-3xl" style={{ borderColor: `${crew.theme.palette.borderSoft}aa` }}>
         <div className="absolute inset-0 z-0">
           {useLeafletMap ? (
             <RacingMap
               points={mapPoints}
               bounds={mapData?.bounds || mapBounds || DEFAULT_BOUNDS}
-              className="h-full min-h-[78vh] w-full md:min-h-[84vh]"
+              className="h-full min-h-[62vh] w-full md:min-h-[74vh]"
               tileLayer={mapData?.meta.tileLayer || "cartodb-dark"}
               onMapClick={(coords) => dispatch({ type: "ui/select-meetup-point", payload: coords })}
               onMapLongPress={(coords) => dispatch({ type: "ui/select-meetup-point", payload: coords })}
@@ -161,15 +162,16 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
               <RiderMarkerLayer />
             </RacingMap>
           ) : (
-            <div className="flex h-full min-h-[78vh] items-center justify-center text-muted-foreground">
+            <div className="flex h-full min-h-[62vh] items-center justify-center text-muted-foreground md:min-h-[74vh]">
               VibeMap fallback — set NEXT_PUBLIC_MAP_ENGINE=leaflet
             </div>
           )}
           <div className="pointer-events-none absolute inset-0 z-10 bg-gradient-to-b from-black/30 via-transparent to-black/30" />
+          <div className="pointer-events-none absolute bottom-0 left-0 right-0 z-20 h-5 bg-[var(--mr-card)]/95 backdrop-blur-sm" />
         </div>
 
         {/* Floating badges */}
-        <div className="pointer-events-none relative z-20 flex min-h-[78vh] flex-col justify-between p-3 md:min-h-[84vh] md:p-6">
+        <div className="pointer-events-none relative z-30 flex min-h-[62vh] flex-col justify-between p-3 md:min-h-[74vh] md:p-6">
           <div className="flex flex-wrap gap-2">
             <Badge className="border bg-black/55 text-white backdrop-blur-md">{useLeafletMap ? `Leaflet${isUsingTelegram ? " + Telegram GPS" : " + Browser GPS"}` : "VibeMap"}</Badge>
             {mapData?.routes?.length ? <Badge className="border border-sky-300/50 bg-sky-500/20 text-sky-100">{mapData.routes.length} routes</Badge> : null}

--- a/components/maps/MapInteractionCapture.tsx
+++ b/components/maps/MapInteractionCapture.tsx
@@ -18,6 +18,9 @@ export function MapInteractionCapture({
   const map = useMap();
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressTriggeredRef = useRef(false);
+  const touchStartRef = useRef<{ timestamp: number; lat: number; lng: number } | null>(null);
+
+  const TOUCH_MOVE_CANCEL_METERS = 18;
 
   const clearLongPress = useCallback(() => {
     if (longPressTimerRef.current) {
@@ -36,18 +39,34 @@ export function MapInteractionCapture({
 
     const handleTouchStart = (event: L.LeafletMouseEvent) => {
       clearLongPress();
+      touchStartRef.current = {
+        timestamp: Date.now(),
+        lat: event.latlng.lat,
+        lng: event.latlng.lng,
+      };
       longPressTimerRef.current = setTimeout(() => {
         onMapLongPress?.([event.latlng.lat, event.latlng.lng]);
         longPressTriggeredRef.current = true;
       }, longPressDelay);
     };
 
-    const handleTouchMove = () => {
-      clearLongPress();
+    const handleTouchMove = (event: L.LeafletMouseEvent) => {
+      const started = touchStartRef.current;
+      if (!started) return;
+      const movedMeters = map.distance([started.lat, started.lng], event.latlng);
+      if (movedMeters >= TOUCH_MOVE_CANCEL_METERS) {
+        clearLongPress();
+        touchStartRef.current = null;
+      }
     };
 
     const handleTouchEnd = () => {
-      // Touch tap should not place meetup accidentally.
+      const started = touchStartRef.current;
+      const holdMs = started ? Date.now() - started.timestamp : 0;
+      if (!longPressTriggeredRef.current && started && holdMs >= longPressDelay) {
+        onMapLongPress?.([started.lat, started.lng]);
+      }
+      touchStartRef.current = null;
       clearLongPress();
     };
 

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -1786,6 +1786,8 @@ Append only compact session deltas here as pointers when needed; full narrative 
 - 2026-04-06: Для `I6` заведены новые SupaPlan задачи: privacy `3edabd9c-6f88-4491-aa31-2f11566e3059`, replay UI `b2fb8b78-dc2d-4913-b379-caf22eb1c4e5`, speed-gradient `92b48f2c-9c24-451e-bd4e-7cc761a7fc68`, ordering/anti-spoof `2d2c9b4a-ca83-4f41-9bf6-75f7bc475830`, field QA + screenshots `e9c8f76f-0863-4f20-a871-6a09dd3bf7f8`.
 - 2026-04-06: По обратной связи оператора закрыт SupaPlan task `2d2c9b4a-ca83-4f41-9bf6-75f7bc475830`: в `lib/map-riders-reducer.ts` добавлены guardrails против out-of-order realtime packets и anti-spoof sanity checks (нереалистичные GPS прыжки/координаты отбрасываются). Дополнительно удалён бинарный screenshot из git и зафиксированы guardrails для `scripts/page-screenshot-skill.mjs` в `AGENTS.md`, `README.MD`, `docs/README_TLDR.md`.
 
+- 2026-04-17: T55 hotfix slice — закрыт P1 leak в `hooks/useLiveRiders.ts` (Telegram callback polling теперь гарантированно останавливается по timeout/resolve), усилен mobile long-press захват в `components/maps/MapInteractionCapture.tsx`, карта на `/franchize/vip-bike/map-riders` сделана ниже и full-bleed на mobile + добавлен нижний overlay для перекрытия attribution-зоны; demo rider координаты синхронизированы с базой на Стригинский переулок 13Б (`map_rider_sessions` + `live_locations`), а demo-id исключены из eviction в reducer, чтобы кластер не исчезал через несколько секунд.
+
 ---
 
 ## 8) Skills and tooling note

--- a/hooks/useLiveRiders.ts
+++ b/hooks/useLiveRiders.ts
@@ -188,14 +188,26 @@ export function useLiveRiders(options: UseLiveRidersOptions) {
       }
     } else {
       await new Promise<void>((resolve) => {
-        const timeout = setTimeout(resolve, 2200);
+        let settled = false;
+        let pollTimer: ReturnType<typeof setTimeout> | null = null;
+        const timeout = setTimeout(() => {
+          settled = true;
+          if (pollTimer) {
+            clearTimeout(pollTimer);
+            pollTimer = null;
+          }
+          resolve();
+        }, 2200);
+
         const check = () => {
+          if (settled) return;
           if (gotPoint) {
+            settled = true;
             clearTimeout(timeout);
             resolve();
             return;
           }
-          setTimeout(check, 100);
+          pollTimer = setTimeout(check, 100);
         };
         check();
       });

--- a/lib/map-riders-reducer.ts
+++ b/lib/map-riders-reducer.ts
@@ -149,6 +149,11 @@ export const initialMapRidersState: MapRidersState = {
 const STALE_MS = 30_000;   // 30s → faded
 const EVICT_MS = 120_000;  // 2min → removed
 const MAX_PLAUSIBLE_SPEED_KMH = 280;
+const DEMO_RIDER_PREFIX = "demo-rider-";
+
+function isPinnedDemoRider(userId: string): boolean {
+  return userId.startsWith(DEMO_RIDER_PREFIX);
+}
 
 function isFiniteCoordinate(lat: number, lng: number): boolean {
   return Number.isFinite(lat) && Number.isFinite(lng) && lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
@@ -290,6 +295,7 @@ export function mapRidersReducer(state: MapRidersState, action: MapRidersAction)
       const nextRiders = new Map(state.liveRiders);
 
       for (const [userId, rider] of nextRiders) {
+        if (isPinnedDemoRider(userId)) continue;
         const age = now - new Date(rider.updated_at).getTime();
         if (age > EVICT_MS) {
           nextRiders.delete(userId);


### PR DESCRIPTION
### Motivation
- Prevent unbounded timer chains when Telegram `requestLocation` runs in callback mode and never delivers a location (denied or missing) to avoid CPU/timer build-up for active sessions.
- Make long-press meetup placement reliable on mobile by tolerating small finger drift and triggering when hold duration is met.
- Improve mobile map presentation and demo experience so demo riders appear at the real home base and demo clusters don't disappear.

### Description
- Fixed the Telegram callback fallback in `hooks/useLiveRiders.ts` by adding a `settled` guard and a cancellable `pollTimer` so the internal polling stops on timeout or when a point arrives instead of chaining perpetual `setTimeout` calls.
- Hardened touch long-press behavior in `components/maps/MapInteractionCapture.tsx` by tracking touch start timestamp/coords, allowing a small move threshold (`TOUCH_MOVE_CANCEL_METERS`), and firing the long-press on `touchend` when the hold duration is met.
- Adjusted mobile map layout and attribution overlap in `components/map-riders/MapRidersClientRefactored.tsx` by reducing map min-height on mobile, making the map full-bleed horizontally, and adding a bottom overlay strip to bide the Leaflet attribution area.
- Aligned demo fallback point to VIP Bike home base coordinates `56.2041281, 43.7986412` and kept demo markers pinned by updating eviction behavior in `lib/map-riders-reducer.ts` to skip eviction for `demo-rider-*` IDs.
- Updated procedural diary entry in `docs/THE_FRANCHEEZEPLAN.md` to record this hotfix slice (per repo agent contract).
- Performed Supabase runtime updates to align demo data: updated `live_locations` and `map_rider_sessions` rows for `demo-rider-*` under crew `vip-bike` to the new coordinates and refreshed timestamps so the UI shows corrected demo locations.

### Testing
- Ran lint on changed files via `npx eslint hooks/useLiveRiders.ts components/maps/MapInteractionCapture.tsx components/map-riders/MapRidersClientRefactored.tsx lib/map-riders-reducer.ts` and it passed.
- Executed the smoke script `npm run qa:map-riders` which checks `GET /franchize/vip-bike/map-riders`, `/api/map-riders/overview`, `/api/map-riders/leaderboard`, `/api/map-riders/health`, and `/api/map-riders`; all checks returned HTTP 200 and the script completed successfully.
- Verified Supabase `live_locations` rows for the `demo-rider-*` set returned the updated coordinates and `updated_at` timestamps after the ops update (verification via REST query succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18b90bcac83248cf184436f1c63fb)