### PR TITLE
supaplan_task:c55e20dc-f8a8-47a0-9dda-d16a44de3ef9 Restrict franchize admin links to real admins

### DIFF
--- a/app/franchize/hooks/useIsAdmin.ts
+++ b/app/franchize/hooks/useIsAdmin.ts
@@ -3,19 +3,19 @@
 import { useMemo } from "react";
 import { useAppContext } from "@/contexts/AppContext";
 
-const CREW_ADMIN_ROLES = new Set(["owner", "admin", "manager"]);
+const ADMIN_ROLES = new Set(["admin", "vpradmin"]);
 
 export function useIsAdmin(): boolean {
-  const { isAdmin, dbUser, userCrewInfo } = useAppContext();
+  const { isAdmin, dbUser } = useAppContext();
 
   return useMemo(() => {
     const hasGlobalAdmin = typeof isAdmin === "function" ? isAdmin() : false;
     if (hasGlobalAdmin) return true;
 
     const dbRole = String(dbUser?.role || "").toLowerCase();
-    if (dbRole === "admin" || dbRole === "vpradmin") return true;
+    if (ADMIN_ROLES.has(dbRole)) return true;
 
-    const crewRole = String((userCrewInfo as { role?: string } | null)?.role || "").toLowerCase();
-    return CREW_ADMIN_ROLES.has(crewRole);
-  }, [isAdmin, dbUser?.role, userCrewInfo]);
+    const dbStatus = String(dbUser?.status || "").toLowerCase();
+    return dbStatus === "admin";
+  }, [isAdmin, dbUser?.role, dbUser?.status]);
 }


### PR DESCRIPTION
### Motivation
- Prevent non-admin users from seeing admin-only links by removing crew-role based escalation and relying only on explicit admin signals.

### Description
- Modify `app/franchize/hooks/useIsAdmin.ts` to stop treating crew roles (`owner`/`manager`) as admins and instead return true only when global `isAdmin()` is true or when the DB indicates `role` is `admin`/`vpradmin` or `status` is `admin`.

supaplan_task: c55e20dc-f8a8-47a0-9dda-d16a44de3ef9

### Testing
- Confirmed task lifecycle with `node scripts/supaplan-skill.mjs task-status --taskId c55e20dc-f8a8-47a0-9dda-d16a44de3ef9` and moved status to `ready_for_pr` successfully; attempted `npm run -s lint` and `npm run -s lint -- app/franchize/hooks/useIsAdmin.ts` which failed/produced repo-level warnings due to existing Next.js/lint workspace issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5bd1a42883259dee3282d612546e)