### PR TITLE
supaplan_task:c55e20dc-f8a4-47a0-9dda-d16a44de3ef9 hide admin-only franchize links for non-admin users

### DIFF
--- a/app/franchize/components/FranchizeProfileButton.tsx
+++ b/app/franchize/components/FranchizeProfileButton.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { ChevronDown, Palette, Settings, Shield, User, IdCard } from "lucide-react";
 import { useAppContext } from "@/contexts/AppContext";
+import { useIsAdmin } from "@/app/franchize/hooks/useIsAdmin";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,11 +32,11 @@ function getInitials(name: string): string {
 }
 
 export function FranchizeProfileButton({ bgColor, textColor, borderColor, currentSlug }: FranchizeProfileButtonProps) {
-  const { dbUser, user, userCrewInfo, isAdmin } = useAppContext();
+  const { dbUser, user, userCrewInfo } = useAppContext();
   const effectiveUser = dbUser || user;
   const displayName = effectiveUser?.username || effectiveUser?.full_name || effectiveUser?.first_name || "Operator";
   const avatarUrl = dbUser?.avatar_url || user?.photo_url;
-  const userIsAdmin = typeof isAdmin === "function" ? isAdmin() : false;
+  const userIsAdmin = useIsAdmin();
   const scopeSlug = currentSlug || userCrewInfo?.slug || "vip-bike";
   const franchizeAdminHref = `/franchize/${scopeSlug}/admin`;
   const franchizeProfileHref = `/franchize/${scopeSlug}/profile`;
@@ -88,12 +89,14 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
             </Link>
           </DropdownMenuItem>
 
-          <DropdownMenuItem asChild>
-            <Link href={franchizeAdminHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-              <Shield className="mr-2 h-4 w-4 shrink-0" />
-              <span className="truncate">Franchize admin</span>
-            </Link>
-          </DropdownMenuItem>
+          {userIsAdmin ? (
+            <DropdownMenuItem asChild>
+              <Link href={franchizeAdminHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                <Shield className="mr-2 h-4 w-4 shrink-0" />
+                <span className="truncate">Franchize admin</span>
+              </Link>
+            </DropdownMenuItem>
+          ) : null}
 
           <DropdownMenuItem asChild>
             <Link href={franchizeProfileHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">

--- a/app/franchize/hooks/useIsAdmin.ts
+++ b/app/franchize/hooks/useIsAdmin.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useMemo } from "react";
+import { useAppContext } from "@/contexts/AppContext";
+
+const CREW_ADMIN_ROLES = new Set(["owner", "admin", "manager"]);
+
+export function useIsAdmin(): boolean {
+  const { isAdmin, dbUser, userCrewInfo } = useAppContext();
+
+  return useMemo(() => {
+    const hasGlobalAdmin = typeof isAdmin === "function" ? isAdmin() : false;
+    if (hasGlobalAdmin) return true;
+
+    const dbRole = String(dbUser?.role || "").toLowerCase();
+    if (dbRole === "admin" || dbRole === "vpradmin") return true;
+
+    const crewRole = String((userCrewInfo as { role?: string } | null)?.role || "").toLowerCase();
+    return CREW_ADMIN_ROLES.has(crewRole);
+  }, [isAdmin, dbUser?.role, userCrewInfo]);
+}

--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -20,6 +20,7 @@ import { useMaps } from "@/lib/maps/useMaps";
 import { MapRidersProvider, useMapRiders } from "@/hooks/useMapRidersContext";
 import { formatRideDuration, initialsFromName, riderDisplayName } from "@/lib/map-riders";
 import { useLiveRiders } from "@/hooks/useLiveRiders";
+import { useIsAdmin } from "@/app/franchize/hooks/useIsAdmin";
 import { getMapRidersWriteHeaders } from "@/lib/map-riders-client-auth";
 import { FranchizeConfirmModal } from "@/app/franchize/components/FranchizeConfirmModal";
 import { FranchizePromptModal } from "@/app/franchize/components/FranchizePromptModal";
@@ -42,6 +43,7 @@ const MEETUP_ACTION_DEBOUNCE_MS = 2000;
 function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
   const { dbUser } = useAppContext();
   const { state, dispatch, crewSlug, fetchSnapshot, fetchSessionDetail } = useMapRiders();
+  const isAdmin = useIsAdmin();
   const [isQuickMeetupSaving, setIsQuickMeetupSaving] = useState(false);
   const [selectedMeetupId, setSelectedMeetupId] = useState<string | null>(null);
   const [isMeetupDeleting, setIsMeetupDeleting] = useState(false);
@@ -392,9 +394,11 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
             {state.shareEnabled ? "Ты сейчас в эфире на карте" : "Геошеринг выключен"}
           </p>
           <div className="mt-4 space-y-3">
-            <Button asChild variant="outline" className="w-full justify-center">
-              <Link href="/admin/map-routes">Открыть маршруты карты</Link>
-            </Button>
+            {isAdmin ? (
+              <Button asChild variant="outline" className="w-full justify-center">
+                <Link href="/admin/map-routes">Открыть маршруты карты</Link>
+              </Button>
+            ) : null}
             <div className="space-y-2 rounded-xl border border-white/10 bg-black/20 p-3">
               <Input
                 value={state.rideName}

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -1821,3 +1821,4 @@ For operator shortcut mode `FRANCHEEZEPLAN_EXECUTIONER`, use:
 Detailed historical execution notes moved to:
 - `docs/THE_FRANCHEEZEPLAN_HISTORY_ARCHIVE.md`
 - `docs/AGENT_DIARY.md` (compact) and `docs/AGENT_DIARY_ARCHIVE_2026Q1.md` (full)
+- 2026-04-23: Выполнен UX-02 (`c55e20dc-f8a8-47a0-9dda-d16a44de3ef9`) — добавлен хук `useIsAdmin` для единой проверки глобальной/crew-admin роли, скрыты admin-only ссылки для non-admin в `MapRidersClientRefactored` (`/admin/map-routes`) и в профайл-меню franchize (`Franchize admin`).


### PR DESCRIPTION
### Motivation
- Centralize admin-role checks and prevent non-admin users from seeing or navigating to admin-only controls in the franchize UI to reduce accidental actions and surface confusion.
- Keep visibility logic consistent across MapRiders and profile dropdown by using a single shared hook.

### Description
- Added a new client hook `app/franchize/hooks/useIsAdmin.ts` that consolidates global admin checks and crew-role checks into one reusable utility.
- Replaced inline admin visibility checks with `useIsAdmin()` in `components/map-riders/MapRidersClientRefactored.tsx` to hide the `/admin/map-routes` button for non-admins and in `app/franchize/components/FranchizeProfileButton.tsx` to hide the `Franchize admin` dropdown link for non-admins.
- Updated the execution diary with a short note in `docs/THE_FRANCHEEZEPLAN.md` and included the SupaPlan task reference in the PR body: `supaplan_task: c55e20dc-f8a8-47a0-9dda-d16a44de3ef9`.

### Testing
- Ran lint: `npm run lint -- --file components/map-riders/MapRidersClientRefactored.tsx --file app/franchize/components/FranchizeProfileButton.tsx --file app/franchize/hooks/useIsAdmin.ts`, which completed with no ESLint warnings or errors.
- No unit/test suite was executed in this change; visual verification (UI screenshot) was not possible in the current runner environment.
- Files changed: `app/franchize/hooks/useIsAdmin.ts` (new), `components/map-riders/MapRidersClientRefactored.tsx` (modified), `app/franchize/components/FranchizeProfileButton.tsx` (modified), and `docs/THE_FRANCHEEZEPLAN.md` (modified).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5a0b82748325bbb08dcb15821051)
supaplan_task:c55e20dc-f8a4-47a0-9dda-d16a44de3ef9