### PR TITLE
test: harden franchize doc-flow coverage & export map-route helpers

### DIFF
--- a/app/admin/map-routes/helpers.ts
+++ b/app/admin/map-routes/helpers.ts
@@ -1,0 +1,34 @@
+export function uniquePush(target: Array<[number, number]>, next: [number, number], tolerance = 0.00003) {
+  const prev = target[target.length - 1];
+  if (!prev) {
+    target.push(next);
+    return;
+  }
+  const same = Math.abs(prev[0] - next[0]) <= tolerance && Math.abs(prev[1] - next[1]) <= tolerance;
+  if (!same) target.push(next);
+}
+
+export function trimSuffixBySegment(
+  source: Array<[number, number]>,
+  suffix: Array<[number, number]>,
+  tolerance = 0.0001,
+): Array<[number, number]> {
+  if (!source.length || !suffix.length || source.length <= suffix.length) return source;
+  const start = source.length - suffix.length;
+  const matches = suffix.every((point, index) => {
+    const candidate = source[start + index];
+    return (
+      Math.abs(candidate[0] - point[0]) <= tolerance && Math.abs(candidate[1] - point[1]) <= tolerance
+    );
+  });
+  if (!matches) return source;
+  return source.slice(0, start);
+}
+
+export function mergeSegments(...segments: Array<Array<[number, number]>>): Array<[number, number]> {
+  const merged: Array<[number, number]> = [];
+  for (const segment of segments) {
+    for (const point of segment) uniquePush(merged, point);
+  }
+  return merged;
+}

--- a/app/admin/map-routes/page.tsx
+++ b/app/admin/map-routes/page.tsx
@@ -80,7 +80,7 @@ function geojsonToCoords(value: unknown): Array<[number, number]> {
   return result;
 }
 
-function trimSuffixBySegment(
+export function trimSuffixBySegment(
   source: Array<[number, number]>,
   suffix: Array<[number, number]>,
   tolerance = 0.0001,
@@ -97,7 +97,7 @@ function trimSuffixBySegment(
   return source.slice(0, start);
 }
 
-function mergeSegments(...segments: Array<Array<[number, number]>>): Array<[number, number]> {
+export function mergeSegments(...segments: Array<Array<[number, number]>>): Array<[number, number]> {
   const merged: Array<[number, number]> = [];
   for (const segment of segments) {
     for (const point of segment) uniquePush(merged, point);

--- a/app/admin/map-routes/page.tsx
+++ b/app/admin/map-routes/page.tsx
@@ -10,6 +10,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import { Badge } from '@/components/ui/badge';
 import dynamic from 'next/dynamic';
 import type { PointOfInterest } from '@/lib/map-utils';
+import { mergeSegments, trimSuffixBySegment, uniquePush } from './helpers';
 
 const RacingMap = dynamic(() => import('@/components/maps/RacingMap').then((mod) => mod.RacingMap), { ssr: false });
 
@@ -46,16 +47,6 @@ function parseWaypoints(raw: string): Array<{ lat: string; lon: string }> {
   }
 }
 
-function uniquePush(target: Array<[number, number]>, next: [number, number], tolerance = 0.00003) {
-  const prev = target[target.length - 1];
-  if (!prev) {
-    target.push(next);
-    return;
-  }
-  const same = Math.abs(prev[0] - next[0]) <= tolerance && Math.abs(prev[1] - next[1]) <= tolerance;
-  if (!same) target.push(next);
-}
-
 function geojsonToCoords(value: unknown): Array<[number, number]> {
   if (!value || typeof value !== 'object') return [];
   const result: Array<[number, number]> = [];
@@ -78,31 +69,6 @@ function geojsonToCoords(value: unknown): Array<[number, number]> {
   }
 
   return result;
-}
-
-export function trimSuffixBySegment(
-  source: Array<[number, number]>,
-  suffix: Array<[number, number]>,
-  tolerance = 0.0001,
-): Array<[number, number]> {
-  if (!source.length || !suffix.length || source.length <= suffix.length) return source;
-  const start = source.length - suffix.length;
-  const matches = suffix.every((point, index) => {
-    const candidate = source[start + index];
-    return (
-      Math.abs(candidate[0] - point[0]) <= tolerance && Math.abs(candidate[1] - point[1]) <= tolerance
-    );
-  });
-  if (!matches) return source;
-  return source.slice(0, start);
-}
-
-export function mergeSegments(...segments: Array<Array<[number, number]>>): Array<[number, number]> {
-  const merged: Array<[number, number]> = [];
-  for (const segment of segments) {
-    for (const point of segment) uniquePush(merged, point);
-  }
-  return merged;
 }
 
 async function generateRoadSegment(waypoints: Array<[number, number]>): Promise<Array<[number, number]>> {

--- a/tests/franchize/doc-flow.spec.ts
+++ b/tests/franchize/doc-flow.spec.ts
@@ -1,53 +1,54 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const createInvoiceMock = vi.fn();
-const notifyAdminMock = vi.fn();
-const sendTelegramDocumentMock = vi.fn();
-const sendTelegramInvoiceMock = vi.fn();
-const loggerErrorMock = vi.fn();
-const buildDocxMock = vi.fn();
-const getUserSensitiveDataMock = vi.fn();
-const getCrewSensitiveDataMock = vi.fn();
-
-const fromMock = vi.fn();
+const mocks = vi.hoisted(() => ({
+  createInvoice: vi.fn(),
+  notifyAdmin: vi.fn(),
+  sendTelegramDocument: vi.fn(),
+  sendTelegramInvoice: vi.fn(),
+  loggerError: vi.fn(),
+  buildDocx: vi.fn(),
+  getUserSensitiveData: vi.fn(),
+  getCrewSensitiveData: vi.fn(),
+  from: vi.fn(),
+}));
 
 vi.mock('@/lib/supabase-server', () => ({
-  createInvoice: createInvoiceMock,
+  createInvoice: mocks.createInvoice,
   supabaseAdmin: {
-    from: fromMock,
+    from: mocks.from,
   },
 }));
 
 vi.mock('@/app/actions', () => ({
-  notifyAdmin: notifyAdminMock,
-  sendTelegramDocument: sendTelegramDocumentMock,
-  sendTelegramInvoice: sendTelegramInvoiceMock,
+  notifyAdmin: mocks.notifyAdmin,
+  sendTelegramDocument: mocks.sendTelegramDocument,
+  sendTelegramInvoice: mocks.sendTelegramInvoice,
 }));
 
 vi.mock('@/lib/logger', () => ({
   logger: {
-    error: loggerErrorMock,
+    error: mocks.loggerError,
     warn: vi.fn(),
     info: vi.fn(),
   },
 }));
 
 vi.mock('@/app/franchize/lib/docx-capability', () => ({
-  buildFranchizeDocxFromTemplate: buildDocxMock,
+  buildFranchizeDocxFromTemplate: mocks.buildDocx,
 }));
 
 vi.mock('@/app/lib/private-secrets', () => ({
-  getUserSensitiveData: getUserSensitiveDataMock,
-  getCrewSensitiveData: getCrewSensitiveDataMock,
+  getUserSensitiveData: mocks.getUserSensitiveData,
+  getCrewSensitiveData: mocks.getCrewSensitiveData,
   saveCrewSensitiveData: vi.fn(),
 }));
 
 import { createFranchizeOrderCheckout } from '@/app/franchize/actions';
 
-function buildPayload(payment: 'telegram_xtr' | 'card' = 'telegram_xtr') {
+function buildPayload(payment: 'telegram_xtr' | 'card' = 'telegram_xtr', orderId = 'order-1') {
   return {
     slug: 'vip-bike',
-    orderId: 'order-1',
+    orderId,
     telegramUserId: '42',
     recipient: 'Ivan Ivanov',
     phone: '+79998887766',
@@ -127,34 +128,34 @@ function buildSupabaseFromMock() {
 describe('franchize checkout doc-flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    fromMock.mockImplementation(buildSupabaseFromMock());
-    getUserSensitiveDataMock.mockResolvedValue({});
-    getCrewSensitiveDataMock.mockResolvedValue({ contractDefaults: {} });
-    sendTelegramDocumentMock.mockResolvedValue({ success: true });
-    notifyAdminMock.mockResolvedValue({ success: true });
-    sendTelegramInvoiceMock.mockResolvedValue({ success: true });
-    createInvoiceMock.mockResolvedValue({ success: true });
-    buildDocxMock.mockResolvedValue({ bytes: new Uint8Array([1, 2, 3]), renderedMarkdown: 'ok' });
+    mocks.from.mockImplementation(buildSupabaseFromMock());
+    mocks.getUserSensitiveData.mockResolvedValue({});
+    mocks.getCrewSensitiveData.mockResolvedValue({ contractDefaults: {} });
+    mocks.sendTelegramDocument.mockResolvedValue({ success: true });
+    mocks.notifyAdmin.mockResolvedValue({ success: true });
+    mocks.sendTelegramInvoice.mockResolvedValue({ success: true });
+    mocks.createInvoice.mockResolvedValue({ success: true });
+    mocks.buildDocx.mockResolvedValue({ bytes: new Uint8Array([1, 2, 3]), renderedMarkdown: 'ok' });
     vi.stubEnv('ADMIN_CHAT_ID', '417553377');
   });
 
   it('does not create invoice when DOCX generation fails', async () => {
-    buildDocxMock.mockRejectedValueOnce(new Error('docx render failed'));
+    mocks.buildDocx.mockRejectedValueOnce(new Error('docx render failed'));
 
-    const result = await createFranchizeOrderCheckout(buildPayload('telegram_xtr'));
+    const result = await createFranchizeOrderCheckout(buildPayload('telegram_xtr', 'order-2'));
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('docx render failed');
-    expect(createInvoiceMock).not.toHaveBeenCalled();
-    expect(sendTelegramInvoiceMock).not.toHaveBeenCalled();
+    expect(mocks.createInvoice).not.toHaveBeenCalled();
+    expect(mocks.sendTelegramInvoice).not.toHaveBeenCalled();
   });
 
   it('creates and sends invoice only after DOCX delivery succeeds', async () => {
     const result = await createFranchizeOrderCheckout(buildPayload('telegram_xtr'));
 
     expect(result.success).toBe(true);
-    expect(createInvoiceMock).toHaveBeenCalledTimes(1);
-    expect(sendTelegramInvoiceMock).toHaveBeenCalledTimes(1);
-    expect(sendTelegramDocumentMock).toHaveBeenCalled();
+    expect(mocks.createInvoice).toHaveBeenCalledTimes(1);
+    expect(mocks.sendTelegramInvoice).toHaveBeenCalledTimes(1);
+    expect(mocks.sendTelegramDocument).toHaveBeenCalled();
   });
 });

--- a/tests/franchize/doc-flow.spec.ts
+++ b/tests/franchize/doc-flow.spec.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createInvoiceMock = vi.fn();
+const notifyAdminMock = vi.fn();
+const sendTelegramDocumentMock = vi.fn();
+const sendTelegramInvoiceMock = vi.fn();
+const loggerErrorMock = vi.fn();
+const buildDocxMock = vi.fn();
+const getUserSensitiveDataMock = vi.fn();
+const getCrewSensitiveDataMock = vi.fn();
+
+const fromMock = vi.fn();
+
+vi.mock('@/lib/supabase-server', () => ({
+  createInvoice: createInvoiceMock,
+  supabaseAdmin: {
+    from: fromMock,
+  },
+}));
+
+vi.mock('@/app/actions', () => ({
+  notifyAdmin: notifyAdminMock,
+  sendTelegramDocument: sendTelegramDocumentMock,
+  sendTelegramInvoice: sendTelegramInvoiceMock,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: loggerErrorMock,
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@/app/franchize/lib/docx-capability', () => ({
+  buildFranchizeDocxFromTemplate: buildDocxMock,
+}));
+
+vi.mock('@/app/lib/private-secrets', () => ({
+  getUserSensitiveData: getUserSensitiveDataMock,
+  getCrewSensitiveData: getCrewSensitiveDataMock,
+  saveCrewSensitiveData: vi.fn(),
+}));
+
+import { createFranchizeOrderCheckout } from '@/app/franchize/actions';
+
+function buildPayload(payment: 'telegram_xtr' | 'card' = 'telegram_xtr') {
+  return {
+    slug: 'vip-bike',
+    orderId: 'order-1',
+    telegramUserId: '42',
+    recipient: 'Ivan Ivanov',
+    phone: '+79998887766',
+    time: '10:00',
+    comment: '',
+    payment,
+    delivery: 'pickup',
+    subtotal: 100000,
+    extrasTotal: 0,
+    totalAmount: 100000,
+    extras: [],
+    cartLines: [
+      {
+        lineId: 'line-1',
+        itemId: 'car-1',
+        qty: 1,
+        pricePerDay: 100000,
+        lineTotal: 100000,
+        options: {
+          package: 'Базовый',
+          duration: '1 день',
+          perk: 'Стандарт',
+          auction: 'Без аукциона',
+        },
+      },
+    ],
+  };
+}
+
+function buildSupabaseFromMock() {
+  return (table: string) => {
+    if (table === 'franchize_order_notifications') {
+      return {
+        insert: () => ({
+          select: () => ({
+            single: async () => ({ data: { id: 'log-1' }, error: null }),
+          }),
+        }),
+        update: () => ({
+          eq: async () => ({ error: null }),
+        }),
+      };
+    }
+
+    if (table === 'cars') {
+      return {
+        select: () => ({
+          in: async () => ({ data: [{ id: 'car-1', make: 'Yamaha', model: 'Tracer', specs: {} }], error: null }),
+        }),
+      };
+    }
+
+    if (table === 'crews') {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: null }),
+          }),
+        }),
+      };
+    }
+
+    if (table === 'invoices') {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: null }),
+          }),
+        }),
+      };
+    }
+
+    throw new Error(`Unexpected table mock request: ${table}`);
+  };
+}
+
+describe('franchize checkout doc-flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromMock.mockImplementation(buildSupabaseFromMock());
+    getUserSensitiveDataMock.mockResolvedValue({});
+    getCrewSensitiveDataMock.mockResolvedValue({ contractDefaults: {} });
+    sendTelegramDocumentMock.mockResolvedValue({ success: true });
+    notifyAdminMock.mockResolvedValue({ success: true });
+    sendTelegramInvoiceMock.mockResolvedValue({ success: true });
+    createInvoiceMock.mockResolvedValue({ success: true });
+    buildDocxMock.mockResolvedValue({ bytes: new Uint8Array([1, 2, 3]), renderedMarkdown: 'ok' });
+    vi.stubEnv('ADMIN_CHAT_ID', '417553377');
+  });
+
+  it('does not create invoice when DOCX generation fails', async () => {
+    buildDocxMock.mockRejectedValueOnce(new Error('docx render failed'));
+
+    const result = await createFranchizeOrderCheckout(buildPayload('telegram_xtr'));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('docx render failed');
+    expect(createInvoiceMock).not.toHaveBeenCalled();
+    expect(sendTelegramInvoiceMock).not.toHaveBeenCalled();
+  });
+
+  it('creates and sends invoice only after DOCX delivery succeeds', async () => {
+    const result = await createFranchizeOrderCheckout(buildPayload('telegram_xtr'));
+
+    expect(result.success).toBe(true);
+    expect(createInvoiceMock).toHaveBeenCalledTimes(1);
+    expect(sendTelegramInvoiceMock).toHaveBeenCalledTimes(1);
+    expect(sendTelegramDocumentMock).toHaveBeenCalled();
+  });
+});

--- a/tests/franchize/e2e/flow.spec.ts
+++ b/tests/franchize/e2e/flow.spec.ts
@@ -25,4 +25,18 @@ test.describe('franchize renting flow characterization', () => {
       expect(response.status()).toBeLessThan(300);
     }
   });
+
+  test('doc delivery assertion endpoint reports sent status after checkout flow', async ({ request }) => {
+    const assertUrl = process.env.FRANCHIZE_QA_DOC_ASSERT_URL;
+    if (!assertUrl) {
+      test.skip(true, 'FRANCHIZE_QA_DOC_ASSERT_URL is not configured for doc delivery verification.');
+      return;
+    }
+
+    const response = await request.get(assertUrl);
+    expect(response.ok(), `Expected QA doc assertion endpoint to be reachable: ${assertUrl}`).toBeTruthy();
+
+    const payload = await response.json();
+    expect(payload).toMatchObject({ success: true, sendStatus: 'sent' });
+  });
 });

--- a/tests/franchize/map-route-helpers.spec.ts
+++ b/tests/franchize/map-route-helpers.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { mergeSegments, trimSuffixBySegment } from '@/app/admin/map-routes/page';
+
+describe('map route helper utilities', () => {
+  it('trimSuffixBySegment removes a matching suffix only', () => {
+    const source: Array<[number, number]> = [
+      [56.1, 43.1],
+      [56.2, 43.2],
+      [56.3, 43.3],
+      [56.4, 43.4],
+    ];
+
+    const result = trimSuffixBySegment(source, [
+      [56.3, 43.3],
+      [56.4, 43.4],
+    ]);
+
+    expect(result).toEqual([
+      [56.1, 43.1],
+      [56.2, 43.2],
+    ]);
+  });
+
+  it('mergeSegments deduplicates boundary points', () => {
+    const result = mergeSegments(
+      [
+        [56.1, 43.1],
+        [56.2, 43.2],
+      ],
+      [
+        [56.2, 43.2],
+        [56.3, 43.3],
+      ],
+      [
+        [56.3, 43.3],
+        [56.4, 43.4],
+      ],
+    );
+
+    expect(result).toEqual([
+      [56.1, 43.1],
+      [56.2, 43.2],
+      [56.3, 43.3],
+      [56.4, 43.4],
+    ]);
+  });
+});

--- a/tests/franchize/map-route-helpers.spec.ts
+++ b/tests/franchize/map-route-helpers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mergeSegments, trimSuffixBySegment } from '@/app/admin/map-routes/page';
+import { mergeSegments, trimSuffixBySegment } from '@/app/admin/map-routes/helpers';
 
 describe('map route helper utilities', () => {
   it('trimSuffixBySegment removes a matching suffix only', () => {


### PR DESCRIPTION
### Motivation

- Ensure the franchize checkout → doc → invoice flow is safe by proving invoices are not created if DOCX generation fails. 
- Make map-route helper utilities testable by exporting `trimSuffixBySegment` and `mergeSegments` so small deterministic unit tests can cover key behaviors. 
- Add an optional Playwright check to let CI/QA assert that a separate doc-delivery probe reports `sent` after an end-to-end checkout flow.

### Description

- Add `tests/franchize/doc-flow.spec.ts` which mocks `supabaseAdmin`, `createInvoice`, `notifyAdmin`, `sendTelegramDocument`, `sendTelegramInvoice`, `buildFranchizeDocxFromTemplate`, and private-secrets helpers to characterize `createFranchizeOrderCheckout` and assert that invoice creation/sending is blocked when DOCX generation fails and proceeds only after document delivery succeeds. 
- Export `trimSuffixBySegment` and `mergeSegments` from `app/admin/map-routes/page.tsx` to allow direct unit testing. 
- Add `tests/franchize/map-route-helpers.spec.ts` unit tests covering suffix trimming and boundary deduplication for `mergeSegments`. 
- Extend `tests/franchize/e2e/flow.spec.ts` with an optional Playwright test that probes `FRANCHIZE_QA_DOC_ASSERT_URL` to verify doc delivery `sendStatus: 'sent'` when a QA assertion endpoint is provided.

### Testing

- Attempted `npm run test -- tests/franchize/doc-flow.spec.ts tests/franchize/map-route-helpers.spec.ts`, but the runner failed with `vitest: not found` in this environment so unit tests could not be executed here. 
- Attempted `npx vitest run tests/franchize/doc-flow.spec.ts tests/franchize/map-route-helpers.spec.ts`, but execution failed due to unresolved local `vitest/config` because `node_modules` are not installed in this environment. 
- Attempted `npm run test:e2e -- --grep franchize --list`, but `playwright` is not available in this runner so E2E checks could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ba22835483259626df1a8db8526b)