### PR TITLE
We'll overhaul the franchize status page into an interactive, double-c

### DIFF
--- a/app/supaplan/actions.ts
+++ b/app/supaplan/actions.ts
@@ -84,7 +84,7 @@ export type PriorityTask = {
  *   polishing 1.2, ux-fix 1.2, seo 1.1, code-quality 1.0, tech-debt 0.8, post-launch 0.7
  * - Capability base weight (higher = more foundational).
  * - Priority tag (from metadata.priority or body JSON) → critical 2.5, high 2.0, medium 1.5, low 1.0.
- *   Tags like "p0", "p1", "p2" in body also mapped: p0=2.5, p1=2.0, p2=1.5.
+ *   Tags like "p0", "p1", "p2" in body also mapped: p0=2.5, p2=1.5.
  *   The strongest multiplier wins.
  * - Freshness boost: 2.0 if created within last 48h, 1.5 if within last 7d,
  *   0.8 if older than 30d (to slightly demote stale tasks).
@@ -194,11 +194,10 @@ export async function getTopPriorityTasks(): Promise<{
       const maxPriority = Math.max(fromTag, fromText, 1.0);
       if (maxPriority > 1.0) {
         priorityMult = maxPriority;
-        priorityLabel =
-          fromTag >= maxPriority ? ` ${bodyPriorityTag.toUpperCase()}` : ` ${metaPriorityText}`;
+        priorityLabel = fromTag >= maxPriority ? ` ${bodyPriorityTag.toUpperCase()}` : ` ${metaPriorityText}`;
       }
 
-      // Freshness boost – new tasks get bonus, old ones slightly penalised
+      // Freshness boost
       const ageDays = (Date.now() - new Date(task.created_at).getTime()) / (1000 * 60 * 60 * 24);
       let freshnessMult = 1.0;
       let freshnessLabel = "";

--- a/app/supaplan/actions.ts
+++ b/app/supaplan/actions.ts
@@ -82,3 +82,122 @@ export async function notifyTaskPickInTelegram(input: TaskNotifyInput) {
 
   return { success: true };
 }
+
+export type PriorityTask = {
+  id: string;
+  title: string;
+  status: string;
+  capability: string | null;
+  score: number;
+  reasoning: string;
+};
+
+/**
+ * Scores a non‑done franchize task based on status, phase, and capability importance.
+ * Returns the 5 tasks with the highest priority score.
+ */
+export async function getTopPriorityTasks(): Promise<{
+  success: boolean;
+  data?: PriorityTask[];
+  error?: string;
+}> {
+  try {
+    // 1. Fetch all non‑done franchize tasks
+    const { data, error } = await supabaseAdmin
+      .from("supaplan_tasks")
+      .select("id,title,status,capability,created_at")
+      .or("capability.like.franchize.%,capability.eq.greenbox.franchize")
+      .neq("status", "done")
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+    if (!data || data.length === 0) {
+      return { success: true, data: [] };
+    }
+
+    // 2. Scoring weights (all tunable)
+    const statusScore: Record<string, number> = {
+      open: 10,
+      claimed: 7,
+      running: 5,
+      ready_for_pr: 3,
+    };
+
+    const phaseMultiplier: Record<string, number> = {
+      "Апрель": 1.5,
+      "Май": 1.3,
+      "Июнь": 1.1,
+      "Лето": 0.9,
+      "2027": 0.7,
+    };
+
+    // Capability priority: higher = more foundational
+    const capabilityImportance: Record<string, number> = {
+      "franchize.rental": 1.4,
+      "franchize.backend.supabase": 1.4,
+      "franchize.info": 1.2,
+      "franchize.telegram": 1.2,
+      "franchize.analytics": 1.1,
+      "franchize.kpi": 1.1,
+      "franchize.ui.ux": 1.0,
+      "franchize.onboarding": 1.0,
+      "franchize.integration": 0.9,
+      "franchize.sales": 0.9,
+      "franchize.growth": 0.8,
+      "franchize.gamification": 0.7,
+    };
+
+    const phaseMap: Record<string, string> = {
+      "franchize.info": "Апрель",
+      "franchize.rental": "Апрель",
+      "franchize.kpi": "Апрель",
+      "franchize.telegram": "Апрель",
+      "franchize.analytics": "Апрель",
+      "franchize.ui.ux": "Апрель",
+      "franchize.backend.supabase": "Апрель",
+      "franchize.sales": "Май",
+      "franchize.onboarding": "Май",
+      "franchize.growth": "Май",
+      "franchize.integration": "Июнь",
+      "franchize.gamification": "Лето",
+    };
+
+    // 3. Calculate priority score for each task
+    const scored = (data as any[]).map((task: any) => {
+      const baseScore = statusScore[task.status] || 0;
+      const capability = task.capability || "";
+      const phase = phaseMap[capability] || "2027";
+      const phaseMult = phaseMultiplier[phase] || 1.0;
+      const capImportance = capabilityImportance[capability] || 1.0;
+
+      // Age boost: tasks created more than 7 days ago get +0.5
+      const ageDays = (Date.now() - new Date(task.created_at).getTime()) / (1000 * 60 * 60 * 24);
+      const ageBoost = ageDays > 7 ? 0.5 : 0;
+
+      const total = baseScore * phaseMult * capImportance + ageBoost;
+
+      let reasoning = `${baseScore} (статус) × ${phaseMult} (фаза ${phase}) × ${capImportance} (важность)`;
+      if (ageBoost > 0) reasoning += ` +0.5 (старше 7 дней)`;
+
+      return { ...task, score: Math.round(total * 10) / 10, reasoning };
+    });
+
+    // 4. Sort descending, pick top 5
+    scored.sort((a: any, b: any) => b.score - a.score);
+    const top5 = scored.slice(0, 5).map(
+      (t: any): PriorityTask => ({
+        id: t.id,
+        title: t.title,
+        status: t.status,
+        capability: t.capability,
+        score: t.score,
+        reasoning: t.reasoning,
+      })
+    );
+
+    return { success: true, data: top5 };
+  } catch (err: any) {
+    console.error("[getTopPriorityTasks]", err);
+    return { success: false, error: err.message || "Failed to compute priority tasks" };
+  }
+}

--- a/app/supaplan/actions.ts
+++ b/app/supaplan/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { supabaseAdmin } from "@/hooks/supabase";
+import { supabaseAdmin } from "@/lib/supabase-server";
 import { sendTelegramMessageCore } from "@/app/core/telegram_actions";
 
 type TaskNotifyInput = {
@@ -93,7 +93,8 @@ export type PriorityTask = {
 };
 
 /**
- * Scores a non‑done franchize task based on status, phase, and capability importance.
+ * Scores a non‑done franchize task based on status, phase, capability importance,
+ * and an optional JSON‑encoded priority (p0/p1/p2) in the `body` field.
  * Returns the 5 tasks with the highest priority score.
  */
 export async function getTopPriorityTasks(): Promise<{
@@ -102,10 +103,10 @@ export async function getTopPriorityTasks(): Promise<{
   error?: string;
 }> {
   try {
-    // 1. Fetch all non‑done franchize tasks
+    // 1. Fetch all non‑done franchize tasks, including the body
     const { data, error } = await supabaseAdmin
       .from("supaplan_tasks")
-      .select("id,title,status,capability,created_at")
+      .select("id,title,status,capability,created_at,body")
       .or("capability.like.franchize.%,capability.eq.greenbox.franchize")
       .neq("status", "done")
       .order("created_at", { ascending: false });
@@ -115,7 +116,7 @@ export async function getTopPriorityTasks(): Promise<{
       return { success: true, data: [] };
     }
 
-    // 2. Scoring weights (all tunable)
+    // 2. Scoring weights
     const statusScore: Record<string, number> = {
       open: 10,
       claimed: 7,
@@ -131,15 +132,15 @@ export async function getTopPriorityTasks(): Promise<{
       "2027": 0.7,
     };
 
-    // Capability priority: higher = more foundational
+    // Capability priority – bumped ui.ux significantly
     const capabilityImportance: Record<string, number> = {
       "franchize.rental": 1.4,
       "franchize.backend.supabase": 1.4,
+      "franchize.ui.ux": 1.8,   // was 1.0 → now top tier
       "franchize.info": 1.2,
       "franchize.telegram": 1.2,
       "franchize.analytics": 1.1,
       "franchize.kpi": 1.1,
-      "franchize.ui.ux": 1.0,
       "franchize.onboarding": 1.0,
       "franchize.integration": 0.9,
       "franchize.sales": 0.9,
@@ -162,6 +163,13 @@ export async function getTopPriorityTasks(): Promise<{
       "franchize.gamification": "Лето",
     };
 
+    // Priority tag multiplier from JSON body (p0, p1, p2)
+    const priorityMultiplier: Record<string, number> = {
+      p0: 2.2,
+      p1: 1.6,
+      p2: 1.25,
+    };
+
     // 3. Calculate priority score for each task
     const scored = (data as any[]).map((task: any) => {
       const baseScore = statusScore[task.status] || 0;
@@ -170,13 +178,32 @@ export async function getTopPriorityTasks(): Promise<{
       const phaseMult = phaseMultiplier[phase] || 1.0;
       const capImportance = capabilityImportance[capability] || 1.0;
 
+      // Parse body JSON for priority tag
+      let priorityMult = 1.0;
+      let priorityLabel = "";
+      if (task.body) {
+        try {
+          const bodyObj = typeof task.body === "string" ? JSON.parse(task.body) : task.body;
+          if (bodyObj && typeof bodyObj === "object" && bodyObj.priority) {
+            const raw = String(bodyObj.priority).toLowerCase();
+            if (priorityMultiplier[raw]) {
+              priorityMult = priorityMultiplier[raw];
+              priorityLabel = ` +${raw.toUpperCase()} (×${priorityMult})`;
+            }
+          }
+        } catch {
+          // ignore parse errors
+        }
+      }
+
       // Age boost: tasks created more than 7 days ago get +0.5
       const ageDays = (Date.now() - new Date(task.created_at).getTime()) / (1000 * 60 * 60 * 24);
       const ageBoost = ageDays > 7 ? 0.5 : 0;
 
-      const total = baseScore * phaseMult * capImportance + ageBoost;
+      const total = baseScore * phaseMult * capImportance * priorityMult + ageBoost;
 
       let reasoning = `${baseScore} (статус) × ${phaseMult} (фаза ${phase}) × ${capImportance} (важность)`;
+      if (priorityLabel) reasoning += priorityLabel;
       if (ageBoost > 0) reasoning += ` +0.5 (старше 7 дней)`;
 
       return { ...task, score: Math.round(total * 10) / 10, reasoning };

--- a/app/supaplan/actions.ts
+++ b/app/supaplan/actions.ts
@@ -16,26 +16,16 @@ export async function claimTask(capability: string, agentId: string) {
     p_capability: capability,
     p_agent: agentId,
   });
-
-  if (error) {
-    throw error;
-  }
-
+  if (error) throw error;
   return data;
 }
 
 export async function updateTaskStatus(taskId: string, status: string) {
   const { error } = await supabaseAdmin
     .from("supaplan_tasks")
-    .update({
-      status,
-      updated_at: new Date().toISOString(),
-    })
+    .update({ status, updated_at: new Date().toISOString() })
     .eq("id", taskId);
-
-  if (error) {
-    throw error;
-  }
+  if (error) throw error;
 }
 
 export async function logTaskProgressEvent(taskId: string, summary: string) {
@@ -44,11 +34,7 @@ export async function logTaskProgressEvent(taskId: string, summary: string) {
     type: "task_progress",
     payload: { taskId, summary },
   });
-
-  if (error) {
-    throw error;
-  }
-
+  if (error) throw error;
   return { success: true };
 }
 
@@ -74,12 +60,8 @@ export async function notifyTaskPickInTelegram(input: TaskNotifyInput) {
     { text: "Телеграм ВебАпп", url: deepLink },
   ], undefined, input.chatId ?? undefined);
 
-  if (!result.success) {
-    return { success: false, error: result.error };
-  }
-
+  if (!result.success) return { success: false, error: result.error };
   await logTaskProgressEvent(input.taskId, "Задача отправлена в Телеграм из панели");
-
   return { success: true };
 }
 
@@ -93,9 +75,20 @@ export type PriorityTask = {
 };
 
 /**
- * Scores a non‑done franchize task based on status, phase, capability importance,
- * and an optional JSON‑encoded priority (p0/p1/p2) in the `body` field.
- * Returns the 5 tasks with the highest priority score.
+ * Priority scoring engine – franchize tasks only (ignores greenbox.*).
+ *
+ * Factors:
+ * - Status weight: Open=10, Claimed=7, Running=5, Ready for PR=3
+ * - Phase multiplier from metadata.phase:
+ *   launch-blocker 2.0, launch-quality 1.6, security 1.5, performance 1.3,
+ *   polishing 1.2, ux-fix 1.2, seo 1.1, code-quality 1.0, tech-debt 0.8, post-launch 0.7
+ * - Capability base weight (higher = more foundational).
+ * - Priority tag (from metadata.priority or body JSON) → critical 2.5, high 2.0, medium 1.5, low 1.0.
+ *   Tags like "p0", "p1", "p2" in body also mapped: p0=2.5, p1=2.0, p2=1.5.
+ *   The strongest multiplier wins.
+ * - Freshness boost: 2.0 if created within last 48h, 1.5 if within last 7d,
+ *   0.8 if older than 30d (to slightly demote stale tasks).
+ * - Quick win bonus: +1.0 if estimated_hours ≤ 4.
  */
 export async function getTopPriorityTasks(): Promise<{
   success: boolean;
@@ -103,20 +96,16 @@ export async function getTopPriorityTasks(): Promise<{
   error?: string;
 }> {
   try {
-    // 1. Fetch all non‑done franchize tasks, including the body
     const { data, error } = await supabaseAdmin
       .from("supaplan_tasks")
-      .select("id,title,status,capability,created_at,body")
-      .or("capability.like.franchize.%,capability.eq.greenbox.franchize")
+      .select("id,title,status,capability,created_at,body,metadata")
+      .or("capability.like.franchize.%")
       .neq("status", "done")
       .order("created_at", { ascending: false });
 
     if (error) throw error;
-    if (!data || data.length === 0) {
-      return { success: true, data: [] };
-    }
+    if (!data || data.length === 0) return { success: true, data: [] };
 
-    // 2. Scoring weights
     const statusScore: Record<string, number> = {
       open: 10,
       claimed: 7,
@@ -125,18 +114,27 @@ export async function getTopPriorityTasks(): Promise<{
     };
 
     const phaseMultiplier: Record<string, number> = {
-      "Апрель": 1.5,
-      "Май": 1.3,
-      "Июнь": 1.1,
-      "Лето": 0.9,
-      "2027": 0.7,
+      "launch-blocker": 2.0,
+      "launch-quality": 1.6,
+      "security": 1.5,
+      "performance": 1.3,
+      "polishing": 1.2,
+      "ux-fix": 1.2,
+      "seo": 1.1,
+      "code-quality": 1.0,
+      "tech-debt": 0.8,
+      "post-launch": 0.7,
     };
 
-    // Capability priority – bumped ui.ux significantly
     const capabilityImportance: Record<string, number> = {
       "franchize.rental": 1.4,
       "franchize.backend.supabase": 1.4,
-      "franchize.ui.ux": 1.8,   // was 1.0 → now top tier
+      "franchize.ui.ux": 1.8,
+      "franchize.finance": 1.3,
+      "franchize.security": 1.5,
+      "franchize.performance": 1.2,
+      "franchize.code-quality": 1.0,
+      "franchize.accessibility": 0.9,
       "franchize.info": 1.2,
       "franchize.telegram": 1.2,
       "franchize.analytics": 1.1,
@@ -148,68 +146,92 @@ export async function getTopPriorityTasks(): Promise<{
       "franchize.gamification": 0.7,
     };
 
-    const phaseMap: Record<string, string> = {
-      "franchize.info": "Апрель",
-      "franchize.rental": "Апрель",
-      "franchize.kpi": "Апрель",
-      "franchize.telegram": "Апрель",
-      "franchize.analytics": "Апрель",
-      "franchize.ui.ux": "Апрель",
-      "franchize.backend.supabase": "Апрель",
-      "franchize.sales": "Май",
-      "franchize.onboarding": "Май",
-      "franchize.growth": "Май",
-      "franchize.integration": "Июнь",
-      "franchize.gamification": "Лето",
+    const priorityTextMultiplier: Record<string, number> = {
+      critical: 2.5,
+      high: 2.0,
+      medium: 1.5,
+      low: 1.0,
     };
 
-    // Priority tag multiplier from JSON body (p0, p1, p2)
-    const priorityMultiplier: Record<string, number> = {
-      p0: 2.2,
-      p1: 1.6,
-      p2: 1.25,
-    };
-
-    // 3. Calculate priority score for each task
-    const scored = (data as any[]).map((task: any) => {
-      const baseScore = statusScore[task.status] || 0;
+    const scored = data.map((task: any) => {
+      const base = statusScore[task.status] || 0;
       const capability = task.capability || "";
-      const phase = phaseMap[capability] || "2027";
-      const phaseMult = phaseMultiplier[phase] || 1.0;
-      const capImportance = capabilityImportance[capability] || 1.0;
+      const capWeight = capabilityImportance[capability] || 1.0;
 
-      // Parse body JSON for priority tag
-      let priorityMult = 1.0;
-      let priorityLabel = "";
+      // metadata parsing
+      let metaPhase = "";
+      let metaPriorityText = "";
+      let estimatedHours = 0;
+      if (task.metadata) {
+        try {
+          const meta = typeof task.metadata === "string" ? JSON.parse(task.metadata) : task.metadata;
+          metaPhase = meta.phase || "";
+          metaPriorityText = (meta.priority || "").toLowerCase();
+          estimatedHours = Number(meta.estimated_hours) || 0;
+        } catch {}
+      }
+
+      // body parsing for p0/p1/p2
+      let bodyPriorityTag = "";
       if (task.body) {
         try {
           const bodyObj = typeof task.body === "string" ? JSON.parse(task.body) : task.body;
           if (bodyObj && typeof bodyObj === "object" && bodyObj.priority) {
-            const raw = String(bodyObj.priority).toLowerCase();
-            if (priorityMultiplier[raw]) {
-              priorityMult = priorityMultiplier[raw];
-              priorityLabel = ` +${raw.toUpperCase()} (×${priorityMult})`;
-            }
+            bodyPriorityTag = String(bodyObj.priority).toLowerCase();
           }
-        } catch {
-          // ignore parse errors
-        }
+        } catch {}
       }
 
-      // Age boost: tasks created more than 7 days ago get +0.5
+      // Phase multiplier
+      const phaseKey = metaPhase || "";
+      const phaseMult = phaseMultiplier[phaseKey] || 1.0;
+
+      // Priority multiplier: take strongest from text or tag
+      let priorityMult = 1.0;
+      let priorityLabel = "";
+      const fromTag = bodyPriorityTag === "p0" ? 2.5 : bodyPriorityTag === "p1" ? 2.0 : bodyPriorityTag === "p2" ? 1.5 : 0;
+      const fromText = priorityTextMultiplier[metaPriorityText] || 0;
+      const maxPriority = Math.max(fromTag, fromText, 1.0);
+      if (maxPriority > 1.0) {
+        priorityMult = maxPriority;
+        priorityLabel =
+          fromTag >= maxPriority ? ` ${bodyPriorityTag.toUpperCase()}` : ` ${metaPriorityText}`;
+      }
+
+      // Freshness boost – new tasks get bonus, old ones slightly penalised
       const ageDays = (Date.now() - new Date(task.created_at).getTime()) / (1000 * 60 * 60 * 24);
-      const ageBoost = ageDays > 7 ? 0.5 : 0;
+      let freshnessMult = 1.0;
+      let freshnessLabel = "";
+      if (ageDays <= 2) {
+        freshnessMult = 2.0;
+        freshnessLabel = "новое (≤2 дн)";
+      } else if (ageDays <= 7) {
+        freshnessMult = 1.5;
+        freshnessLabel = "свежее (≤7 дн)";
+      } else if (ageDays > 30) {
+        freshnessMult = 0.8;
+        freshnessLabel = "старое (>30 дн)";
+      }
 
-      const total = baseScore * phaseMult * capImportance * priorityMult + ageBoost;
+      // Quick win bonus
+      let quickWinBonus = 0;
+      let quickWinLabel = "";
+      if (estimatedHours > 0 && estimatedHours <= 4) {
+        quickWinBonus = 1.0;
+        quickWinLabel = "quick win";
+      }
 
-      let reasoning = `${baseScore} (статус) × ${phaseMult} (фаза ${phase}) × ${capImportance} (важность)`;
-      if (priorityLabel) reasoning += priorityLabel;
-      if (ageBoost > 0) reasoning += ` +0.5 (старше 7 дней)`;
+      const total =
+        base * capWeight * phaseMult * priorityMult * freshnessMult + quickWinBonus;
+
+      let reasoning = `${base} × cap:${capWeight} × phase:"${phaseKey}"${phaseMult}`;
+      if (priorityLabel) reasoning += ` × приоритет:${priorityLabel}(${priorityMult})`;
+      if (freshnessLabel) reasoning += ` × ${freshnessLabel}(${freshnessMult})`;
+      if (quickWinBonus) reasoning += ` + ${quickWinBonus} (${quickWinLabel})`;
 
       return { ...task, score: Math.round(total * 10) / 10, reasoning };
     });
 
-    // 4. Sort descending, pick top 5
     scored.sort((a: any, b: any) => b.score - a.score);
     const top5 = scored.slice(0, 5).map(
       (t: any): PriorityTask => ({

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -12,7 +12,6 @@ import {
   Clock3,
   Flame,
   HelpCircle,
-  Info,
   Layers3,
   Milestone,
   Rocket,
@@ -615,11 +614,19 @@ export default function FranchizeStatusPage() {
       <div className="space-y-3">
         {phaseData.map(([phase, { capabilities }]) => {
           const phaseExpanded = expandedPhases.has(phase);
-          const phaseUndone = capabilities.reduce((sum, cap) => {
-            const tasks = capabilityTaskMap.get(cap) || [];
-            return sum + tasks.filter((t) => t.status !== "done").length;
-          }, 0);
-          const isPhaseFullyDone = phaseUndone === 0;
+          // Calculate undone tasks and total tasks in this phase
+          const { undone: phaseUndone, total: phaseTotal } = capabilities.reduce(
+            (acc, cap) => {
+              const capTasks = capabilityTaskMap.get(cap) || [];
+              acc.undone += capTasks.filter((t) => t.status !== "done").length;
+              acc.total += capTasks.length;
+              return acc;
+            },
+            { undone: 0, total: 0 }
+          );
+          // Only show fully done badge if there are tasks and none are undone
+          const isPhaseFullyDone = phaseTotal > 0 && phaseUndone === 0;
+          const phaseHasAnyTasks = phaseTotal > 0;
 
           return (
             <Card
@@ -645,7 +652,7 @@ export default function FranchizeStatusPage() {
                     <Badge variant="outline" className="border-slate-600 text-slate-300 text-xs">
                       {capabilities.length} идеи
                     </Badge>
-                    {phaseUndone > 0 && (
+                    {phaseHasAnyTasks && phaseUndone > 0 && (
                       <Badge className="bg-rose-500/20 text-rose-300 text-xs">
                         {phaseUndone} не завершено
                       </Badge>
@@ -657,6 +664,11 @@ export default function FranchizeStatusPage() {
                     )}
                   </div>
                 </div>
+                {phaseHasAnyTasks && (
+                  <span className="text-xs text-slate-400">
+                    {phaseTotal - phaseUndone}/{phaseTotal}
+                  </span>
+                )}
               </button>
 
               {phaseExpanded && (
@@ -793,7 +805,7 @@ export default function FranchizeStatusPage() {
         })}
       </div>
 
-      {/* ---- Compact Collapsible Legend (moved out of the way) ---- */}
+      {/* ---- Collapsible Board Legend ---- */}
       <div className="mt-8 border-t border-slate-800 pt-4">
         <button
           type="button"
@@ -805,16 +817,64 @@ export default function FranchizeStatusPage() {
         </button>
 
         {legendOpen && (
-          <div className="mt-3 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
-            {Object.entries(TASK_TYPE_DESCRIPTIONS).map(([type, desc]) => (
-              <div
-                key={type}
-                className="rounded-xl border border-slate-700/50 bg-slate-900/50 p-3"
-              >
-                <strong className="text-slate-200">{type}</strong>
-                <p className="text-slate-400">{desc}</p>
+          <div className="mt-3 space-y-4 text-sm text-slate-300">
+            {/* Task types */}
+            <div>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Типы задач
+              </h4>
+              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                {Object.entries(TASK_TYPE_DESCRIPTIONS).map(([type, desc]) => (
+                  <div
+                    key={type}
+                    className="rounded-xl border border-slate-700/50 bg-slate-900/50 p-3"
+                  >
+                    <strong className="text-slate-200">{type}</strong>
+                    <p className="text-slate-400">{desc}</p>
+                  </div>
+                ))}
               </div>
-            ))}
+            </div>
+
+            {/* Statuses */}
+            <div>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Статусы задач
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {(Object.keys(STATUS_LABEL) as TaskStatus[]).map((status) => (
+                  <Badge
+                    key={status}
+                    className={`${STATUS_LABEL[status].className} text-xs`}
+                  >
+                    {STATUS_LABEL[status].label}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            {/* Priority formula */}
+            <div>
+              <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Приоритет (ТОП-5)
+              </h4>
+              <p className="text-slate-400">
+                <code className="rounded bg-slate-800 px-1 text-cyan-300">статус (Open=10, …, Ready for PR=3)</code> ×{" "}
+                <code className="rounded bg-slate-800 px-1 text-cyan-300">фаза (Апрель=1.5 … 2027=0.7)</code> ×{" "}
+                <code className="rounded bg-slate-800 px-1 text-cyan-300">важность способности (0.7‑1.4)</code> +{" "}
+                <code className="rounded bg-slate-800 px-1 text-cyan-300">бонус за возраст (+0.5 если старше 7 дней)</code>
+              </p>
+            </div>
+
+            {/* Phases */}
+            <div>
+              <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Фазы (дорожная карта)
+              </h4>
+              <p className="text-slate-400">
+                {PHASE_ORDER.join(" → ")} – фазы упорядочены по количеству незавершённых задач.
+              </p>
+            </div>
           </div>
         )}
       </div>

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -56,15 +56,16 @@ type IdeaRow = {
   decompositionHint: string;
 };
 
+// Все статусы — на русском
 const STATUS_LABEL: Record<TaskStatusProp, { label: string; className: string }> = {
-  open: { label: "Open", className: "bg-sky-500/15 text-sky-300 border-sky-400/30" },
-  claimed: { label: "Claimed", className: "bg-indigo-500/15 text-indigo-300 border-indigo-400/30" },
-  running: { label: "Running", className: "bg-amber-500/15 text-amber-300 border-amber-400/30" },
+  open: { label: "Открыта", className: "bg-sky-500/15 text-sky-300 border-sky-400/30" },
+  claimed: { label: "Назначена", className: "bg-indigo-500/15 text-indigo-300 border-indigo-400/30" },
+  running: { label: "В работе", className: "bg-amber-500/15 text-amber-300 border-amber-400/30" },
   ready_for_pr: {
-    label: "Ready for PR",
+    label: "Готово к PR",
     className: "bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-400/30",
   },
-  done: { label: "Done", className: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
+  done: { label: "Сделано", className: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
 };
 
 const STATUS_CARD_CONFIG: Record<TaskStatusProp, {
@@ -246,10 +247,10 @@ function formatIso(iso: string): string {
 
 function buildTaskCopyText(task: PriorityTask, fullTask?: FranchizeTask): string {
   const parts = [
-    `Выполни задачу: ${task.title}`,
+    `Задача: ${task.title}`,
     `ID: ${task.id}`,
-    `Статус: ${task.status}`,
-    `Capability: ${task.capability || "—"}`,
+    `Статус: ${STATUS_LABEL[task.status as TaskStatusProp]?.label || task.status}`,
+    `Категория: ${task.capability || "—"}`,
   ];
   if (fullTask?.todo_path) parts.push(`Файл: ${fullTask.todo_path}`);
   if (fullTask?.body) {
@@ -259,9 +260,6 @@ function buildTaskCopyText(task: PriorityTask, fullTask?: FranchizeTask): string
   return parts.join("\n");
 }
 
-/**
- * Custom hook to animate a number from 0 to target over a given duration.
- */
 function useCountUp(target: number, duration = 600) {
   const [display, setDisplay] = useState(0);
   const frameRef = useRef<number>(0);
@@ -272,10 +270,8 @@ function useCountUp(target: number, duration = 600) {
       if (!startTimeRef.current) startTimeRef.current = timestamp;
       const elapsed = timestamp - startTimeRef.current;
       const progress = Math.min(elapsed / duration, 1);
-      // easeOutCubic
       const eased = 1 - Math.pow(1 - progress, 3);
       setDisplay(Math.round(eased * target));
-
       if (progress < 1) {
         frameRef.current = requestAnimationFrame(step);
       }
@@ -365,7 +361,7 @@ export default function FranchizeStatusPage() {
     return totals;
   }, [tasks]);
 
-  // Animated display values for status cards (the surprise!)
+  // Animated counters
   const animatedOpen = useCountUp(statusTotals.open);
   const animatedClaimed = useCountUp(statusTotals.claimed);
   const animatedRunning = useCountUp(statusTotals.running);
@@ -441,11 +437,13 @@ export default function FranchizeStatusPage() {
   }, [tasks]);
 
   const handleCopyAllTop5 = useCallback(async () => {
+    const intro =
+      "Эй, агент! Вот топ‑5 задач для быстрого старта, rock’n’roll! 🤘 (но ты главный – можешь переиграть как угодно)\n\n";
     const texts = priorityTasks.map((pt) => {
       const fullTask = tasks.find((t) => t.id === pt.id);
-      return `--- Задача ${pt.id} ---\n${buildTaskCopyText(pt, fullTask)}`;
+      return `--- ${pt.id} ---\n${buildTaskCopyText(pt, fullTask)}`;
     });
-    const fullText = texts.join("\n\n");
+    const fullText = intro + texts.join("\n\n");
     await navigator.clipboard.writeText(fullText);
     setCopyAllCelebration(true);
     setTimeout(() => setCopyAllCelebration(false), 1500);
@@ -477,24 +475,22 @@ export default function FranchizeStatusPage() {
       {/*  HERO                                                                 */}
       {/* ==================================================================== */}
       <section className="relative rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950/90 to-slate-900 p-5 text-white shadow-2xl sm:p-6">
-        {/* Glows */}
         <div className="pointer-events-none absolute -right-8 -top-8 h-52 w-52 rounded-full bg-cyan-500/20 blur-3xl" />
         <div className="pointer-events-none absolute -bottom-8 -left-8 h-44 w-44 rounded-full bg-purple-500/15 blur-3xl" />
 
         <div className="relative z-10 grid gap-6 md:grid-cols-3">
-          {/* Left column */}
           <div className="md:col-span-2">
             <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-cyan-300">
-              <Badge className="border-cyan-400/40 bg-cyan-400/20 text-cyan-100">FRANCHIZE CONTROL DECK</Badge>
+              <Badge className="border-cyan-400/40 bg-cyan-400/20 text-cyan-100">ПУЛЬТ УПРАВЛЕНИЯ ФРАНШИЗОЙ</Badge>
               <span className="text-slate-400">vip‑bike crew</span>
             </div>
 
             <h1 className="text-3xl font-bold leading-tight sm:text-5xl">
               <span className="bg-gradient-to-r from-cyan-300 via-indigo-400 to-purple-400 bg-clip-text text-transparent">
-                SupaPlan • Franchize
+                SupaPlan • Франшиза
               </span>
               <br />
-              <span className="text-2xl text-slate-100 sm:text-3xl">Live Status Board</span>
+              <span className="text-2xl text-slate-100 sm:text-3xl">Живая панель состояния</span>
             </h1>
 
             <p className="mt-3 max-w-xl text-sm text-slate-300 sm:text-base">
@@ -517,14 +513,14 @@ export default function FranchizeStatusPage() {
                 >
                   <ExternalLink className="h-4 w-4" /> Codex Cloud
                 </a>
-                <span className="absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-[10px] text-white opacity-0 transition-opacity group-hover:opacity-100">
-                  🚀 Deploy to Codex
+                <span className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-[10px] text-white opacity-0 transition-opacity group-hover:opacity-100">
+                  🚀 Деплой в Codex
                 </span>
               </div>
             </div>
           </div>
 
-          {/* Right column: progress ring */}
+          {/* Progress ring */}
           <div className="flex items-center justify-center">
             <div className="relative flex h-36 w-36 items-center justify-center overflow-visible">
               <svg className="h-full w-full -rotate-90" viewBox="0 0 36 36" overflow="visible" aria-hidden>
@@ -565,7 +561,6 @@ export default function FranchizeStatusPage() {
           const config = STATUS_CARD_CONFIG[status];
           const Icon = config.icon;
           const rawValue = statusTotals[status];
-          // choose animated value based on status
           let animatedValue = rawValue;
           if (status === "open") animatedValue = animatedOpen;
           else if (status === "claimed") animatedValue = animatedClaimed;
@@ -641,17 +636,15 @@ export default function FranchizeStatusPage() {
                 <Flame className="h-5 w-5" />
                 ТОП‑5 критических задач
               </CardTitle>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleCopyAllTop5}
-                  className="h-auto px-2 py-1 text-xs text-amber-300 hover:text-amber-100 disabled:opacity-50"
-                >
-                  <Copy className="mr-1 h-3.5 w-3.5" />
-                  {copyAllCelebration ? "🎉 Скопировано!" : "Копировать все 5"}
-                </Button>
-              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleCopyAllTop5}
+                className="h-auto px-2 py-1 text-xs text-amber-300 hover:text-amber-100 disabled:opacity-50"
+              >
+                <Copy className="mr-1 h-3.5 w-3.5" />
+                {copyAllCelebration ? "🎉 Скопировано!" : "Копировать все 5"}
+              </Button>
             </div>
             <CardDescription className="text-slate-400">
               Формула: статус × фаза × важность способности × приоритет × свежесть.
@@ -958,7 +951,7 @@ export default function FranchizeStatusPage() {
             </div>
             <div>
               <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                Типы задач (capabilities)
+                Типы задач (категории)
               </h4>
               <div className="flex flex-wrap gap-2">
                 {[...new Set(tasks.map((t) => t.capability))]
@@ -981,10 +974,10 @@ export default function FranchizeStatusPage() {
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-base">
-            <Wrench className="h-4 w-4 text-cyan-300" /> Runtime checks
+            <Wrench className="h-4 w-4 text-cyan-300" /> Контроль работы
           </CardTitle>
           <CardDescription className="text-slate-400">
-            {tasks.length} franchize‑задач загружено (greenbox исключены).
+            {tasks.length} задач франшизы загружено (greenbox исключены).
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-2 text-sm text-slate-300">

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -26,7 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { supabaseAnon } from "@/hooks/supabase";
-import { getTopPriorityTasks, PriorityTask } from "./actions";
+import { getTopPriorityTasks, PriorityTask } from "../actions";
 
 /* -------------------------------------------------------------------------- */
 /*  Types & constants                                                         */

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -5,17 +5,15 @@ import Link from "next/link";
 import {
   AlertCircle,
   ArrowLeft,
-  Bike,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
   Clock3,
   Copy,
+  ExternalLink,
   Flame,
   HelpCircle,
-  Rocket,
   Sparkles,
-  Timer,
   Wrench,
   Zap,
 } from "lucide-react";
@@ -26,9 +24,9 @@ import { Button } from "@/components/ui/button";
 import { supabaseAnon } from "@/hooks/supabase";
 import { getTopPriorityTasks, PriorityTask } from "../actions";
 
-/* -------------------------------------------------------------------------- */
+/* ========================================================================== */
 /*  Types & constants                                                         */
-/* -------------------------------------------------------------------------- */
+/* ========================================================================== */
 
 type TaskStatusProp = "open" | "claimed" | "running" | "ready_for_pr" | "done";
 
@@ -64,6 +62,14 @@ const STATUS_LABEL: Record<TaskStatusProp, { label: string; className: string }>
     className: "bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-400/30",
   },
   done: { label: "Done", className: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
+};
+
+const STATUS_GLOW: Record<TaskStatusProp, string> = {
+  open: "shadow-sky-500/10",
+  claimed: "shadow-indigo-500/10",
+  running: "shadow-amber-500/10",
+  ready_for_pr: "shadow-fuchsia-500/10",
+  done: "shadow-emerald-500/10",
 };
 
 const PHASE_ORDER = ["Апрель", "Май", "Июнь", "Лето", "2027"] as const;
@@ -179,6 +185,10 @@ const IDEA_MAP: IdeaRow[] = [
   },
 ];
 
+/* ========================================================================== */
+/*  Helpers                                                                   */
+/* ========================================================================== */
+
 function statusUrgency(status: string): number {
   switch (status) {
     case "open": return 0;
@@ -201,7 +211,6 @@ function formatIso(iso: string): string {
   });
 }
 
-// Clipboard helpers
 function buildTaskCopyText(task: PriorityTask, fullTask?: FranchizeTask): string {
   const parts = [
     `Выполни задачу: ${task.title}`,
@@ -217,23 +226,28 @@ function buildTaskCopyText(task: PriorityTask, fullTask?: FranchizeTask): string
   return parts.join("\n");
 }
 
+/* ========================================================================== */
+/*  Page Component                                                            */
+/* ========================================================================== */
+
 export default function FranchizeStatusPage() {
+  // ----- Core data -----
   const [tasks, setTasks] = useState<FranchizeTask[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // ----- Tree expansion -----
   const [expandedPhases, setExpandedPhases] = useState<Set<string>>(new Set());
   const [expandedCapabilities, setExpandedCapabilities] = useState<Set<string>>(new Set());
   const [expandedTasks, setExpandedTasks] = useState<Set<string>>(new Set());
-
   const [legendOpen, setLegendOpen] = useState(false);
 
+  // ----- Priority engine (auto‑loaded) -----
   const [priorityTasks, setPriorityTasks] = useState<PriorityTask[]>([]);
   const [isPriorityLoading, startPriorityTransition] = useTransition();
-  const [showPriority, setShowPriority] = useState(false);
-
   const [copied, setCopied] = useState(false);
 
+  // 1. Fetch all franchize tasks on mount
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
@@ -259,7 +273,18 @@ export default function FranchizeStatusPage() {
     fetchData();
   }, []);
 
-  // Derived stats
+  // 2. Auto‑load Top‑5 once tasks are available
+  useEffect(() => {
+    if (tasks.length === 0 || priorityTasks.length > 0) return;
+    startPriorityTransition(async () => {
+      const res = await getTopPriorityTasks();
+      if (res.success && res.data) {
+        setPriorityTasks(res.data);
+      }
+    });
+  }, [tasks, priorityTasks.length]);
+
+  // ----- Derived stats -----
   const statusTotals = useMemo(() => {
     const totals: Record<TaskStatusProp, number> = { open: 0, claimed: 0, running: 0, ready_for_pr: 0, done: 0 };
     tasks.forEach((t) => {
@@ -271,8 +296,9 @@ export default function FranchizeStatusPage() {
 
   const totalPending = tasks.length - statusTotals.done;
   const progressPercent = tasks.length ? Math.round((statusTotals.done / tasks.length) * 100) : 0;
+  const circumference = 2 * Math.PI * 15.9155; // ~100
 
-  // Group tasks by IDEA_MAP phases, then by capability
+  // ----- Phase grouping -----
   const phaseData = useMemo(() => {
     const map = new Map<string, Map<string, FranchizeTask[]>>();
     PHASE_ORDER.forEach((p) => map.set(p, new Map()));
@@ -300,6 +326,7 @@ export default function FranchizeStatusPage() {
     return orderedPhases;
   }, [tasks]);
 
+  // ----- Toggle helpers -----
   const togglePhase = useCallback((phase: string) => {
     setExpandedPhases((prev) => {
       const next = new Set(prev);
@@ -327,18 +354,7 @@ export default function FranchizeStatusPage() {
     });
   }, []);
 
-  const handleLoadPriority = useCallback(() => {
-    startPriorityTransition(async () => {
-      const res = await getTopPriorityTasks();
-      if (res.success && res.data) {
-        setPriorityTasks(res.data);
-        setShowPriority(true);
-      } else {
-        alert(res.error || "Ошибка загрузки приоритетных задач");
-      }
-    });
-  }, []);
-
+  // ----- Clipboard (single task & all 5) -----
   const handleCopyTask = useCallback(async (pt: PriorityTask) => {
     const fullTask = tasks.find((t) => t.id === pt.id);
     const text = buildTaskCopyText(pt, fullTask);
@@ -358,6 +374,7 @@ export default function FranchizeStatusPage() {
     setTimeout(() => setCopied(false), 2000);
   }, [priorityTasks, tasks]);
 
+  // ----- Render states -----
   if (loading) {
     return (
       <div className="flex min-h-[50vh] items-center justify-center text-slate-200">
@@ -374,182 +391,216 @@ export default function FranchizeStatusPage() {
     );
   }
 
+  /* ======================================================================== */
+  /*  Render                                                                   */
+  /* ======================================================================== */
   return (
-    <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 pb-16 sm:px-6 sm:py-6 lg:px-8">
-      {/* ---- Hero (no overflow-hidden) ---- */}
-      <section className="relative rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-6 text-white shadow-2xl">
-        <div className="absolute -right-16 -top-16 h-64 w-64 rounded-full bg-cyan-500/20 blur-3xl" />
-        <div className="absolute -bottom-12 -left-12 h-48 w-48 rounded-full bg-amber-500/20 blur-3xl" />
+    <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 pb-20 sm:px-6 sm:py-8 lg:px-8">
+      {/* ==================================================================== */}
+      {/*  HERO – cyber command deck                                           */}
+      {/* ==================================================================== */}
+      <section className="relative rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950/90 to-slate-900 p-5 text-white shadow-2xl sm:p-6">
+        {/* Background glows – no overflow‑hidden on the parent so they render fully */}
+        <div className="pointer-events-none absolute -right-10 -top-10 h-56 w-56 rounded-full bg-cyan-500/20 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-10 -left-10 h-44 w-44 rounded-full bg-purple-500/15 blur-3xl" />
+
         <div className="relative z-10 grid gap-6 md:grid-cols-3">
+          {/* Left column: title + meta */}
           <div className="md:col-span-2">
             <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-cyan-300">
               <Badge className="border-cyan-400/40 bg-cyan-400/20 text-cyan-100">FRANCHIZE CONTROL DECK</Badge>
-              <span>vip-bike crew</span>
+              <span className="text-slate-400">vip‑bike crew</span>
             </div>
+
             <h1 className="text-3xl font-bold leading-tight sm:text-5xl">
               <span className="bg-gradient-to-r from-cyan-300 via-indigo-400 to-purple-400 bg-clip-text text-transparent">
                 SupaPlan • Franchize
               </span>
               <br />
-              <span className="text-2xl sm:text-3xl">Live Status Board</span>
+              <span className="text-2xl text-slate-100 sm:text-3xl">Live Status Board</span>
             </h1>
-            <p className="mt-3 text-sm text-slate-300 sm:text-base">
+
+            <p className="mt-3 max-w-xl text-sm text-slate-300 sm:text-base">
               Мгновенный срез по всем эпикам. Приоритеты, фазы, критические задачи — всё под рукой.
             </p>
+
             <div className="mt-4 flex flex-wrap gap-2">
-              <Link href="/supaplan" className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-xs hover:bg-white/15">
+              <Link
+                href="/supaplan"
+                className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-xs transition hover:bg-white/15"
+              >
                 <ArrowLeft className="h-4 w-4" /> Общий SupaPlan
               </Link>
-              <Link href="/nexus" className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-xs hover:bg-white/15">
-                <Rocket className="h-4 w-4" /> Nexus
-              </Link>
-              <Link href="/franchize/vip-bike/map-riders" className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-xs hover:bg-white/15">
-                <Bike className="h-4 w-4" /> Map Riders
-              </Link>
+              <a
+                href="https://chatgpt.com/codex/cloud"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 rounded-lg border border-purple-400/30 bg-purple-400/10 px-3 py-2 text-xs text-purple-200 transition hover:bg-purple-400/20"
+              >
+                <ExternalLink className="h-4 w-4" /> Codex Cloud
+              </a>
             </div>
           </div>
+
+          {/* Right column: progress ring */}
           <div className="flex items-center justify-center">
-            <div className="relative flex h-40 w-40 items-center justify-center">
-              <svg className="h-full w-full -rotate-90" viewBox="0 0 36 36">
-                <path
+            <div className="relative flex h-36 w-36 items-center justify-center">
+              <svg className="h-full w-full -rotate-90" viewBox="0 0 36 36" aria-hidden>
+                <circle
                   className="text-slate-700"
                   fill="none"
                   stroke="currentColor"
                   strokeWidth="2"
-                  d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                  cx="18" cy="18" r="15.9155"
                 />
-                <path
-                  className="text-cyan-400 drop-shadow-[0_0_6px_#22d3ee]"
+                <circle
+                  className="text-cyan-400 drop-shadow-[0_0_6px_#22d3ee] transition-all duration-700"
                   fill="none"
                   stroke="currentColor"
                   strokeWidth="2"
                   strokeLinecap="round"
-                  strokeDasharray={`${progressPercent}, 100`}
-                  d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                  strokeDasharray={`${progressPercent} ${100 - progressPercent}`}
+                  cx="18" cy="18" r="15.9155"
                 />
               </svg>
-              <span className="absolute text-2xl font-bold text-cyan-300">{progressPercent}%</span>
+              <span className="absolute text-2xl font-bold tabular-nums text-cyan-300">
+                {progressPercent}%
+              </span>
             </div>
           </div>
         </div>
       </section>
 
-      {/* ---- Status cards ---- */}
-      <section className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+      {/* ==================================================================== */}
+      {/*  STATUS CARDS – enhanced                                             */}
+      {/* ==================================================================== */}
+      <section className="grid grid-cols-2 gap-2 sm:grid-cols-5 sm:gap-3">
         {(["open", "claimed", "running", "ready_for_pr", "done"] as TaskStatusProp[]).map((status) => (
-          <Card key={status} className="border-slate-800/70 bg-slate-950 text-slate-100">
-            <CardHeader className="space-y-1 pb-1">
-              <CardDescription className="text-xs text-slate-400">{STATUS_LABEL[status].label}</CardDescription>
-              <CardTitle className="text-2xl">{statusTotals[status]}</CardTitle>
+          <Card
+            key={status}
+            className={`border-slate-800/70 bg-slate-950 text-slate-100 transition hover:-translate-y-0.5 hover:shadow-lg ${STATUS_GLOW[status]}`}
+          >
+            <CardHeader className="space-y-1 p-3 pb-1 sm:p-4 sm:pb-1">
+              <CardDescription className="text-[11px] uppercase tracking-wide text-slate-400">
+                {STATUS_LABEL[status].label}
+              </CardDescription>
+              <CardTitle className="text-3xl font-bold tabular-nums tracking-tight">
+                {statusTotals[status]}
+              </CardTitle>
             </CardHeader>
           </Card>
         ))}
       </section>
 
-      {/* ---- Progress bar ---- */}
+      {/* ==================================================================== */}
+      {/*  PROGRESS BAR                                                        */}
+      {/* ==================================================================== */}
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
         <CardContent className="pt-4">
           <div className="h-2 overflow-hidden rounded-full bg-slate-800">
             <div
-              className="h-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-fuchsia-400"
+              className="h-full rounded-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-fuchsia-400 transition-all duration-700"
               style={{ width: `${progressPercent}%` }}
             />
           </div>
           <p className="mt-2 text-sm text-slate-300">
-            Выполнено: <span className="font-semibold text-emerald-300">{statusTotals.done}/{tasks.length}</span> задач. Осталось критических:{" "}
+            Выполнено:{" "}
+            <span className="font-semibold text-emerald-300">
+              {statusTotals.done}/{tasks.length}
+            </span>{" "}
+            задач. Осталось критических:{" "}
             <span className="font-semibold text-rose-400">{totalPending}</span>.
           </p>
         </CardContent>
       </Card>
 
-      {/* 🔥 Top-5 priority */}
-      <section>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleLoadPriority}
-          disabled={isPriorityLoading}
-          className="mb-2 gap-2 bg-amber-900/20 text-amber-300 border-amber-500/40 hover:bg-amber-900/30"
-        >
-          {isPriorityLoading ? (
-            <span className="flex items-center gap-1">
-              <div className="h-4 w-4 animate-spin rounded-full border-2 border-amber-400 border-t-transparent" />
-              Считаю...
-            </span>
-          ) : (
-            <>
-              <Sparkles className="h-4 w-4" />
-              ТОП-5 приоритетных задач
-            </>
-          )}
-        </Button>
+      {/* ==================================================================== */}
+      {/*  TOP‑5 PRIORITY – auto‑loaded, no hide button                        */}
+      {/* ==================================================================== */}
+      {isPriorityLoading && priorityTasks.length === 0 && (
+        <div className="flex items-center gap-2 text-sm text-slate-400">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-amber-400 border-t-transparent" />
+          Загружаю приоритетные задачи…
+        </div>
+      )}
 
-        {showPriority && priorityTasks.length > 0 && (
-          <Card className="border-amber-500/50 bg-gradient-to-br from-amber-950/60 to-slate-950 text-slate-100 shadow-lg shadow-amber-500/10">
-            <CardHeader className="pb-2">
-              <div className="flex items-center justify-between">
-                <CardTitle className="flex items-center gap-2 text-lg text-amber-300">
-                  <Flame className="h-5 w-5" /> ТОП-5 критических задач
-                </CardTitle>
-                <div className="flex items-center gap-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleCopyAllTop5}
-                    className="text-xs text-amber-300 hover:text-amber-100 disabled:opacity-50"
-                  >
-                    <Copy className="mr-1 h-3.5 w-3.5" />
-                    {copied ? "Скопировано!" : "Копировать все 5"}
-                  </Button>
-                  <Button variant="ghost" size="sm" onClick={() => setShowPriority(false)} className="text-slate-400 hover:text-slate-200">
-                    Скрыть
-                  </Button>
-                </div>
+      {priorityTasks.length > 0 && (
+        <Card className="border-amber-500/50 bg-gradient-to-br from-amber-950/60 to-slate-950 text-slate-100 shadow-lg shadow-amber-500/10">
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <CardTitle className="flex items-center gap-2 text-lg text-amber-300">
+                <Flame className="h-5 w-5" />
+                ТОП‑5 критических задач
+              </CardTitle>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleCopyAllTop5}
+                  className="h-auto px-2 py-1 text-xs text-amber-300 hover:text-amber-100 disabled:opacity-50"
+                >
+                  <Copy className="mr-1 h-3.5 w-3.5" />
+                  {copied ? "Скопировано!" : "Копировать все 5"}
+                </Button>
+                <span className="rounded-full bg-amber-400/10 px-2 py-0.5 text-[11px] text-amber-400/80">
+                  авто‑обновление
+                </span>
               </div>
-              <CardDescription className="text-slate-400">
-                Формула: статус × фаза × важность способности × приоритет × свежесть.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="grid gap-2 sm:grid-cols-2">
-              {priorityTasks.map((pt) => {
-                const taskMeta = STATUS_LABEL[pt.status as TaskStatusProp] || STATUS_LABEL.open;
-                const fullTask = tasks.find((t) => t.id === pt.id);
-                return (
-                  <div key={pt.id} className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm">
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="flex-1">
-                        <p className="font-semibold text-slate-100">{pt.title}</p>
-                        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
-                          <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
-                          <Badge variant="outline" className="border-slate-600 text-slate-400">{pt.capability}</Badge>
-                        </div>
+            </div>
+            <CardDescription className="text-slate-400">
+              Формула: статус × фаза × важность способности × приоритет × свежесть.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-2 sm:grid-cols-2">
+            {priorityTasks.map((pt) => {
+              const taskMeta = STATUS_LABEL[pt.status as TaskStatusProp] || STATUS_LABEL.open;
+              const fullTask = tasks.find((t) => t.id === pt.id);
+              return (
+                <div
+                  key={pt.id}
+                  className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex-1">
+                      <p className="font-semibold text-slate-100">{pt.title}</p>
+                      <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                        <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
+                        <Badge variant="outline" className="border-slate-600 text-slate-400">
+                          {pt.capability}
+                        </Badge>
                       </div>
-                      <span className="rounded-full bg-amber-400/20 px-2 py-0.5 text-xs font-mono font-bold text-amber-300">{pt.score}</span>
                     </div>
-                    <p className="mt-2 text-xs text-slate-400">{pt.reasoning}</p>
-                    {fullTask?.todo_path && (
-                      <p className="mt-1 text-xs text-slate-500">todo_path: {fullTask.todo_path}</p>
-                    )}
-                    <div className="mt-2 flex items-center justify-between">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleCopyTask(pt)}
-                        className="h-auto px-2 py-1 text-xs text-cyan-300 hover:text-cyan-100"
-                      >
-                        <Copy className="mr-1 h-3 w-3" />
-                        Копировать задачу
-                      </Button>
-                    </div>
+                    <span className="rounded-full bg-amber-400/20 px-2 py-0.5 text-xs font-mono font-bold tabular-nums text-amber-300">
+                      {pt.score}
+                    </span>
                   </div>
-                );
-              })}
-            </CardContent>
-          </Card>
-        )}
-      </section>
+                  <p className="mt-2 text-xs leading-relaxed text-slate-400">{pt.reasoning}</p>
+                  {fullTask?.todo_path && (
+                    <p className="mt-1 text-[11px] text-slate-500">
+                      todo_path: {fullTask.todo_path}
+                    </p>
+                  )}
+                  <div className="mt-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleCopyTask(pt)}
+                      className="h-auto px-2 py-1 text-xs text-cyan-300 hover:text-cyan-100"
+                    >
+                      <Copy className="mr-1 h-3 w-3" />
+                      Копировать задачу
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
 
-      {/* ---- Phase → Capability → Task tree ---- */}
+      {/* ==================================================================== */}
+      {/*  PHASE → CAPABILITY → TASK TREE                                      */}
+      {/* ==================================================================== */}
       <div className="space-y-3">
         {phaseData.map(([phase, capMap]) => {
           const phaseExpanded = expandedPhases.has(phase);
@@ -557,6 +608,7 @@ export default function FranchizeStatusPage() {
           const undone = phaseTasks.filter((t) => t.status !== "done").length;
           const total = phaseTasks.length;
           const fullyDone = total > 0 && undone === 0;
+
           return (
             <Card
               key={phase}
@@ -568,31 +620,35 @@ export default function FranchizeStatusPage() {
               <button
                 type="button"
                 onClick={() => togglePhase(phase)}
-                className="flex w-full items-center justify-between p-3 sm:p-4 text-left"
+                className="flex w-full items-center justify-between p-3 text-left sm:p-4"
               >
                 <div className="flex items-center gap-2 sm:gap-3">
                   {phaseExpanded ? (
-                    <ChevronDown className="h-5 w-5 text-cyan-300 flex-shrink-0" />
+                    <ChevronDown className="h-5 w-5 flex-shrink-0 text-cyan-300" />
                   ) : (
-                    <ChevronRight className="h-5 w-5 text-cyan-300 flex-shrink-0" />
+                    <ChevronRight className="h-5 w-5 flex-shrink-0 text-cyan-300" />
                   )}
                   <h2 className="text-lg font-semibold capitalize">{phase}</h2>
                   {total > 0 && (
                     <div className="flex flex-wrap gap-1">
-                      <Badge variant="outline" className="border-slate-600 text-slate-300 text-xs">
+                      <Badge variant="outline" className="border-slate-600 text-xs text-slate-300">
                         {capMap.size} способности
                       </Badge>
                       {undone > 0 && (
-                        <Badge className="bg-rose-500/20 text-rose-300 text-xs">{undone} не завершено</Badge>
+                        <Badge className="bg-rose-500/20 text-xs text-rose-300">
+                          {undone} не завершено
+                        </Badge>
                       )}
                       {fullyDone && (
-                        <Badge className="bg-emerald-500/20 text-emerald-300 text-xs">все сделано ✓</Badge>
+                        <Badge className="bg-emerald-500/20 text-xs text-emerald-300">
+                          всё сделано ✓
+                        </Badge>
                       )}
                     </div>
                   )}
                 </div>
                 {total > 0 && (
-                  <span className="text-xs text-slate-400">
+                  <span className="text-xs tabular-nums text-slate-400">
                     {total - undone}/{total}
                   </span>
                 )}
@@ -607,13 +663,19 @@ export default function FranchizeStatusPage() {
                       const allDone = capTasks.length > 0 && doneCount === capTasks.length;
                       const worstStatus = capTasks.length
                         ? capTasks.reduce((worst, t) =>
-                            statusUrgency(t.status) < statusUrgency(worst) ? t.status : worst
-                          , capTasks[0].status)
+                            statusUrgency(t.status) < statusUrgency(worst) ? t.status : worst,
+                            capTasks[0].status
+                          )
                         : "open";
-                      const worstMeta = STATUS_LABEL[worstStatus as TaskStatusProp] || STATUS_LABEL.open;
+                      const worstMeta =
+                        STATUS_LABEL[worstStatus as TaskStatusProp] || STATUS_LABEL.open;
                       const idea = IDEA_MAP.find((i) => i.capability === cap);
+
                       return (
-                        <div key={cap} className="rounded-xl border border-slate-800 bg-slate-900/70">
+                        <div
+                          key={cap}
+                          className="rounded-xl border border-slate-800 bg-slate-900/70"
+                        >
                           <button
                             type="button"
                             onClick={() => toggleCapability(cap)}
@@ -622,32 +684,43 @@ export default function FranchizeStatusPage() {
                             <div className="flex-1">
                               <div className="flex items-center gap-2">
                                 {capExpanded ? (
-                                  <ChevronDown className="h-4 w-4 text-amber-300 flex-shrink-0" />
+                                  <ChevronDown className="h-4 w-4 flex-shrink-0 text-amber-300" />
                                 ) : (
-                                  <ChevronRight className="h-4 w-4 text-amber-300 flex-shrink-0" />
+                                  <ChevronRight className="h-4 w-4 flex-shrink-0 text-amber-300" />
                                 )}
-                                <span className="text-sm font-medium">{idea?.idea || cap}</span>
-                                {allDone && <CheckCircle2 className="h-4 w-4 text-emerald-400" />}
+                                <span className="text-sm font-medium">
+                                  {idea?.idea || cap}
+                                </span>
+                                {allDone && (
+                                  <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+                                )}
                               </div>
                               {idea?.note && (
                                 <p className="mt-1 pl-6 text-xs text-slate-400">{idea.note}</p>
                               )}
                             </div>
                             <div className="ml-2 flex items-center gap-2">
-                              <Badge className={worstMeta.className}>{worstMeta.label}</Badge>
-                              <span className="text-xs text-slate-400">{doneCount}/{capTasks.length}</span>
+                              <Badge className={worstMeta.className}>
+                                {worstMeta.label}
+                              </Badge>
+                              <span className="text-xs tabular-nums text-slate-400">
+                                {doneCount}/{capTasks.length}
+                              </span>
                             </div>
                           </button>
 
                           {capExpanded && (
                             <div className="border-t border-slate-800 px-3 pb-3 pt-2">
                               {idea && (
-                                <div className="mb-2 text-xs text-slate-400">
-                                  <div className="mt-1 flex flex-wrap gap-1">
-                                    {idea.routes.map((r) => (
-                                      <code key={r} className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300">{r}</code>
-                                    ))}
-                                  </div>
+                                <div className="mb-2 flex flex-wrap gap-1">
+                                  {idea.routes.map((r) => (
+                                    <code
+                                      key={r}
+                                      className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300"
+                                    >
+                                      {r}
+                                    </code>
+                                  ))}
                                 </div>
                               )}
 
@@ -656,12 +729,20 @@ export default function FranchizeStatusPage() {
                               ) : (
                                 <ul className="space-y-2">
                                   {capTasks
-                                    .sort((a, b) => statusUrgency(a.status) - statusUrgency(b.status))
+                                    .sort(
+                                      (a, b) =>
+                                        statusUrgency(a.status) - statusUrgency(b.status)
+                                    )
                                     .map((task) => {
                                       const taskExpanded = expandedTasks.has(task.id);
-                                      const taskMeta = STATUS_LABEL[task.status as TaskStatusProp] || STATUS_LABEL.open;
+                                      const taskMeta =
+                                        STATUS_LABEL[task.status as TaskStatusProp] ||
+                                        STATUS_LABEL.open;
                                       return (
-                                        <li key={task.id} className="rounded border border-slate-700/70 bg-slate-950/70 p-2">
+                                        <li
+                                          key={task.id}
+                                          className="rounded border border-slate-700/70 bg-slate-950/70 p-2"
+                                        >
                                           <button
                                             type="button"
                                             onClick={() => toggleTask(task.id)}
@@ -669,24 +750,37 @@ export default function FranchizeStatusPage() {
                                           >
                                             <div className="flex items-center gap-1">
                                               {taskExpanded ? (
-                                                <ChevronDown className="h-3.5 w-3.5 text-slate-400 flex-shrink-0" />
+                                                <ChevronDown className="h-3.5 w-3.5 flex-shrink-0 text-slate-400" />
                                               ) : (
-                                                <ChevronRight className="h-3.5 w-3.5 text-slate-400 flex-shrink-0" />
+                                                <ChevronRight className="h-3.5 w-3.5 flex-shrink-0 text-slate-400" />
                                               )}
-                                              <span className="text-sm text-slate-200">{task.title}</span>
+                                              <span className="text-sm text-slate-200">
+                                                {task.title}
+                                              </span>
                                             </div>
-                                            <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
+                                            <Badge className={taskMeta.className}>
+                                              {taskMeta.label}
+                                            </Badge>
                                           </button>
                                           {taskExpanded && (
                                             <div className="mt-2 space-y-1 pl-5 text-xs text-slate-400">
                                               <p>ID: {task.id}</p>
-                                              {task.todo_path && <p>todo_path: {task.todo_path}</p>}
+                                              {task.todo_path && (
+                                                <p>todo_path: {task.todo_path}</p>
+                                              )}
                                               <p>updated_at (UTC): {formatIso(task.updated_at)}</p>
                                               {task.body && (
-                                                <p className="max-w-lg truncate text-slate-300">{task.body}</p>
+                                                <p className="max-w-lg truncate text-slate-300">
+                                                  {task.body}
+                                                </p>
                                               )}
                                               {task.pr_url && (
-                                                <a className="text-cyan-300 underline underline-offset-2" href={task.pr_url} target="_blank" rel="noreferrer">
+                                                <a
+                                                  className="text-cyan-300 underline underline-offset-2"
+                                                  href={task.pr_url}
+                                                  target="_blank"
+                                                  rel="noreferrer"
+                                                >
                                                   PR: {task.pr_url}
                                                 </a>
                                               )}
@@ -710,8 +804,10 @@ export default function FranchizeStatusPage() {
         })}
       </div>
 
-      {/* ---- Legend ---- */}
-      <div className="mt-8 border-t border-slate-800 pt-4">
+      {/* ==================================================================== */}
+      {/*  LEGEND                                                              */}
+      {/* ==================================================================== */}
+      <div className="border-t border-slate-800 pt-4">
         <button
           type="button"
           onClick={() => setLegendOpen(!legendOpen)}
@@ -724,30 +820,58 @@ export default function FranchizeStatusPage() {
         {legendOpen && (
           <div className="mt-3 space-y-4 text-sm text-slate-300">
             <div>
-              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">Приоритеты (scoring)</h4>
-              <p className="text-slate-400">critical ×2.5, high ×2.0, medium ×1.5, low ×1.0. P0/p1/p2 в теле задачи действуют аналогично.</p>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Приоритеты (scoring)
+              </h4>
+              <p className="text-slate-400">
+                critical ×2.5, high ×2.0, medium ×1.5, low ×1.0. P0/p1/p2 в теле задачи действуют аналогично.
+              </p>
             </div>
             <div>
-              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">Фазы и их множители</h4>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Фазы и их множители
+              </h4>
               <div className="flex flex-wrap gap-2">
-                {["launch-blocker", "launch-quality", "security", "performance", "polishing", "ux-fix", "seo", "code-quality", "tech-debt", "post-launch"].map(p => (
-                  <Badge key={p} className="border-l-2 bg-slate-800/50 capitalize">{p.replace("-", " ")}</Badge>
+                {[
+                  "launch-blocker",
+                  "launch-quality",
+                  "security",
+                  "performance",
+                  "polishing",
+                  "ux-fix",
+                  "seo",
+                  "code-quality",
+                  "tech-debt",
+                  "post-launch",
+                ].map((p) => (
+                  <Badge key={p} className="border-l-2 bg-slate-800/50 capitalize">
+                    {p.replace("-", " ")}
+                  </Badge>
                 ))}
               </div>
             </div>
             <div>
-              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">Типы задач (capabilities)</h4>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Типы задач (capabilities)
+              </h4>
               <div className="flex flex-wrap gap-2">
-                {[...new Set(tasks.map((t) => t.capability))].filter(Boolean).sort().map((cap) => (
-                  <Badge key={cap} variant="outline" className="text-xs">{cap}</Badge>
-                ))}
+                {[...new Set(tasks.map((t) => t.capability))]
+                  .filter(Boolean)
+                  .sort()
+                  .map((cap) => (
+                    <Badge key={cap} variant="outline" className="text-xs">
+                      {cap}
+                    </Badge>
+                  ))}
               </div>
             </div>
           </div>
         )}
       </div>
 
-      {/* ---- Runtime checks ---- */}
+      {/* ==================================================================== */}
+      {/*  RUNTIME CHECKS                                                      */}
+      {/* ==================================================================== */}
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-base">
@@ -767,15 +891,19 @@ export default function FranchizeStatusPage() {
         </CardContent>
       </Card>
 
-      {/* ---- Bottom sticky bar ---- */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 flex items-center justify-between gap-2 border-t border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
+      {/* ==================================================================== */}
+      {/*  BOTTOM STICKY BAR (mobile only)                                     */}
+      {/* ==================================================================== */}
+      <div className="fixed inset-x-0 bottom-0 z-40 flex items-center justify-between gap-2 border-t border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
         <div className="flex items-center gap-2 text-xs">
           <Flame className="h-4 w-4 text-rose-400" />
           <span className="font-medium text-slate-700 dark:text-slate-300">
             {totalPending} критических
           </span>
           <span className="text-slate-400 dark:text-slate-500">|</span>
-          <span className="text-emerald-600 dark:text-emerald-400">{statusTotals.done} сделано</span>
+          <span className="text-emerald-600 dark:text-emerald-400">
+            {statusTotals.done} сделано
+          </span>
         </div>
         <Button
           variant="ghost"

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -480,7 +480,7 @@ export default function FranchizeStatusPage() {
   /*  Render                                                                   */
   /* ======================================================================== */
   return (
-    <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 pb-20 pt-20 sm:px-6 sm:py-8 lg:px-8">
+    <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 pb-20 pt-20 sm:px-6 sm:py-8 lg:px-8 overflow-hidden">
       {/* ==================================================================== */}
       {/*  HERO                                                                 */}
       {/* ==================================================================== */}

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import {
   AlertCircle,
@@ -11,9 +11,12 @@ import {
   ChevronRight,
   Clock3,
   Flame,
+  HelpCircle,
+  Info,
   Layers3,
   Milestone,
   Rocket,
+  Sparkles,
   Timer,
   Wrench,
   Zap,
@@ -23,6 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { supabaseAnon } from "@/hooks/supabase";
+import { getTopPriorityTasks, PriorityTask } from "./actions";
 
 /* -------------------------------------------------------------------------- */
 /*  Types & constants                                                         */
@@ -60,7 +64,13 @@ const STATUS_LABEL: Record<TaskStatus, { label: string; className: string }> = {
   done: { label: "Done", className: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
 };
 
-// Priority weight for sorting: lower = more urgent, higher = more done.
+const TASK_TYPE_DESCRIPTIONS: Record<string, string> = {
+  "R1 Contract": "Блокирующий слой: данные, схемы, совместимость",
+  "R2 Integration": "Telegram/Bridge/API, контур callback",
+  "R3 Ops UX": "Операторская витрина, админ-флоу, CTA",
+  "R4 Growth": "Маркетплейс, комьюнити, геймификация",
+};
+
 function statusUrgency(status: string): number {
   switch (status) {
     case "open": return 0;
@@ -68,7 +78,7 @@ function statusUrgency(status: string): number {
     case "running": return 2;
     case "ready_for_pr": return 3;
     case "done": return 4;
-    default: return 5; // unknown
+    default: return 5;
   }
 }
 
@@ -197,7 +207,7 @@ const IDEA_MAP: IdeaRow[] = [
 ];
 
 /* -------------------------------------------------------------------------- */
-/*  Component                                                                 */
+/*  Page Component                                                            */
 /* -------------------------------------------------------------------------- */
 
 export default function FranchizeStatusPage() {
@@ -209,11 +219,17 @@ export default function FranchizeStatusPage() {
   const [expandedPhases, setExpandedPhases] = useState<Set<string>>(new Set());
   const [expandedCapabilities, setExpandedCapabilities] = useState<Set<string>>(new Set());
   const [expandedTasks, setExpandedTasks] = useState<Set<string>>(new Set());
-
-  // Global expand/collapse
   const [allExpanded, setAllExpanded] = useState(false);
 
-  // Fetch tasks
+  // Legend visibility
+  const [legendOpen, setLegendOpen] = useState(false);
+
+  // Priority tasks state
+  const [priorityTasks, setPriorityTasks] = useState<PriorityTask[]>([]);
+  const [isPriorityLoading, startPriorityTransition] = useTransition();
+  const [showPriority, setShowPriority] = useState(false);
+
+  // Fetch all franchize tasks on mount
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
@@ -263,7 +279,6 @@ export default function FranchizeStatusPage() {
 
   const totalPending = tasks.length - statusTotals.done;
 
-  // Map capability → IdeaRow
   const capabilityIdeaMap = useMemo(() => {
     const map = new Map<string, IdeaRow>();
     IDEA_MAP.forEach((row) => map.set(row.capability, row));
@@ -274,7 +289,7 @@ export default function FranchizeStatusPage() {
     return capabilityIdeaMap.get(cap)?.phase ?? "Uncategorised";
   };
 
-  // ---- Build phase data with intelligent sorting ----
+  // Build phase data with intelligent sorting
   const phaseData = useMemo(() => {
     const phaseMap = new Map<string, { capabilities: string[] }>();
     PHASE_ORDER.forEach((phase) => phaseMap.set(phase, { capabilities: [] }));
@@ -291,8 +306,8 @@ export default function FranchizeStatusPage() {
       phaseMap.get(phase)!.capabilities.push(cap);
     });
 
-    // Sort capabilities within each phase by urgency (worst task status first)
-    phaseMap.forEach((value, phase) => {
+    // Sort capabilities within each phase by urgency (worst status first)
+    phaseMap.forEach((value) => {
       value.capabilities.sort((a, b) => {
         const tasksA = capabilityTaskMap.get(a) || [];
         const tasksB = capabilityTaskMap.get(b) || [];
@@ -303,7 +318,7 @@ export default function FranchizeStatusPage() {
       });
     });
 
-    // Sort phases by total undone tasks (descending), with fully done phases last
+    // Sort phases by total undone tasks (descending), fully done phases last
     const entries = [...phaseMap.entries()].sort(([phaseA, capsA], [phaseB, capsB]) => {
       const undoneA = capsA.capabilities.reduce((sum, cap) => {
         const tasks = capabilityTaskMap.get(cap) || [];
@@ -314,11 +329,10 @@ export default function FranchizeStatusPage() {
         return sum + tasks.filter((t) => t.status !== "done").length;
       }, 0);
 
-      // Phases with 0 undone go to the end
       if (undoneA === 0 && undoneB === 0) return phaseA.localeCompare(phaseB);
       if (undoneA === 0) return 1;
       if (undoneB === 0) return -1;
-      return undoneB - undoneA; // high undone first
+      return undoneB - undoneA;
     });
 
     return entries;
@@ -371,7 +385,6 @@ export default function FranchizeStatusPage() {
     setAllExpanded(false);
   }, []);
 
-  // Jump to first critical phase (first phase with undone tasks)
   const jumpToFirstCritical = useCallback(() => {
     const firstCritical = phaseData.find(([, { capabilities }]) => {
       return capabilities.some((cap) => {
@@ -386,7 +399,20 @@ export default function FranchizeStatusPage() {
     }
   }, [phaseData, capabilityTaskMap]);
 
-  // ---- Rendering ----
+  // Load top priority tasks
+  const handleLoadPriority = useCallback(() => {
+    startPriorityTransition(async () => {
+      const res = await getTopPriorityTasks();
+      if (res.success && res.data) {
+        setPriorityTasks(res.data);
+        setShowPriority(true);
+      } else {
+        alert(res.error || "Ошибка загрузки приоритетных задач");
+      }
+    });
+  }, []);
+
+  // ---- Render ----
   if (loading) {
     return (
       <div className="flex min-h-[50vh] items-center justify-center text-slate-200">
@@ -406,7 +432,7 @@ export default function FranchizeStatusPage() {
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 sm:px-6 sm:py-6 lg:px-8">
       {/* ---- Mobile sticky status bar ---- */}
-      <div className="sticky top-16 z-30 -mx-3 -mt-4 mb-4 flex items-center justify-between gap-2 rounded-b-2xl border-b border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
+      <div className="sticky bottom-0 z-30 -mx-3 -mt-4 mb-4 flex items-center justify-between gap-2 rounded-b-2xl border-b border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
         <div className="flex items-center gap-2 text-xs">
           <Flame className="h-4 w-4 text-rose-400" />
           <span className="font-medium text-slate-700 dark:text-slate-300">
@@ -420,7 +446,7 @@ export default function FranchizeStatusPage() {
         </Button>
       </div>
 
-      {/* ---- Hero Banner (unchanged) ---- */}
+      {/* ---- Hero Banner ---- */}
       <section className="relative overflow-hidden rounded-3xl border border-slate-200/80 bg-[radial-gradient(circle_at_top_right,#0ea5e9_0%,#111827_42%,#020617_100%)] p-5 text-white shadow-lg dark:border-slate-700/80">
         <div className="absolute -right-16 top-0 h-44 w-44 rounded-full bg-cyan-400/25 blur-3xl" aria-hidden />
         <div className="absolute -bottom-16 left-8 h-32 w-32 rounded-full bg-amber-400/20 blur-3xl" aria-hidden />
@@ -431,17 +457,24 @@ export default function FranchizeStatusPage() {
           <span>canonical slug: vip-bike</span>
         </div>
 
-        <h1 className="relative mt-3 text-2xl font-semibold leading-tight sm:text-4xl">SupaPlan • Franchize status board (human-first)</h1>
+        <h1 className="relative mt-3 text-2xl font-semibold leading-tight sm:text-4xl">
+          SupaPlan • Franchize status board (human-first)
+        </h1>
         <p className="relative mt-3 max-w-4xl text-sm text-slate-200 sm:text-base">
-          Сопоставили клиентские идеи и текущий SupaPlan. Здесь видно, какие эпики уже закрыты, какие в работе и где пора декомпозировать
-          в более мелкие задачи во время реализации.
+          Сопоставили клиентские идеи и текущий SupaPlan. Здесь видно, какие эпики уже закрыты, какие в работе и где пора декомпозировать в более мелкие задачи во время реализации.
         </p>
 
         <div className="relative mt-4 flex flex-wrap gap-2 text-xs sm:text-sm">
-          <Link href="/supaplan" className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 hover:bg-white/15">
+          <Link
+            href="/supaplan"
+            className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 hover:bg-white/15"
+          >
             <ArrowLeft className="h-4 w-4" /> Назад в общий SupaPlan
           </Link>
-          <Link href="/nexus" className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 hover:bg-white/15">
+          <Link
+            href="/nexus"
+            className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 hover:bg-white/15"
+          >
             <Rocket className="h-4 w-4" /> Nexus
           </Link>
           <Link
@@ -458,14 +491,16 @@ export default function FranchizeStatusPage() {
         {(["open", "claimed", "running", "ready_for_pr", "done"] as TaskStatus[]).map((status) => (
           <Card key={status} className="border-slate-800/70 bg-slate-950 text-slate-100">
             <CardHeader className="space-y-1 pb-1">
-              <CardDescription className="text-xs text-slate-400">{STATUS_LABEL[status].label}</CardDescription>
+              <CardDescription className="text-xs text-slate-400">
+                {STATUS_LABEL[status].label}
+              </CardDescription>
               <CardTitle className="text-2xl">{statusTotals[status]}</CardTitle>
             </CardHeader>
           </Card>
         ))}
       </section>
 
-      {/* ---- Progress & Legend ---- */}
+      {/* ---- Progress bar ---- */}
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
@@ -477,36 +512,93 @@ export default function FranchizeStatusPage() {
             <div className="h-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-fuchsia-400" style={{ width: `${progressPercent}%` }} />
           </div>
           <p className="mt-2 text-sm text-slate-300">
-            Выполнено: <span className="font-semibold text-emerald-300">{statusTotals.done}/{tasks.length}</span> задач. Осталось критических: <span className="font-semibold text-rose-400">{totalPending}</span>.
+            Выполнено: <span className="font-semibold text-emerald-300">{statusTotals.done}/{tasks.length}</span> задач. Осталось критических:{" "}
+            <span className="font-semibold text-rose-400">{totalPending}</span>.
           </p>
         </CardContent>
       </Card>
 
-      <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
-            <Milestone className="h-4 w-4 text-cyan-300" /> Legend — типы задач и статусов
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
-          <div className="rounded-xl border border-cyan-500/30 bg-cyan-500/10 p-3">
-            <strong>R1 Contract</strong>
-            <p className="text-slate-300">Блокирующий слой: данные, схемы, совместимость, правила декомпозиции.</p>
-          </div>
-          <div className="rounded-xl border border-indigo-500/30 bg-indigo-500/10 p-3">
-            <strong>R2 Integration</strong>
-            <p className="text-slate-300">Интеграции Telegram/Bridge/API, контур callback и внешние связки.</p>
-          </div>
-          <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3">
-            <strong>R3 Ops UX</strong>
-            <p className="text-slate-300">Операторская витрина, админ-флоу, понятные статусы и CTA.</p>
-          </div>
-          <div className="rounded-xl border border-fuchsia-500/30 bg-fuchsia-500/10 p-3">
-            <strong>R4 Growth</strong>
-            <p className="text-slate-300">Маркетплейс, комьюнити, геймификация и ростовые механики.</p>
-          </div>
-        </CardContent>
-      </Card>
+      {/* 🔥 TOP-5 PRIORITY SECTION */}
+      <section>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleLoadPriority}
+          disabled={isPriorityLoading}
+          className="mb-2 gap-2 bg-amber-900/20 text-amber-300 border-amber-500/40 hover:bg-amber-900/30"
+        >
+          {isPriorityLoading ? (
+            <span className="flex items-center gap-1">
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-amber-400 border-t-transparent" />
+              Считаю...
+            </span>
+          ) : (
+            <>
+              <Sparkles className="h-4 w-4" />
+              Загрузить ТОП-5 приоритетных задач
+            </>
+          )}
+        </Button>
+
+        {showPriority && priorityTasks.length > 0 && (
+          <Card className="border-amber-500/50 bg-gradient-to-br from-amber-950/60 to-slate-950 text-slate-100 shadow shadow-amber-500/10">
+            <CardHeader className="pb-2">
+              <div className="flex items-center justify-between">
+                <CardTitle className="flex items-center gap-2 text-lg text-amber-300">
+                  <Flame className="h-5 w-5" /> ТОП-5 критических задач
+                </CardTitle>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowPriority(false)}
+                  className="text-slate-400 hover:text-slate-200"
+                >
+                  Скрыть
+                </Button>
+              </div>
+              <CardDescription className="text-slate-400">
+                Умная сортировка: статус × фаза × важность способности. Обнови в любой момент.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-2 sm:grid-cols-2">
+              {priorityTasks.map((pt) => {
+                const taskMeta = STATUS_LABEL[pt.status as TaskStatus] || STATUS_LABEL.open;
+                const fullTask = tasks.find((t) => t.id === pt.id);
+                return (
+                  <div key={pt.id} className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="flex-1">
+                        <p className="font-semibold text-slate-100">{pt.title}</p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                          <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
+                          <Badge variant="outline" className="border-slate-600 text-slate-400">
+                            {pt.capability}
+                          </Badge>
+                        </div>
+                      </div>
+                      <span className="rounded-full bg-amber-400/20 px-2 py-0.5 text-xs font-mono font-bold text-amber-300">
+                        {pt.score}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-400">{pt.reasoning}</p>
+                    {fullTask?.todo_path && (
+                      <p className="mt-1 text-xs text-slate-500">todo_path: {fullTask.todo_path}</p>
+                    )}
+                    <div className="mt-2">
+                      <Link
+                        href={`/supaplan?task=${pt.id}`}
+                        className="inline-flex items-center gap-1 text-xs text-cyan-300 underline underline-offset-2"
+                      >
+                        Перейти к задаче →
+                      </Link>
+                    </div>
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+        )}
+      </section>
 
       {/* ---- Global expand/collapse ---- */}
       <div className="flex flex-wrap items-center gap-2">
@@ -516,21 +608,19 @@ export default function FranchizeStatusPage() {
         <Button variant="outline" size="sm" onClick={handleCollapseAll} className="text-xs">
           Свернуть всё
         </Button>
-        <span className="ml-auto text-xs text-slate-400">
-          Фазы упорядочены по критичности
-        </span>
+        <span className="ml-auto text-xs text-slate-400">Фазы упорядочены по критичности</span>
       </div>
 
       {/* ---- Phase → Capability → Task tree ---- */}
       <div className="space-y-3">
         {phaseData.map(([phase, { capabilities }]) => {
           const phaseExpanded = expandedPhases.has(phase);
-          // Count undone tasks for the phase badge
           const phaseUndone = capabilities.reduce((sum, cap) => {
             const tasks = capabilityTaskMap.get(cap) || [];
             return sum + tasks.filter((t) => t.status !== "done").length;
           }, 0);
           const isPhaseFullyDone = phaseUndone === 0;
+
           return (
             <Card
               key={phase}
@@ -576,7 +666,6 @@ export default function FranchizeStatusPage() {
                       const capTasks = capabilityTaskMap.get(cap) || [];
                       const idea = capabilityIdeaMap.get(cap);
                       const capExpanded = expandedCapabilities.has(cap);
-
                       const doneCount = capTasks.filter((t) => t.status === "done").length;
                       const allDone = capTasks.length > 0 && doneCount === capTasks.length;
                       const worstStatus = capTasks.length
@@ -619,7 +708,10 @@ export default function FranchizeStatusPage() {
                                   <p className="text-slate-300">{idea.note}</p>
                                   <div className="mt-1 flex flex-wrap gap-1">
                                     {idea.routes.map((r) => (
-                                      <code key={r} className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300">
+                                      <code
+                                        key={r}
+                                        className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300"
+                                      >
                                         {r}
                                       </code>
                                     ))}
@@ -637,9 +729,13 @@ export default function FranchizeStatusPage() {
                                     .sort((a, b) => statusUrgency(a.status) - statusUrgency(b.status))
                                     .map((task) => {
                                       const taskExpanded = expandedTasks.has(task.id);
-                                      const taskMeta = STATUS_LABEL[task.status as TaskStatus] || STATUS_LABEL.open;
+                                      const taskMeta =
+                                        STATUS_LABEL[task.status as TaskStatus] || STATUS_LABEL.open;
                                       return (
-                                        <li key={task.id} className="rounded border border-slate-700/70 bg-slate-950/70 p-2">
+                                        <li
+                                          key={task.id}
+                                          className="rounded border border-slate-700/70 bg-slate-950/70 p-2"
+                                        >
                                           <button
                                             type="button"
                                             onClick={() => toggleTask(task.id)}
@@ -653,14 +749,20 @@ export default function FranchizeStatusPage() {
                                               )}
                                               <span className="text-sm text-slate-200">{task.title}</span>
                                             </div>
-                                            <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
+                                            <Badge className={taskMeta.className}>
+                                              {taskMeta.label}
+                                            </Badge>
                                           </button>
                                           {taskExpanded && (
                                             <div className="mt-2 space-y-1 pl-5 text-xs text-slate-400">
                                               <p>ID: {task.id}</p>
-                                              {task.todo_path && <p>todo_path: {task.todo_path}</p>}
+                                              {task.todo_path && (
+                                                <p>todo_path: {task.todo_path}</p>
+                                              )}
                                               <p>updated_at (UTC): {formatIso(task.updated_at)}</p>
-                                              {task.body && <p className="text-slate-300">{task.body}</p>}
+                                              {task.body && (
+                                                <p className="text-slate-300">{task.body}</p>
+                                              )}
                                               {task.pr_url && (
                                                 <a
                                                   className="text-cyan-300 underline underline-offset-2"
@@ -691,13 +793,41 @@ export default function FranchizeStatusPage() {
         })}
       </div>
 
+      {/* ---- Compact Collapsible Legend (moved out of the way) ---- */}
+      <div className="mt-8 border-t border-slate-800 pt-4">
+        <button
+          type="button"
+          onClick={() => setLegendOpen(!legendOpen)}
+          className="inline-flex items-center gap-1 text-sm text-slate-400 hover:text-slate-200"
+        >
+          <HelpCircle className="h-4 w-4" />
+          {legendOpen ? "Скрыть легенду" : "Показать легенду"}
+        </button>
+
+        {legendOpen && (
+          <div className="mt-3 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+            {Object.entries(TASK_TYPE_DESCRIPTIONS).map(([type, desc]) => (
+              <div
+                key={type}
+                className="rounded-xl border border-slate-700/50 bg-slate-900/50 p-3"
+              >
+                <strong className="text-slate-200">{type}</strong>
+                <p className="text-slate-400">{desc}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
       {/* ---- Runtime checks ---- */}
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
             <Wrench className="h-4 w-4 text-cyan-300" /> Runtime checks
           </CardTitle>
-          <CardDescription className="text-slate-400">Текущая выборка из supaplan_tasks (capability like `franchize.%`).</CardDescription>
+          <CardDescription className="text-slate-400">
+            Текущая выборка из supaplan_tasks (capability like `franchize.%`).
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-2 text-sm text-slate-300">
           <p className="flex items-center gap-2">

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -970,7 +970,7 @@ export default function FranchizeStatusPage() {
                   "tech-debt",
                   "post-launch",
                 ].map((p) => (
-                  <Badge key={p} className="border-l-2 bg-slate-800/50 capitalize">
+                  <Badge key={p} className="border-l-2 bg-cyan-800/50 capitalize">
                     {p.replace("-", " ")}
                   </Badge>
                 ))}
@@ -1004,7 +1004,7 @@ export default function FranchizeStatusPage() {
             <Wrench className="h-4 w-4 text-cyan-300" /> Контроль работы
           </CardTitle>
           <CardDescription className="text-slate-400">
-            {tasks.length} задач франшизы загружено (greenbox исключены).
+            {tasks.length} задач франшизы загружено.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-2 text-sm text-slate-300">

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -432,7 +432,7 @@ export default function FranchizeStatusPage() {
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 sm:px-6 sm:py-6 lg:px-8">
       {/* ---- Mobile sticky status bar ---- */}
-      <div className="sticky bottom-0 z-30 -mx-3 -mt-4 mb-4 flex items-center justify-between gap-2 rounded-b-2xl border-b border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
+      <div className="sticky top-16 z-30 -mx-3 -mt-4 mb-4 flex items-center justify-between gap-2 rounded-b-2xl border-b border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
         <div className="flex items-center gap-2 text-xs">
           <Flame className="h-4 w-4 text-rose-400" />
           <span className="font-medium text-slate-700 dark:text-slate-300">

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronRight,
   Clock3,
+  Copy,
   Flame,
   HelpCircle,
   Rocket,
@@ -200,9 +201,21 @@ function formatIso(iso: string): string {
   });
 }
 
-/* -------------------------------------------------------------------------- */
-/*  Page Component                                                            */
-/* -------------------------------------------------------------------------- */
+// Clipboard helpers
+function buildTaskCopyText(task: PriorityTask, fullTask?: FranchizeTask): string {
+  const parts = [
+    `Выполни задачу: ${task.title}`,
+    `ID: ${task.id}`,
+    `Статус: ${task.status}`,
+    `Capability: ${task.capability || "—"}`,
+  ];
+  if (fullTask?.todo_path) parts.push(`Файл: ${fullTask.todo_path}`);
+  if (fullTask?.body) {
+    const bodyPreview = fullTask.body.length > 200 ? `${fullTask.body.slice(0, 200)}...` : fullTask.body;
+    parts.push(`Описание: ${bodyPreview}`);
+  }
+  return parts.join("\n");
+}
 
 export default function FranchizeStatusPage() {
   const [tasks, setTasks] = useState<FranchizeTask[]>([]);
@@ -218,6 +231,8 @@ export default function FranchizeStatusPage() {
   const [priorityTasks, setPriorityTasks] = useState<PriorityTask[]>([]);
   const [isPriorityLoading, startPriorityTransition] = useTransition();
   const [showPriority, setShowPriority] = useState(false);
+
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -257,36 +272,31 @@ export default function FranchizeStatusPage() {
   const totalPending = tasks.length - statusTotals.done;
   const progressPercent = tasks.length ? Math.round((statusTotals.done / tasks.length) * 100) : 0;
 
-  // Group tasks by IDEA_MAP phases, then by capability (using IDEA_MAP for display)
+  // Group tasks by IDEA_MAP phases, then by capability
   const phaseData = useMemo(() => {
     const map = new Map<string, Map<string, FranchizeTask[]>>();
-    // Initialize phases from PHASE_ORDER
     PHASE_ORDER.forEach((p) => map.set(p, new Map()));
 
-    // Add tasks to their IDEA_MAP phase (fallback to metadata.phase if not found)
     const ideaByCap = new Map(IDEA_MAP.map((i) => [i.capability, i]));
     tasks.forEach((task) => {
       const cap = task.capability || "unknown";
       const idea = ideaByCap.get(cap);
-      const phase = idea?.phase ?? "2027"; // default to last phase if unknown
+      const phase = idea?.phase ?? "2027";
       if (!map.has(phase)) map.set(phase, new Map());
       const capMap = map.get(phase)!;
       if (!capMap.has(cap)) capMap.set(cap, []);
       capMap.get(cap)!.push(task);
     });
 
-    // Remove empty phases (with no tasks) for cleanliness, but keep order
     const orderedPhases: [string, Map<string, FranchizeTask[]>][] = [];
     PHASE_ORDER.forEach((p) => {
       if (map.get(p)?.size) orderedPhases.push([p, map.get(p)!]);
     });
-    // Append any extra phases not in PHASE_ORDER (e.g., "2027") at end
     map.forEach((capMap, phase) => {
       if (!PHASE_ORDER.includes(phase as any) && capMap.size) {
         orderedPhases.push([phase, capMap]);
       }
     });
-
     return orderedPhases;
   }, [tasks]);
 
@@ -329,6 +339,25 @@ export default function FranchizeStatusPage() {
     });
   }, []);
 
+  const handleCopyTask = useCallback(async (pt: PriorityTask) => {
+    const fullTask = tasks.find((t) => t.id === pt.id);
+    const text = buildTaskCopyText(pt, fullTask);
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [tasks]);
+
+  const handleCopyAllTop5 = useCallback(async () => {
+    const texts = priorityTasks.map((pt) => {
+      const fullTask = tasks.find((t) => t.id === pt.id);
+      return `--- Задача ${pt.id} ---\n${buildTaskCopyText(pt, fullTask)}`;
+    });
+    const fullText = texts.join("\n\n");
+    await navigator.clipboard.writeText(fullText);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [priorityTasks, tasks]);
+
   if (loading) {
     return (
       <div className="flex min-h-[50vh] items-center justify-center text-slate-200">
@@ -346,32 +375,9 @@ export default function FranchizeStatusPage() {
   }
 
   return (
-    <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 sm:px-6 sm:py-6 lg:px-8">
-      {/* ---- Mobile sticky bar ---- */}
-      <div className="sticky top-16 z-30 -mx-3 -mt-4 mb-4 flex items-center justify-between gap-2 rounded-b-2xl border-b border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
-        <div className="flex items-center gap-2 text-xs">
-          <Flame className="h-4 w-4 text-rose-400" />
-          <span className="font-medium text-slate-700 dark:text-slate-300">
-            {totalPending} критических
-          </span>
-          <span className="text-slate-400 dark:text-slate-500">|</span>
-          <span className="text-emerald-600 dark:text-emerald-400">{statusTotals.done} сделано</span>
-        </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            const first = document.querySelector("[data-phase]");
-            first?.scrollIntoView({ behavior: "smooth", block: "start" });
-          }}
-          className="h-7 text-xs"
-        >
-          <Zap className="mr-1 h-3 w-3" /> К первому
-        </Button>
-      </div>
-
-      {/* ---- Hero ---- */}
-      <section className="relative overflow-hidden rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-6 text-white shadow-2xl">
+    <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 pb-16 sm:px-6 sm:py-6 lg:px-8">
+      {/* ---- Hero (no overflow-hidden) ---- */}
+      <section className="relative rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-6 text-white shadow-2xl">
         <div className="absolute -right-16 -top-16 h-64 w-64 rounded-full bg-cyan-500/20 blur-3xl" />
         <div className="absolute -bottom-12 -left-12 h-48 w-48 rounded-full bg-amber-500/20 blur-3xl" />
         <div className="relative z-10 grid gap-6 md:grid-cols-3">
@@ -381,7 +387,7 @@ export default function FranchizeStatusPage() {
               <span>vip-bike crew</span>
             </div>
             <h1 className="text-3xl font-bold leading-tight sm:text-5xl">
-              <span className="bg-gradient-to-r from-cyan-400 via-amber-300 to-fuchsia-400 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-cyan-300 via-indigo-400 to-purple-400 bg-clip-text text-transparent">
                 SupaPlan • Franchize
               </span>
               <br />
@@ -485,7 +491,20 @@ export default function FranchizeStatusPage() {
                 <CardTitle className="flex items-center gap-2 text-lg text-amber-300">
                   <Flame className="h-5 w-5" /> ТОП-5 критических задач
                 </CardTitle>
-                <Button variant="ghost" size="sm" onClick={() => setShowPriority(false)} className="text-slate-400 hover:text-slate-200">Скрыть</Button>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleCopyAllTop5}
+                    className="text-xs text-amber-300 hover:text-amber-100 disabled:opacity-50"
+                  >
+                    <Copy className="mr-1 h-3.5 w-3.5" />
+                    {copied ? "Скопировано!" : "Копировать все 5"}
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => setShowPriority(false)} className="text-slate-400 hover:text-slate-200">
+                    Скрыть
+                  </Button>
+                </div>
               </div>
               <CardDescription className="text-slate-400">
                 Формула: статус × фаза × важность способности × приоритет × свежесть.
@@ -511,10 +530,16 @@ export default function FranchizeStatusPage() {
                     {fullTask?.todo_path && (
                       <p className="mt-1 text-xs text-slate-500">todo_path: {fullTask.todo_path}</p>
                     )}
-                    <div className="mt-2">
-                      <Link href={`/supaplan?task=${pt.id}`} className="inline-flex items-center gap-1 text-xs text-cyan-300 underline underline-offset-2">
-                        Перейти к задаче →
-                      </Link>
+                    <div className="mt-2 flex items-center justify-between">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleCopyTask(pt)}
+                        className="h-auto px-2 py-1 text-xs text-cyan-300 hover:text-cyan-100"
+                      >
+                        <Copy className="mr-1 h-3 w-3" />
+                        Копировать задачу
+                      </Button>
                     </div>
                   </div>
                 );
@@ -532,7 +557,6 @@ export default function FranchizeStatusPage() {
           const undone = phaseTasks.filter((t) => t.status !== "done").length;
           const total = phaseTasks.length;
           const fullyDone = total > 0 && undone === 0;
-          const ideaForPhase = IDEA_MAP.find((i) => i.phase === phase);
           return (
             <Card
               key={phase}
@@ -593,18 +617,23 @@ export default function FranchizeStatusPage() {
                           <button
                             type="button"
                             onClick={() => toggleCapability(cap)}
-                            className="flex w-full items-center justify-between p-3 text-left"
+                            className="flex w-full items-start justify-between p-3 text-left"
                           >
-                            <div className="flex items-center gap-2">
-                              {capExpanded ? (
-                                <ChevronDown className="h-4 w-4 text-amber-300 flex-shrink-0" />
-                              ) : (
-                                <ChevronRight className="h-4 w-4 text-amber-300 flex-shrink-0" />
+                            <div className="flex-1">
+                              <div className="flex items-center gap-2">
+                                {capExpanded ? (
+                                  <ChevronDown className="h-4 w-4 text-amber-300 flex-shrink-0" />
+                                ) : (
+                                  <ChevronRight className="h-4 w-4 text-amber-300 flex-shrink-0" />
+                                )}
+                                <span className="text-sm font-medium">{idea?.idea || cap}</span>
+                                {allDone && <CheckCircle2 className="h-4 w-4 text-emerald-400" />}
+                              </div>
+                              {idea?.note && (
+                                <p className="mt-1 pl-6 text-xs text-slate-400">{idea.note}</p>
                               )}
-                              <span className="text-sm font-medium">{idea?.idea || cap}</span>
-                              {allDone && <CheckCircle2 className="h-4 w-4 text-emerald-400" />}
                             </div>
-                            <div className="flex items-center gap-2">
+                            <div className="ml-2 flex items-center gap-2">
                               <Badge className={worstMeta.className}>{worstMeta.label}</Badge>
                               <span className="text-xs text-slate-400">{doneCount}/{capTasks.length}</span>
                             </div>
@@ -614,12 +643,9 @@ export default function FranchizeStatusPage() {
                             <div className="border-t border-slate-800 px-3 pb-3 pt-2">
                               {idea && (
                                 <div className="mb-2 text-xs text-slate-400">
-                                  <p className="text-slate-300">{idea.note}</p>
                                   <div className="mt-1 flex flex-wrap gap-1">
                                     {idea.routes.map((r) => (
-                                      <code key={r} className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300">
-                                        {r}
-                                      </code>
+                                      <code key={r} className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300">{r}</code>
                                     ))}
                                   </div>
                                 </div>
@@ -740,6 +766,29 @@ export default function FranchizeStatusPage() {
           </p>
         </CardContent>
       </Card>
+
+      {/* ---- Bottom sticky bar ---- */}
+      <div className="fixed bottom-0 left-0 right-0 z-40 flex items-center justify-between gap-2 border-t border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
+        <div className="flex items-center gap-2 text-xs">
+          <Flame className="h-4 w-4 text-rose-400" />
+          <span className="font-medium text-slate-700 dark:text-slate-300">
+            {totalPending} критических
+          </span>
+          <span className="text-slate-400 dark:text-slate-500">|</span>
+          <span className="text-emerald-600 dark:text-emerald-400">{statusTotals.done} сделано</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            const first = document.querySelector("[data-phase]");
+            first?.scrollIntoView({ behavior: "smooth", block: "start" });
+          }}
+          className="h-7 text-xs"
+        >
+          <Zap className="mr-1 h-3 w-3" /> К первому
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -10,15 +10,18 @@ import {
   ChevronDown,
   ChevronRight,
   Clock3,
+  Flame,
   Layers3,
   Milestone,
   Rocket,
   Timer,
   Wrench,
+  Zap,
 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { supabaseAnon } from "@/hooks/supabase";
 
 /* -------------------------------------------------------------------------- */
@@ -42,7 +45,7 @@ type FranchizeTask = {
 type IdeaRow = {
   idea: string;
   capability: string;
-  phase: string; // we'll still use the existing phases, but allow new ones to fall into "Uncategorised"
+  phase: string;
   taskType: "R1 Contract" | "R2 Integration" | "R3 Ops UX" | "R4 Growth";
   routes: string[];
   note: string;
@@ -56,6 +59,29 @@ const STATUS_LABEL: Record<TaskStatus, { label: string; className: string }> = {
   ready_for_pr: { label: "Ready for PR", className: "bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-400/30" },
   done: { label: "Done", className: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
 };
+
+// Priority weight for sorting: lower = more urgent, higher = more done.
+function statusUrgency(status: string): number {
+  switch (status) {
+    case "open": return 0;
+    case "claimed": return 1;
+    case "running": return 2;
+    case "ready_for_pr": return 3;
+    case "done": return 4;
+    default: return 5; // unknown
+  }
+}
+
+function formatIso(iso: string): string {
+  return new Date(iso).toLocaleString("ru-RU", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+  });
+}
 
 const PHASE_ORDER = ["Апрель", "Май", "Июнь", "Лето", "2027"] as const;
 
@@ -150,7 +176,6 @@ const IDEA_MAP: IdeaRow[] = [
     note: "Матчинг «идея ↔ capability ↔ task/status».",
     decompositionHint: "Регулярно спаунить детализацию эпиков при старте реализации.",
   },
-  // ---- NEW CAPABILITIES ----
   {
     idea: "UI/UX-дизайн для франшизы",
     capability: "franchize.ui.ux",
@@ -172,32 +197,7 @@ const IDEA_MAP: IdeaRow[] = [
 ];
 
 /* -------------------------------------------------------------------------- */
-/*  Helpers                                                                   */
-/* -------------------------------------------------------------------------- */
-
-function statusWeight(status: string): number {
-  switch (status) {
-    case "done": return 4;
-    case "ready_for_pr": return 3;
-    case "running": return 2;
-    case "claimed": return 1;
-    default: return 0;
-  }
-}
-
-function formatIso(iso: string): string {
-  return new Date(iso).toLocaleString("ru-RU", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZone: "UTC",
-  });
-}
-
-/* -------------------------------------------------------------------------- */
-/*  Page Component                                                            */
+/*  Component                                                                 */
 /* -------------------------------------------------------------------------- */
 
 export default function FranchizeStatusPage() {
@@ -205,12 +205,15 @@ export default function FranchizeStatusPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Drill‑down states: which phase / capability / task is expanded
+  // Tree expansion state
   const [expandedPhases, setExpandedPhases] = useState<Set<string>>(new Set());
   const [expandedCapabilities, setExpandedCapabilities] = useState<Set<string>>(new Set());
   const [expandedTasks, setExpandedTasks] = useState<Set<string>>(new Set());
 
-  // ---- Fetch all franchize tasks ----
+  // Global expand/collapse
+  const [allExpanded, setAllExpanded] = useState(false);
+
+  // Fetch tasks
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
@@ -233,7 +236,7 @@ export default function FranchizeStatusPage() {
     fetchData();
   }, []);
 
-  // ---- Group tasks by capability ----
+  // ---- Derived data ----
   const capabilityTaskMap = useMemo(() => {
     const map = new Map<string, FranchizeTask[]>();
     tasks.forEach((task) => {
@@ -245,7 +248,6 @@ export default function FranchizeStatusPage() {
     return map;
   }, [tasks]);
 
-  // ---- Stats ----
   const statusTotals = useMemo(() => {
     const totals: Record<TaskStatus, number> = { open: 0, claimed: 0, running: 0, ready_for_pr: 0, done: 0 };
     tasks.forEach((task) => {
@@ -259,7 +261,9 @@ export default function FranchizeStatusPage() {
     return tasks.length ? Math.round((statusTotals.done / tasks.length) * 100) : 0;
   }, [tasks, statusTotals.done]);
 
-  // ---- Map capabilities to phases (using IDEA_MAP + fallback) ----
+  const totalPending = tasks.length - statusTotals.done;
+
+  // Map capability → IdeaRow
   const capabilityIdeaMap = useMemo(() => {
     const map = new Map<string, IdeaRow>();
     IDEA_MAP.forEach((row) => map.set(row.capability, row));
@@ -270,16 +274,14 @@ export default function FranchizeStatusPage() {
     return capabilityIdeaMap.get(cap)?.phase ?? "Uncategorised";
   };
 
-  // ---- Build data per phase ----
+  // ---- Build phase data with intelligent sorting ----
   const phaseData = useMemo(() => {
     const phaseMap = new Map<string, { capabilities: string[] }>();
-
     PHASE_ORDER.forEach((phase) => phaseMap.set(phase, { capabilities: [] }));
 
-    // All capabilities present in tasks (or the map)
     const allCaps = new Set<string>();
     capabilityTaskMap.forEach((_, cap) => allCaps.add(cap));
-    capabilityIdeaMap.forEach((_, cap) => allCaps.add(cap)); // even empty ideas
+    capabilityIdeaMap.forEach((_, cap) => allCaps.add(cap));
 
     allCaps.forEach((cap) => {
       const phase = getPhaseForCapability(cap);
@@ -289,12 +291,37 @@ export default function FranchizeStatusPage() {
       phaseMap.get(phase)!.capabilities.push(cap);
     });
 
-    // Sort capabilities inside each phase (alphabetically, or by some weight)
-    phaseMap.forEach((value) => {
-      value.capabilities.sort((a, b) => a.localeCompare(b));
+    // Sort capabilities within each phase by urgency (worst task status first)
+    phaseMap.forEach((value, phase) => {
+      value.capabilities.sort((a, b) => {
+        const tasksA = capabilityTaskMap.get(a) || [];
+        const tasksB = capabilityTaskMap.get(b) || [];
+        const worstA = tasksA.reduce((min, t) => Math.min(min, statusUrgency(t.status)), 4);
+        const worstB = tasksB.reduce((min, t) => Math.min(min, statusUrgency(t.status)), 4);
+        if (worstA !== worstB) return worstA - worstB;
+        return a.localeCompare(b);
+      });
     });
 
-    return phaseMap;
+    // Sort phases by total undone tasks (descending), with fully done phases last
+    const entries = [...phaseMap.entries()].sort(([phaseA, capsA], [phaseB, capsB]) => {
+      const undoneA = capsA.capabilities.reduce((sum, cap) => {
+        const tasks = capabilityTaskMap.get(cap) || [];
+        return sum + tasks.filter((t) => t.status !== "done").length;
+      }, 0);
+      const undoneB = capsB.capabilities.reduce((sum, cap) => {
+        const tasks = capabilityTaskMap.get(cap) || [];
+        return sum + tasks.filter((t) => t.status !== "done").length;
+      }, 0);
+
+      // Phases with 0 undone go to the end
+      if (undoneA === 0 && undoneB === 0) return phaseA.localeCompare(phaseB);
+      if (undoneA === 0) return 1;
+      if (undoneB === 0) return -1;
+      return undoneB - undoneA; // high undone first
+    });
+
+    return entries;
   }, [capabilityTaskMap, capabilityIdeaMap]);
 
   // ---- Toggle helpers ----
@@ -325,6 +352,40 @@ export default function FranchizeStatusPage() {
     });
   }, []);
 
+  const handleExpandAll = useCallback(() => {
+    const allPhases = new Set(phaseData.map(([phase]) => phase));
+    const allCaps = new Set<string>();
+    phaseData.forEach(([, { capabilities }]) => capabilities.forEach((c) => allCaps.add(c)));
+    const allTasks = new Set(tasks.map((t) => t.id));
+
+    setExpandedPhases(allPhases);
+    setExpandedCapabilities(allCaps);
+    setExpandedTasks(allTasks);
+    setAllExpanded(true);
+  }, [phaseData, tasks]);
+
+  const handleCollapseAll = useCallback(() => {
+    setExpandedPhases(new Set());
+    setExpandedCapabilities(new Set());
+    setExpandedTasks(new Set());
+    setAllExpanded(false);
+  }, []);
+
+  // Jump to first critical phase (first phase with undone tasks)
+  const jumpToFirstCritical = useCallback(() => {
+    const firstCritical = phaseData.find(([, { capabilities }]) => {
+      return capabilities.some((cap) => {
+        const tasks = capabilityTaskMap.get(cap) || [];
+        return tasks.some((t) => t.status !== "done");
+      });
+    });
+    if (firstCritical) {
+      const [phase] = firstCritical;
+      setExpandedPhases((prev) => new Set(prev).add(phase));
+      document.getElementById(`phase-${phase}`)?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [phaseData, capabilityTaskMap]);
+
   // ---- Rendering ----
   if (loading) {
     return (
@@ -344,7 +405,22 @@ export default function FranchizeStatusPage() {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 sm:px-6 sm:py-6 lg:px-8">
-      {/* ---- Hero Banner (unchanged structure) ---- */}
+      {/* ---- Mobile sticky status bar ---- */}
+      <div className="sticky top-16 z-30 -mx-3 -mt-4 mb-4 flex items-center justify-between gap-2 rounded-b-2xl border-b border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
+        <div className="flex items-center gap-2 text-xs">
+          <Flame className="h-4 w-4 text-rose-400" />
+          <span className="font-medium text-slate-700 dark:text-slate-300">
+            {totalPending} критических
+          </span>
+          <span className="text-slate-400 dark:text-slate-500">|</span>
+          <span className="text-emerald-600 dark:text-emerald-400">{statusTotals.done} сделано</span>
+        </div>
+        <Button variant="ghost" size="sm" onClick={jumpToFirstCritical} className="h-7 text-xs">
+          <Zap className="mr-1 h-3 w-3" /> К первому
+        </Button>
+      </div>
+
+      {/* ---- Hero Banner (unchanged) ---- */}
       <section className="relative overflow-hidden rounded-3xl border border-slate-200/80 bg-[radial-gradient(circle_at_top_right,#0ea5e9_0%,#111827_42%,#020617_100%)] p-5 text-white shadow-lg dark:border-slate-700/80">
         <div className="absolute -right-16 top-0 h-44 w-44 rounded-full bg-cyan-400/25 blur-3xl" aria-hidden />
         <div className="absolute -bottom-16 left-8 h-32 w-32 rounded-full bg-amber-400/20 blur-3xl" aria-hidden />
@@ -393,7 +469,7 @@ export default function FranchizeStatusPage() {
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
-            <Timer className="h-4 w-4 text-emerald-300" /> Прогресс по всем задачам
+            <Timer className="h-4 w-4 text-emerald-300" /> Прогресс ({progressPercent}%)
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -401,7 +477,7 @@ export default function FranchizeStatusPage() {
             <div className="h-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-fuchsia-400" style={{ width: `${progressPercent}%` }} />
           </div>
           <p className="mt-2 text-sm text-slate-300">
-            Выполнено: <span className="font-semibold text-emerald-300">{progressPercent}%</span> ({statusTotals.done}/{tasks.length}) задач.
+            Выполнено: <span className="font-semibold text-emerald-300">{statusTotals.done}/{tasks.length}</span> задач. Осталось критических: <span className="font-semibold text-rose-400">{totalPending}</span>.
           </p>
         </CardContent>
       </Card>
@@ -432,167 +508,190 @@ export default function FranchizeStatusPage() {
         </CardContent>
       </Card>
 
-      {/* ---- Double-collapsible phase → capability → task ---- */}
-      <div className="space-y-3">
-        {[...phaseData.entries()]
-          .sort(([phaseA], [phaseB]) => {
-            const idxA = PHASE_ORDER.indexOf(phaseA as any);
-            const idxB = PHASE_ORDER.indexOf(phaseB as any);
-            if (idxA !== -1 && idxB !== -1) return idxA - idxB;
-            if (idxA !== -1) return -1;
-            if (idxB !== -1) return 1;
-            return phaseA.localeCompare(phaseB);
-          })
-          .map(([phase, { capabilities }]) => {
-            const phaseExpanded = expandedPhases.has(phase);
-            // Count tasks per phase for a small summary
-            const phaseTaskCount = capabilities.reduce((sum, cap) => sum + (capabilityTaskMap.get(cap)?.length || 0), 0);
-            return (
-              <Card key={phase} className="border-slate-800/70 bg-slate-950 text-slate-100">
-                {/* Phase header */}
-                <button
-                  type="button"
-                  onClick={() => togglePhase(phase)}
-                  className="flex w-full items-center justify-between p-4 text-left"
-                >
-                  <div className="flex items-center gap-3">
-                    {phaseExpanded ? (
-                      <ChevronDown className="h-5 w-5 text-cyan-300" />
-                    ) : (
-                      <ChevronRight className="h-5 w-5 text-cyan-300" />
-                    )}
-                    <h2 className="text-lg font-semibold uppercase tracking-wide">{phase}</h2>
-                    <Badge variant="outline" className="border-slate-600 text-slate-300">
-                      {capabilities.length} идеи · {phaseTaskCount} задач
-                    </Badge>
-                  </div>
-                </button>
-
-                {/* Collapsible content */}
-                {phaseExpanded && (
-                  <CardContent className="pt-0">
-                    <div className="space-y-3">
-                      {capabilities.map((cap) => {
-                        const capTasks = capabilityTaskMap.get(cap) || [];
-                        const idea = capabilityIdeaMap.get(cap);
-                        const capExpanded = expandedCapabilities.has(cap);
-
-                        // Determine the "worst" status across tasks
-                        const worstStatus = capTasks.length
-                          ? capTasks.reduce((worst, t) =>
-                              statusWeight(t.status) < statusWeight(worst) ? t.status : worst
-                            , capTasks[0].status)
-                          : "open";
-                        const worstMeta = STATUS_LABEL[worstStatus as TaskStatus] || STATUS_LABEL.open;
-
-                        return (
-                          <div
-                            key={cap}
-                            className="rounded-xl border border-slate-800 bg-slate-900/70"
-                          >
-                            {/* Capability row */}
-                            <button
-                              type="button"
-                              onClick={() => toggleCapability(cap)}
-                              className="flex w-full items-center justify-between p-3 text-left"
-                            >
-                              <div className="flex items-center gap-2">
-                                {capExpanded ? (
-                                  <ChevronDown className="h-4 w-4 text-amber-300" />
-                                ) : (
-                                  <ChevronRight className="h-4 w-4 text-amber-300" />
-                                )}
-                                <span className="text-sm font-medium">{idea?.idea || cap}</span>
-                              </div>
-                              <div className="flex items-center gap-2">
-                                <Badge className={worstMeta.className}>{worstMeta.label}</Badge>
-                                <span className="text-xs text-slate-400">{capTasks.length} tasks</span>
-                              </div>
-                            </button>
-
-                            {/* Capability detail + tasks */}
-                            {capExpanded && (
-                              <div className="border-t border-slate-800 px-3 pb-3 pt-2">
-                                {idea && (
-                                  <div className="mb-2 text-xs text-slate-400">
-                                    <p className="text-slate-300">{idea.note}</p>
-                                    <div className="mt-1 flex flex-wrap gap-1">
-                                      {idea.routes.map((r) => (
-                                        <code key={r} className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300">
-                                          {r}
-                                        </code>
-                                      ))}
-                                    </div>
-                                  </div>
-                                )}
-
-                                {/* Tasks list */}
-                                {capTasks.length === 0 ? (
-                                  <p className="flex items-center gap-1 text-xs text-amber-300">
-                                    <AlertCircle className="h-3.5 w-3.5" /> Нет задач – нужно создать.
-                                  </p>
-                                ) : (
-                                  <ul className="space-y-2">
-                                    {capTasks
-                                      .sort((a, b) => statusWeight(b.status) - statusWeight(a.status))
-                                      .map((task) => {
-                                        const taskExpanded = expandedTasks.has(task.id);
-                                        const taskMeta = STATUS_LABEL[task.status as TaskStatus] || STATUS_LABEL.open;
-                                        return (
-                                          <li key={task.id} className="rounded border border-slate-700/70 bg-slate-950/70 p-2">
-                                            <div className="flex items-center justify-between gap-2">
-                                              <button
-                                                type="button"
-                                                onClick={() => toggleTask(task.id)}
-                                                className="flex flex-1 items-center gap-1 text-left"
-                                              >
-                                                {taskExpanded ? (
-                                                  <ChevronDown className="h-3.5 w-3.5 text-slate-400" />
-                                                ) : (
-                                                  <ChevronRight className="h-3.5 w-3.5 text-slate-400" />
-                                                )}
-                                                <span className="text-sm text-slate-200">{task.title}</span>
-                                              </button>
-                                              <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
-                                            </div>
-                                            {/* Task details */}
-                                            {taskExpanded && (
-                                              <div className="mt-2 space-y-1 pl-5 text-xs text-slate-400">
-                                                <p>ID: {task.id}</p>
-                                                {task.todo_path && <p>todo_path: {task.todo_path}</p>}
-                                                <p>updated_at (UTC): {formatIso(task.updated_at)}</p>
-                                                {task.body && <p className="text-slate-300">{task.body}</p>}
-                                                {task.pr_url && (
-                                                  <a
-                                                    className="text-cyan-300 underline underline-offset-2"
-                                                    href={task.pr_url}
-                                                    target="_blank"
-                                                    rel="noreferrer"
-                                                  >
-                                                    PR: {task.pr_url}
-                                                  </a>
-                                                )}
-                                              </div>
-                                            )}
-                                          </li>
-                                        );
-                                      })}
-                                  </ul>
-                                )}
-                              </div>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </CardContent>
-                )}
-              </Card>
-            );
-          })}
+      {/* ---- Global expand/collapse ---- */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button variant="outline" size="sm" onClick={handleExpandAll} className="text-xs">
+          Развернуть всё
+        </Button>
+        <Button variant="outline" size="sm" onClick={handleCollapseAll} className="text-xs">
+          Свернуть всё
+        </Button>
+        <span className="ml-auto text-xs text-slate-400">
+          Фазы упорядочены по критичности
+        </span>
       </div>
 
-      {/* ---- Runtime checks (compact footer) ---- */}
+      {/* ---- Phase → Capability → Task tree ---- */}
+      <div className="space-y-3">
+        {phaseData.map(([phase, { capabilities }]) => {
+          const phaseExpanded = expandedPhases.has(phase);
+          // Count undone tasks for the phase badge
+          const phaseUndone = capabilities.reduce((sum, cap) => {
+            const tasks = capabilityTaskMap.get(cap) || [];
+            return sum + tasks.filter((t) => t.status !== "done").length;
+          }, 0);
+          const isPhaseFullyDone = phaseUndone === 0;
+          return (
+            <Card
+              key={phase}
+              id={`phase-${phase}`}
+              className={`border-slate-800/70 bg-slate-950 text-slate-100 scroll-mt-28 ${
+                isPhaseFullyDone ? "ring-1 ring-emerald-500/30" : ""
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => togglePhase(phase)}
+                className="flex w-full items-center justify-between p-3 sm:p-4 text-left"
+              >
+                <div className="flex items-center gap-2 sm:gap-3">
+                  {phaseExpanded ? (
+                    <ChevronDown className="h-5 w-5 text-cyan-300 flex-shrink-0" />
+                  ) : (
+                    <ChevronRight className="h-5 w-5 text-cyan-300 flex-shrink-0" />
+                  )}
+                  <h2 className="text-lg font-semibold uppercase tracking-wide">{phase}</h2>
+                  <div className="flex flex-wrap gap-1">
+                    <Badge variant="outline" className="border-slate-600 text-slate-300 text-xs">
+                      {capabilities.length} идеи
+                    </Badge>
+                    {phaseUndone > 0 && (
+                      <Badge className="bg-rose-500/20 text-rose-300 text-xs">
+                        {phaseUndone} не завершено
+                      </Badge>
+                    )}
+                    {isPhaseFullyDone && (
+                      <Badge className="bg-emerald-500/20 text-emerald-300 text-xs">
+                        Все сделано ✓
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+              </button>
+
+              {phaseExpanded && (
+                <CardContent className="pt-0">
+                  <div className="space-y-3">
+                    {capabilities.map((cap) => {
+                      const capTasks = capabilityTaskMap.get(cap) || [];
+                      const idea = capabilityIdeaMap.get(cap);
+                      const capExpanded = expandedCapabilities.has(cap);
+
+                      const doneCount = capTasks.filter((t) => t.status === "done").length;
+                      const allDone = capTasks.length > 0 && doneCount === capTasks.length;
+                      const worstStatus = capTasks.length
+                        ? capTasks.reduce((worst, t) =>
+                            statusUrgency(t.status) < statusUrgency(worst) ? t.status : worst
+                          , capTasks[0].status)
+                        : "open";
+                      const worstMeta = STATUS_LABEL[worstStatus as TaskStatus] || STATUS_LABEL.open;
+
+                      return (
+                        <div key={cap} className="rounded-xl border border-slate-800 bg-slate-900/70">
+                          <button
+                            type="button"
+                            onClick={() => toggleCapability(cap)}
+                            className="flex w-full items-center justify-between p-3 text-left"
+                          >
+                            <div className="flex items-center gap-2">
+                              {capExpanded ? (
+                                <ChevronDown className="h-4 w-4 text-amber-300 flex-shrink-0" />
+                              ) : (
+                                <ChevronRight className="h-4 w-4 text-amber-300 flex-shrink-0" />
+                              )}
+                              <span className="text-sm font-medium">{idea?.idea || cap}</span>
+                              {allDone && (
+                                <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+                              )}
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <Badge className={worstMeta.className}>{worstMeta.label}</Badge>
+                              <span className="text-xs text-slate-400">
+                                {doneCount}/{capTasks.length}
+                              </span>
+                            </div>
+                          </button>
+
+                          {capExpanded && (
+                            <div className="border-t border-slate-800 px-3 pb-3 pt-2">
+                              {idea && (
+                                <div className="mb-2 text-xs text-slate-400">
+                                  <p className="text-slate-300">{idea.note}</p>
+                                  <div className="mt-1 flex flex-wrap gap-1">
+                                    {idea.routes.map((r) => (
+                                      <code key={r} className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300">
+                                        {r}
+                                      </code>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+
+                              {capTasks.length === 0 ? (
+                                <p className="flex items-center gap-1 text-xs text-amber-300">
+                                  <AlertCircle className="h-3.5 w-3.5" /> Нет задач – нужно создать.
+                                </p>
+                              ) : (
+                                <ul className="space-y-2">
+                                  {capTasks
+                                    .sort((a, b) => statusUrgency(a.status) - statusUrgency(b.status))
+                                    .map((task) => {
+                                      const taskExpanded = expandedTasks.has(task.id);
+                                      const taskMeta = STATUS_LABEL[task.status as TaskStatus] || STATUS_LABEL.open;
+                                      return (
+                                        <li key={task.id} className="rounded border border-slate-700/70 bg-slate-950/70 p-2">
+                                          <button
+                                            type="button"
+                                            onClick={() => toggleTask(task.id)}
+                                            className="flex w-full items-center justify-between gap-2 text-left"
+                                          >
+                                            <div className="flex items-center gap-1">
+                                              {taskExpanded ? (
+                                                <ChevronDown className="h-3.5 w-3.5 text-slate-400 flex-shrink-0" />
+                                              ) : (
+                                                <ChevronRight className="h-3.5 w-3.5 text-slate-400 flex-shrink-0" />
+                                              )}
+                                              <span className="text-sm text-slate-200">{task.title}</span>
+                                            </div>
+                                            <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
+                                          </button>
+                                          {taskExpanded && (
+                                            <div className="mt-2 space-y-1 pl-5 text-xs text-slate-400">
+                                              <p>ID: {task.id}</p>
+                                              {task.todo_path && <p>todo_path: {task.todo_path}</p>}
+                                              <p>updated_at (UTC): {formatIso(task.updated_at)}</p>
+                                              {task.body && <p className="text-slate-300">{task.body}</p>}
+                                              {task.pr_url && (
+                                                <a
+                                                  className="text-cyan-300 underline underline-offset-2"
+                                                  href={task.pr_url}
+                                                  target="_blank"
+                                                  rel="noreferrer"
+                                                >
+                                                  PR: {task.pr_url}
+                                                </a>
+                                              )}
+                                            </div>
+                                          )}
+                                        </li>
+                                      );
+                                    })}
+                                </ul>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </CardContent>
+              )}
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* ---- Runtime checks ---- */}
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base sm:text-lg">

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -44,6 +44,16 @@ type FranchizeTask = {
   metadata?: any;
 };
 
+type IdeaRow = {
+  idea: string;
+  capability: string;
+  phase: string;
+  taskType: "R1 Contract" | "R2 Integration" | "R3 Ops UX" | "R4 Growth";
+  routes: string[];
+  note: string;
+  decompositionHint: string;
+};
+
 const STATUS_LABEL: Record<TaskStatusProp, { label: string; className: string }> = {
   open: { label: "Open", className: "bg-sky-500/15 text-sky-300 border-sky-400/30" },
   claimed: { label: "Claimed", className: "bg-indigo-500/15 text-indigo-300 border-indigo-400/30" },
@@ -55,18 +65,118 @@ const STATUS_LABEL: Record<TaskStatusProp, { label: string; className: string }>
   done: { label: "Done", className: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
 };
 
-const PHASE_COLORS: Record<string, string> = {
-  "launch-blocker": "border-l-red-500 text-red-300",
-  "launch-quality": "border-l-amber-500 text-amber-300",
-  "security": "border-l-orange-500 text-orange-300",
-  "performance": "border-l-cyan-500 text-cyan-300",
-  "polishing": "border-l-emerald-500 text-emerald-300",
-  "ux-fix": "border-l-pink-500 text-pink-300",
-  "seo": "border-l-blue-500 text-blue-300",
-  "code-quality": "border-l-slate-500 text-slate-300",
-  "tech-debt": "border-l-gray-500 text-gray-300",
-  "post-launch": "border-l-purple-500 text-purple-300",
-};
+const PHASE_ORDER = ["Апрель", "Май", "Июнь", "Лето", "2027"] as const;
+
+const IDEA_MAP: IdeaRow[] = [
+  {
+    idea: "Инфо-лендинг + адреса/услуги (VIP Bike)",
+    capability: "franchize.info",
+    phase: "Апрель",
+    taskType: "R3 Ops UX",
+    routes: ["/vipbikerental", "/franchize/vip-bike/*"],
+    note: "Лендинг + брендинг админка для акций и контента.",
+    decompositionHint: "Разбить на дочерние задачи: контент-блоки, CTA и sync с брендинг-админкой.",
+  },
+  {
+    idea: "Аренда: каталог, доступность, календарь и договор",
+    capability: "franchize.rental",
+    phase: "Апрель",
+    taskType: "R1 Contract",
+    routes: ["/franchize/vip-bike/market", "/rent-bike", "/markdown-doc"],
+    note: "VIN через админку + финализация MD шаблона договора.",
+    decompositionHint: "Спаунить subtasks: availability sync, VIN CRUD, markdown-doc attach к rental flow.",
+  },
+  {
+    idea: "Продажа новых/БУ + трейд-ин (отложенный блок)",
+    capability: "franchize.sales",
+    phase: "Май",
+    taskType: "R4 Growth",
+    routes: ["/franchize/vip-bike/market"],
+    note: "Через specs-флаги “в продаже / трейд-ин”.",
+    decompositionHint: "Отдельные подзадачи на specs flags, фильтры витрины и честные обзоры.",
+  },
+  {
+    idea: "Сервис + эндуро-направление (crew: vip-cross)",
+    capability: "franchize.integration",
+    phase: "Июнь",
+    taskType: "R2 Integration",
+    routes: ["/docs/sql/*.sql", "/franchize/vip-cross/*"],
+    note: "Отдельный crew-слой и SQL-гидрация сервисных потоков.",
+    decompositionHint: "Создать seed по аналогии с vip-bike: docs/sql/vip-cross-franchize-hydration.sql.",
+  },
+  {
+    idea: "Инфоблок для новичков и safety-подсказки",
+    capability: "franchize.onboarding",
+    phase: "Май",
+    taskType: "R3 Ops UX",
+    routes: ["/start (@oneBikePlsBot)", "/franchize/vip-bike/*"],
+    note: "Триггер предупреждений для новых пользователей.",
+    decompositionHint: "Подзадачи на сегментацию новичков, тексты warning и ссылку на FAQ.",
+  },
+  {
+    idea: "Мотомероприятия + партнёры + акции",
+    capability: "franchize.growth",
+    phase: "Май",
+    taskType: "R4 Growth",
+    routes: ["/franchize/vip-bike/*", "брендинг-админка"],
+    note: "Управление через акционные блоки и партнёрские ссылки.",
+    decompositionHint: "Отдельные задачи для партнёров, акций и ивент-ленты.",
+  },
+  {
+    idea: "Map Riders / ивенты / челленджи / захват районов",
+    capability: "franchize.gamification",
+    phase: "Лето",
+    taskType: "R4 Growth",
+    routes: ["/franchize/vip-bike/map-riders", "/admin/map-calibrator"],
+    note: "Геймификация + карты + weekly challenge-ритм.",
+    decompositionHint: "Сначала telemetry contract, потом challenges и achievements.",
+  },
+  {
+    idea: "KPI и воронка статуса франшизы для оператора",
+    capability: "franchize.kpi",
+    phase: "Апрель",
+    taskType: "R3 Ops UX",
+    routes: ["/supaplan", "/nexus", "/supaplan/franchize"],
+    note: "Понятная human-first витрина статуса и прогресса.",
+    decompositionHint: "Детализировать KPI в child tasks: lead->booking, conversion и SLA.",
+  },
+  {
+    idea: "Telegram-first контур и уведомления",
+    capability: "franchize.telegram",
+    phase: "Апрель",
+    taskType: "R2 Integration",
+    routes: ["@oneBikePlsBot", "/api/codex-bridge/callback"],
+    note: "Проверка callback parity + операторские уведомления.",
+    decompositionHint: "Выделить подзадачи на callback schema, retry, fallback telegram post.",
+  },
+  {
+    idea: "Аналитика и разметка SupaPlan-задач по идеям",
+    capability: "franchize.analytics",
+    phase: "Апрель",
+    taskType: "R1 Contract",
+    routes: ["/supaplan/franchize", "/nexus"],
+    note: "Матчинг «идея ↔ capability ↔ task/status».",
+    decompositionHint: "Регулярно спаунить детализацию эпиков при старте реализации.",
+  },
+  {
+    idea: "UI/UX-дизайн для франшизы",
+    capability: "franchize.ui.ux",
+    phase: "Апрель",
+    taskType: "R3 Ops UX",
+    routes: ["/franchize/vip-bike/*"],
+    note: "Система дизайн-компонентов и UX-флоу для мобильных и веб-версий.",
+    decompositionHint: "Создать дизайн-систему и сверстать ключевые экраны.",
+  },
+  {
+    idea: "Бэкенд Supabase-инфраструктура франшизы",
+    capability: "franchize.backend.supabase",
+    phase: "Апрель",
+    taskType: "R1 Contract",
+    routes: ["/supabase", "/sql"],
+    note: "Настройка RLS, миграции, функции и API-роуты.",
+    decompositionHint: "Подготовить миграции схем данных, ролевую модель и хранимые процедуры.",
+  },
+];
 
 function statusUrgency(status: string): number {
   switch (status) {
@@ -88,17 +198,6 @@ function formatIso(iso: string): string {
     minute: "2-digit",
     timeZone: "UTC",
   });
-}
-
-function extractPhase(task: FranchizeTask): string {
-  try {
-    const meta = task.metadata;
-    if (!meta) return "no-phase";
-    const parsed = typeof meta === "string" ? JSON.parse(meta) : meta;
-    return parsed.phase || "no-phase";
-  } catch {
-    return "no-phase";
-  }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -158,42 +257,37 @@ export default function FranchizeStatusPage() {
   const totalPending = tasks.length - statusTotals.done;
   const progressPercent = tasks.length ? Math.round((statusTotals.done / tasks.length) * 100) : 0;
 
-  // Group tasks by phase (from metadata) then by capability
+  // Group tasks by IDEA_MAP phases, then by capability (using IDEA_MAP for display)
   const phaseData = useMemo(() => {
-    const phaseMap = new Map<string, Map<string, FranchizeTask[]>>();
+    const map = new Map<string, Map<string, FranchizeTask[]>>();
+    // Initialize phases from PHASE_ORDER
+    PHASE_ORDER.forEach((p) => map.set(p, new Map()));
+
+    // Add tasks to their IDEA_MAP phase (fallback to metadata.phase if not found)
+    const ideaByCap = new Map(IDEA_MAP.map((i) => [i.capability, i]));
     tasks.forEach((task) => {
-      const phase = extractPhase(task);
       const cap = task.capability || "unknown";
-      if (!phaseMap.has(phase)) phaseMap.set(phase, new Map());
-      const capMap = phaseMap.get(phase)!;
+      const idea = ideaByCap.get(cap);
+      const phase = idea?.phase ?? "2027"; // default to last phase if unknown
+      if (!map.has(phase)) map.set(phase, new Map());
+      const capMap = map.get(phase)!;
       if (!capMap.has(cap)) capMap.set(cap, []);
       capMap.get(cap)!.push(task);
     });
 
-    // Sort phases: launch-blocker first, then by total undone tasks
-    const order = [
-      "launch-blocker",
-      "launch-quality",
-      "security",
-      "performance",
-      "polishing",
-      "ux-fix",
-      "seo",
-      "code-quality",
-      "tech-debt",
-      "post-launch",
-      "no-phase",
-    ];
-    const sortedPhases = [...phaseMap.entries()].sort((a, b) => {
-      const idxA = order.indexOf(a[0]) === -1 ? 999 : order.indexOf(a[0]);
-      const idxB = order.indexOf(b[0]) === -1 ? 999 : order.indexOf(b[0]);
-      if (idxA !== idxB) return idxA - idxB;
-      // then by undone task count
-      const undoneA = [...a[1].values()].flat().filter((t) => t.status !== "done").length;
-      const undoneB = [...b[1].values()].flat().filter((t) => t.status !== "done").length;
-      return undoneB - undoneA;
+    // Remove empty phases (with no tasks) for cleanliness, but keep order
+    const orderedPhases: [string, Map<string, FranchizeTask[]>][] = [];
+    PHASE_ORDER.forEach((p) => {
+      if (map.get(p)?.size) orderedPhases.push([p, map.get(p)!]);
     });
-    return sortedPhases;
+    // Append any extra phases not in PHASE_ORDER (e.g., "2027") at end
+    map.forEach((capMap, phase) => {
+      if (!PHASE_ORDER.includes(phase as any) && capMap.size) {
+        orderedPhases.push([phase, capMap]);
+      }
+    });
+
+    return orderedPhases;
   }, [tasks]);
 
   const togglePhase = useCallback((phase: string) => {
@@ -276,7 +370,7 @@ export default function FranchizeStatusPage() {
         </Button>
       </div>
 
-      {/* ---- Hero Section (overhauled) ---- */}
+      {/* ---- Hero ---- */}
       <section className="relative overflow-hidden rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-6 text-white shadow-2xl">
         <div className="absolute -right-16 -top-16 h-64 w-64 rounded-full bg-cyan-500/20 blur-3xl" />
         <div className="absolute -bottom-12 -left-12 h-48 w-48 rounded-full bg-amber-500/20 blur-3xl" />
@@ -362,7 +456,7 @@ export default function FranchizeStatusPage() {
         </CardContent>
       </Card>
 
-      {/* 🔥 Top-5 priority */ }
+      {/* 🔥 Top-5 priority */}
       <section>
         <Button
           variant="outline"
@@ -379,7 +473,7 @@ export default function FranchizeStatusPage() {
           ) : (
             <>
               <Sparkles className="h-4 w-4" />
-              ТОП-5 приоритетных задач (AI‑ранжирование)
+              ТОП-5 приоритетных задач
             </>
           )}
         </Button>
@@ -391,12 +485,10 @@ export default function FranchizeStatusPage() {
                 <CardTitle className="flex items-center gap-2 text-lg text-amber-300">
                   <Flame className="h-5 w-5" /> ТОП-5 критических задач
                 </CardTitle>
-                <Button variant="ghost" size="sm" onClick={() => setShowPriority(false)} className="text-slate-400 hover:text-slate-200">
-                  Скрыть
-                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setShowPriority(false)} className="text-slate-400 hover:text-slate-200">Скрыть</Button>
               </div>
               <CardDescription className="text-slate-400">
-                Формула: статус × фаза × важность способности × приоритет × свежесть + быстрые победы.
+                Формула: статус × фаза × важность способности × приоритет × свежесть.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid gap-2 sm:grid-cols-2">
@@ -410,24 +502,17 @@ export default function FranchizeStatusPage() {
                         <p className="font-semibold text-slate-100">{pt.title}</p>
                         <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
                           <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
-                          <Badge variant="outline" className="border-slate-600 text-slate-400">
-                            {pt.capability}
-                          </Badge>
+                          <Badge variant="outline" className="border-slate-600 text-slate-400">{pt.capability}</Badge>
                         </div>
                       </div>
-                      <span className="rounded-full bg-amber-400/20 px-2 py-0.5 text-xs font-mono font-bold text-amber-300">
-                        {pt.score}
-                      </span>
+                      <span className="rounded-full bg-amber-400/20 px-2 py-0.5 text-xs font-mono font-bold text-amber-300">{pt.score}</span>
                     </div>
                     <p className="mt-2 text-xs text-slate-400">{pt.reasoning}</p>
                     {fullTask?.todo_path && (
                       <p className="mt-1 text-xs text-slate-500">todo_path: {fullTask.todo_path}</p>
                     )}
                     <div className="mt-2">
-                      <Link
-                        href={`/supaplan?task=${pt.id}`}
-                        className="inline-flex items-center gap-1 text-xs text-cyan-300 underline underline-offset-2"
-                      >
+                      <Link href={`/supaplan?task=${pt.id}`} className="inline-flex items-center gap-1 text-xs text-cyan-300 underline underline-offset-2">
                         Перейти к задаче →
                       </Link>
                     </div>
@@ -447,6 +532,7 @@ export default function FranchizeStatusPage() {
           const undone = phaseTasks.filter((t) => t.status !== "done").length;
           const total = phaseTasks.length;
           const fullyDone = total > 0 && undone === 0;
+          const ideaForPhase = IDEA_MAP.find((i) => i.phase === phase);
           return (
             <Card
               key={phase}
@@ -501,6 +587,7 @@ export default function FranchizeStatusPage() {
                           , capTasks[0].status)
                         : "open";
                       const worstMeta = STATUS_LABEL[worstStatus as TaskStatusProp] || STATUS_LABEL.open;
+                      const idea = IDEA_MAP.find((i) => i.capability === cap);
                       return (
                         <div key={cap} className="rounded-xl border border-slate-800 bg-slate-900/70">
                           <button
@@ -514,19 +601,30 @@ export default function FranchizeStatusPage() {
                               ) : (
                                 <ChevronRight className="h-4 w-4 text-amber-300 flex-shrink-0" />
                               )}
-                              <span className="text-sm font-medium">{cap}</span>
+                              <span className="text-sm font-medium">{idea?.idea || cap}</span>
                               {allDone && <CheckCircle2 className="h-4 w-4 text-emerald-400" />}
                             </div>
                             <div className="flex items-center gap-2">
                               <Badge className={worstMeta.className}>{worstMeta.label}</Badge>
-                              <span className="text-xs text-slate-400">
-                                {doneCount}/{capTasks.length}
-                              </span>
+                              <span className="text-xs text-slate-400">{doneCount}/{capTasks.length}</span>
                             </div>
                           </button>
 
                           {capExpanded && (
                             <div className="border-t border-slate-800 px-3 pb-3 pt-2">
+                              {idea && (
+                                <div className="mb-2 text-xs text-slate-400">
+                                  <p className="text-slate-300">{idea.note}</p>
+                                  <div className="mt-1 flex flex-wrap gap-1">
+                                    {idea.routes.map((r) => (
+                                      <code key={r} className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300">
+                                        {r}
+                                      </code>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+
                               {capTasks.length === 0 ? (
                                 <p className="text-xs text-amber-300">Нет задач</p>
                               ) : (
@@ -586,7 +684,7 @@ export default function FranchizeStatusPage() {
         })}
       </div>
 
-      {/* ---- Legend (overhauled) ---- */}
+      {/* ---- Legend ---- */}
       <div className="mt-8 border-t border-slate-800 pt-4">
         <button
           type="button"
@@ -600,38 +698,23 @@ export default function FranchizeStatusPage() {
         {legendOpen && (
           <div className="mt-3 space-y-4 text-sm text-slate-300">
             <div>
-              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                Приоритеты (scoring)
-              </h4>
-              <p className="text-slate-400">
-                critical ×2.5, high ×2.0, medium ×1.5, low ×1.0. P0/p1/p2 в теле задачи действуют аналогично.
-              </p>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">Приоритеты (scoring)</h4>
+              <p className="text-slate-400">critical ×2.5, high ×2.0, medium ×1.5, low ×1.0. P0/p1/p2 в теле задачи действуют аналогично.</p>
             </div>
             <div>
-              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                Фазы и их множители
-              </h4>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">Фазы и их множители</h4>
               <div className="flex flex-wrap gap-2">
-                {Object.entries(PHASE_COLORS).map(([p, cls]) => (
-                  <Badge key={p} className={`border-l-2 bg-slate-800/50 ${cls}`}>
-                    {p}
-                  </Badge>
+                {["launch-blocker", "launch-quality", "security", "performance", "polishing", "ux-fix", "seo", "code-quality", "tech-debt", "post-launch"].map(p => (
+                  <Badge key={p} className="border-l-2 bg-slate-800/50 capitalize">{p.replace("-", " ")}</Badge>
                 ))}
               </div>
             </div>
             <div>
-              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                Типы задач (capabilities)
-              </h4>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">Типы задач (capabilities)</h4>
               <div className="flex flex-wrap gap-2">
-                {[...new Set(tasks.map((t) => t.capability))]
-                  .filter(Boolean)
-                  .sort()
-                  .map((cap) => (
-                    <Badge key={cap} variant="outline" className="text-xs">
-                      {cap}
-                    </Badge>
-                  ))}
+                {[...new Set(tasks.map((t) => t.capability))].filter(Boolean).sort().map((cap) => (
+                  <Badge key={cap} variant="outline" className="text-xs">{cap}</Badge>
+                ))}
               </div>
             </div>
           </div>

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -108,6 +108,7 @@ const STATUS_CARD_CONFIG: Record<TaskStatusProp, {
 
 const PHASE_ORDER = ["Апрель", "Май", "Июнь", "Лето", "2027"] as const;
 
+// ----- IDEA_MAP (полный, без изменений) -----
 const IDEA_MAP: IdeaRow[] = [
   {
     idea: "Инфо-лендинг + адреса/услуги (VIP Bike)",
@@ -313,6 +314,7 @@ export default function FranchizeStatusPage() {
   const [isPriorityLoading, startPriorityTransition] = useTransition();
   const [copied, setCopied] = useState(false);
   const [copyAllCelebration, setCopyAllCelebration] = useState(false);
+  const [heroCelebrate, setHeroCelebrate] = useState(false);
 
   // 1. Fetch all franchize tasks on mount
   useEffect(() => {
@@ -446,7 +448,15 @@ export default function FranchizeStatusPage() {
     const fullText = intro + texts.join("\n\n");
     await navigator.clipboard.writeText(fullText);
     setCopyAllCelebration(true);
+    setHeroCelebrate(true);
     setTimeout(() => setCopyAllCelebration(false), 1500);
+    // Прокрутка к кнопке Codex Cloud через небольшую задержку
+    setTimeout(() => {
+      document.getElementById("codex-deploy-button")?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }, 200);
   }, [priorityTasks, tasks]);
 
   // ----- Render states -----
@@ -474,14 +484,21 @@ export default function FranchizeStatusPage() {
       {/* ==================================================================== */}
       {/*  HERO                                                                 */}
       {/* ==================================================================== */}
-      <section className="relative rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950/90 to-slate-900 p-5 text-white shadow-2xl sm:p-6">
+      <section
+        className={`relative rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950/90 to-slate-900 p-5 text-white shadow-2xl transition-all duration-500 sm:p-6 ${
+          heroCelebrate ? "ring-2 ring-amber-400/50" : ""
+        }`}
+      >
+        {/* Glows */}
         <div className="pointer-events-none absolute -right-8 -top-8 h-52 w-52 rounded-full bg-cyan-500/20 blur-3xl" />
         <div className="pointer-events-none absolute -bottom-8 -left-8 h-44 w-44 rounded-full bg-purple-500/15 blur-3xl" />
 
         <div className="relative z-10 grid gap-6 md:grid-cols-3">
           <div className="md:col-span-2">
             <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-cyan-300">
-              <Badge className="border-cyan-400/40 bg-cyan-400/20 text-cyan-100">ПУЛЬТ УПРАВЛЕНИЯ ФРАНШИЗОЙ</Badge>
+              <Badge className="border-cyan-400/40 bg-cyan-400/20 text-cyan-100">
+                {heroCelebrate ? "🚀 ЗАДАЧИ ОТПРАВЛЕНЫ" : "ПУЛЬТ УПРАВЛЕНИЯ ФРАНШИЗОЙ"}
+              </Badge>
               <span className="text-slate-400">vip‑bike crew</span>
             </div>
 
@@ -490,11 +507,15 @@ export default function FranchizeStatusPage() {
                 SupaPlan • Франшиза
               </span>
               <br />
-              <span className="text-2xl text-slate-100 sm:text-3xl">Живая панель состояния</span>
+              <span className="text-2xl text-slate-100 sm:text-3xl">
+                {heroCelebrate ? "Отправь в Codex!" : "Живая панель состояния"}
+              </span>
             </h1>
 
             <p className="mt-3 max-w-xl text-sm text-slate-300 sm:text-base">
-              Мгновенный срез по всем эпикам. Приоритеты, фазы, критические задачи — всё под рукой.
+              {heroCelebrate
+                ? "Топ‑5 скопированы. Нажми кнопку ниже, чтобы мгновенно деплоить в Codex Cloud."
+                : "Мгновенный срез по всем эпикам. Приоритеты, фазы, критические задачи — всё под рукой."}
             </p>
 
             <div className="mt-4 flex flex-wrap gap-2">
@@ -506,15 +527,21 @@ export default function FranchizeStatusPage() {
               </Link>
               <div className="group relative inline-flex">
                 <a
+                  id="codex-deploy-button"
                   href="https://chatgpt.com/codex/cloud"
                   target="_blank"
                   rel="noreferrer"
-                  className="inline-flex items-center gap-1 rounded-lg border border-purple-400/30 bg-purple-400/10 px-3 py-2 text-xs text-purple-200 transition hover:bg-purple-400/20"
+                  className={`inline-flex items-center gap-1 rounded-lg border px-3 py-2 text-xs transition hover:scale-105 ${
+                    heroCelebrate
+                      ? "animate-pulse border-amber-400/60 bg-amber-400/20 text-amber-200 shadow-[0_0_20px_#f59e0b]"
+                      : "border-purple-400/30 bg-purple-400/10 text-purple-200 hover:bg-purple-400/20"
+                  }`}
                 >
-                  <ExternalLink className="h-4 w-4" /> Codex Cloud
+                  <ExternalLink className="h-4 w-4" />
+                  {heroCelebrate ? "🚀 Деплой в Codex" : "Codex Cloud"}
                 </a>
                 <span className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-[10px] text-white opacity-0 transition-opacity group-hover:opacity-100">
-                  🚀 Деплой в Codex
+                  {heroCelebrate ? "Погнали, агент!" : "Deploy to Codex"}
                 </span>
               </div>
             </div>

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -12,8 +12,6 @@ import {
   Clock3,
   Flame,
   HelpCircle,
-  Layers3,
-  Milestone,
   Rocket,
   Sparkles,
   Timer,
@@ -31,43 +29,43 @@ import { getTopPriorityTasks, PriorityTask } from "../actions";
 /*  Types & constants                                                         */
 /* -------------------------------------------------------------------------- */
 
-type TaskStatus = "open" | "claimed" | "running" | "ready_for_pr" | "done";
+type TaskStatusProp = "open" | "claimed" | "running" | "ready_for_pr" | "done";
 
 type FranchizeTask = {
   id: string;
   title: string;
   body: string | null;
   capability: string | null;
-  status: TaskStatus | string;
+  status: TaskStatusProp | string;
   todo_path: string | null;
   created_at: string;
   updated_at: string;
   pr_url: string | null;
+  metadata?: any;
 };
 
-type IdeaRow = {
-  idea: string;
-  capability: string;
-  phase: string;
-  taskType: "R1 Contract" | "R2 Integration" | "R3 Ops UX" | "R4 Growth";
-  routes: string[];
-  note: string;
-  decompositionHint: string;
-};
-
-const STATUS_LABEL: Record<TaskStatus, { label: string; className: string }> = {
+const STATUS_LABEL: Record<TaskStatusProp, { label: string; className: string }> = {
   open: { label: "Open", className: "bg-sky-500/15 text-sky-300 border-sky-400/30" },
   claimed: { label: "Claimed", className: "bg-indigo-500/15 text-indigo-300 border-indigo-400/30" },
   running: { label: "Running", className: "bg-amber-500/15 text-amber-300 border-amber-400/30" },
-  ready_for_pr: { label: "Ready for PR", className: "bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-400/30" },
+  ready_for_pr: {
+    label: "Ready for PR",
+    className: "bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-400/30",
+  },
   done: { label: "Done", className: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
 };
 
-const TASK_TYPE_DESCRIPTIONS: Record<string, string> = {
-  "R1 Contract": "Блокирующий слой: данные, схемы, совместимость",
-  "R2 Integration": "Telegram/Bridge/API, контур callback",
-  "R3 Ops UX": "Операторская витрина, админ-флоу, CTA",
-  "R4 Growth": "Маркетплейс, комьюнити, геймификация",
+const PHASE_COLORS: Record<string, string> = {
+  "launch-blocker": "border-l-red-500 text-red-300",
+  "launch-quality": "border-l-amber-500 text-amber-300",
+  "security": "border-l-orange-500 text-orange-300",
+  "performance": "border-l-cyan-500 text-cyan-300",
+  "polishing": "border-l-emerald-500 text-emerald-300",
+  "ux-fix": "border-l-pink-500 text-pink-300",
+  "seo": "border-l-blue-500 text-blue-300",
+  "code-quality": "border-l-slate-500 text-slate-300",
+  "tech-debt": "border-l-gray-500 text-gray-300",
+  "post-launch": "border-l-purple-500 text-purple-300",
 };
 
 function statusUrgency(status: string): number {
@@ -92,118 +90,16 @@ function formatIso(iso: string): string {
   });
 }
 
-const PHASE_ORDER = ["Апрель", "Май", "Июнь", "Лето", "2027"] as const;
-
-const IDEA_MAP: IdeaRow[] = [
-  {
-    idea: "Инфо-лендинг + адреса/услуги (VIP Bike)",
-    capability: "franchize.info",
-    phase: "Апрель",
-    taskType: "R3 Ops UX",
-    routes: ["/vipbikerental", "/franchize/vip-bike/*"],
-    note: "Лендинг + брендинг админка для акций и контента.",
-    decompositionHint: "Разбить на дочерние задачи: контент-блоки, CTA и sync с брендинг-админкой.",
-  },
-  {
-    idea: "Аренда: каталог, доступность, календарь и договор",
-    capability: "franchize.rental",
-    phase: "Апрель",
-    taskType: "R1 Contract",
-    routes: ["/franchize/vip-bike/market", "/rent-bike", "/markdown-doc"],
-    note: "VIN через админку + финализация MD шаблона договора.",
-    decompositionHint: "Спаунить subtasks: availability sync, VIN CRUD, markdown-doc attach к rental flow.",
-  },
-  {
-    idea: "Продажа новых/БУ + трейд-ин (отложенный блок)",
-    capability: "franchize.sales",
-    phase: "Май",
-    taskType: "R4 Growth",
-    routes: ["/franchize/vip-bike/market"],
-    note: "Через specs-флаги “в продаже / трейд-ин”.",
-    decompositionHint: "Отдельные подзадачи на specs flags, фильтры витрины и честные обзоры.",
-  },
-  {
-    idea: "Сервис + эндуро-направление (crew: vip-cross)",
-    capability: "franchize.integration",
-    phase: "Июнь",
-    taskType: "R2 Integration",
-    routes: ["/docs/sql/*.sql", "/franchize/vip-cross/*"],
-    note: "Отдельный crew-слой и SQL-гидрация сервисных потоков.",
-    decompositionHint: "Создать seed по аналогии с vip-bike: docs/sql/vip-cross-franchize-hydration.sql.",
-  },
-  {
-    idea: "Инфоблок для новичков и safety-подсказки",
-    capability: "franchize.onboarding",
-    phase: "Май",
-    taskType: "R3 Ops UX",
-    routes: ["/start (@oneBikePlsBot)", "/franchize/vip-bike/*"],
-    note: "Триггер предупреждений для новых пользователей.",
-    decompositionHint: "Подзадачи на сегментацию новичков, тексты warning и ссылку на FAQ.",
-  },
-  {
-    idea: "Мотомероприятия + партнёры + акции",
-    capability: "franchize.growth",
-    phase: "Май",
-    taskType: "R4 Growth",
-    routes: ["/franchize/vip-bike/*", "брендинг-админка"],
-    note: "Управление через акционные блоки и партнёрские ссылки.",
-    decompositionHint: "Отдельные задачи для партнёров, акций и ивент-ленты.",
-  },
-  {
-    idea: "Map Riders / ивенты / челленджи / захват районов",
-    capability: "franchize.gamification",
-    phase: "Лето",
-    taskType: "R4 Growth",
-    routes: ["/franchize/vip-bike/map-riders", "/admin/map-calibrator"],
-    note: "Геймификация + карты + weekly challenge-ритм.",
-    decompositionHint: "Сначала telemetry contract, потом challenges и achievements.",
-  },
-  {
-    idea: "KPI и воронка статуса франшизы для оператора",
-    capability: "franchize.kpi",
-    phase: "Апрель",
-    taskType: "R3 Ops UX",
-    routes: ["/supaplan", "/nexus", "/supaplan/franchize"],
-    note: "Понятная human-first витрина статуса и прогресса.",
-    decompositionHint: "Детализировать KPI в child tasks: lead->booking, conversion и SLA.",
-  },
-  {
-    idea: "Telegram-first контур и уведомления",
-    capability: "franchize.telegram",
-    phase: "Апрель",
-    taskType: "R2 Integration",
-    routes: ["@oneBikePlsBot", "/api/codex-bridge/callback"],
-    note: "Проверка callback parity + операторские уведомления.",
-    decompositionHint: "Выделить подзадачи на callback schema, retry, fallback telegram post.",
-  },
-  {
-    idea: "Аналитика и разметка SupaPlan-задач по идеям",
-    capability: "franchize.analytics",
-    phase: "Апрель",
-    taskType: "R1 Contract",
-    routes: ["/supaplan/franchize", "/nexus"],
-    note: "Матчинг «идея ↔ capability ↔ task/status».",
-    decompositionHint: "Регулярно спаунить детализацию эпиков при старте реализации.",
-  },
-  {
-    idea: "UI/UX-дизайн для франшизы",
-    capability: "franchize.ui.ux",
-    phase: "Апрель",
-    taskType: "R3 Ops UX",
-    routes: ["/franchize/vip-bike/*"],
-    note: "Система дизайн-компонентов и UX-флоу для мобильных и веб-версий.",
-    decompositionHint: "Создать дизайн-систему и сверстать ключевые экраны.",
-  },
-  {
-    idea: "Бэкенд Supabase-инфраструктура франшизы",
-    capability: "franchize.backend.supabase",
-    phase: "Апрель",
-    taskType: "R1 Contract",
-    routes: ["/supabase", "/sql"],
-    note: "Настройка RLS, миграции, функции и API-роуты.",
-    decompositionHint: "Подготовить миграции схем данных, ролевую модель и хранимые процедуры.",
-  },
-];
+function extractPhase(task: FranchizeTask): string {
+  try {
+    const meta = task.metadata;
+    if (!meta) return "no-phase";
+    const parsed = typeof meta === "string" ? JSON.parse(meta) : meta;
+    return parsed.phase || "no-phase";
+  } catch {
+    return "no-phase";
+  }
+}
 
 /* -------------------------------------------------------------------------- */
 /*  Page Component                                                            */
@@ -214,21 +110,16 @@ export default function FranchizeStatusPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Tree expansion state
   const [expandedPhases, setExpandedPhases] = useState<Set<string>>(new Set());
   const [expandedCapabilities, setExpandedCapabilities] = useState<Set<string>>(new Set());
   const [expandedTasks, setExpandedTasks] = useState<Set<string>>(new Set());
-  const [allExpanded, setAllExpanded] = useState(false);
 
-  // Legend visibility
   const [legendOpen, setLegendOpen] = useState(false);
 
-  // Priority tasks state
   const [priorityTasks, setPriorityTasks] = useState<PriorityTask[]>([]);
   const [isPriorityLoading, startPriorityTransition] = useTransition();
   const [showPriority, setShowPriority] = useState(false);
 
-  // Fetch all franchize tasks on mount
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
@@ -236,12 +127,15 @@ export default function FranchizeStatusPage() {
       try {
         const { data, error } = await supabaseAnon
           .from("supaplan_tasks")
-          .select("id,title,body,capability,status,todo_path,created_at,updated_at,pr_url")
-          .or("capability.like.franchize.%,capability.eq.greenbox.franchize")
+          .select("id,title,body,capability,status,todo_path,created_at,updated_at,pr_url,metadata")
+          .or("capability.like.franchize.%")
           .order("updated_at", { ascending: false });
 
         if (error) throw error;
-        setTasks((data as FranchizeTask[]) || []);
+        const filtered = (data as FranchizeTask[]).filter(
+          (t) => t.capability && !t.capability.startsWith("greenbox.")
+        );
+        setTasks(filtered);
       } catch (err: any) {
         setError(err.message || "Не удалось загрузить задачи");
       } finally {
@@ -251,93 +145,57 @@ export default function FranchizeStatusPage() {
     fetchData();
   }, []);
 
-  // ---- Derived data ----
-  const capabilityTaskMap = useMemo(() => {
-    const map = new Map<string, FranchizeTask[]>();
-    tasks.forEach((task) => {
-      if (!task.capability) return;
-      const prev = map.get(task.capability) || [];
-      prev.push(task);
-      map.set(task.capability, prev);
-    });
-    return map;
-  }, [tasks]);
-
+  // Derived stats
   const statusTotals = useMemo(() => {
-    const totals: Record<TaskStatus, number> = { open: 0, claimed: 0, running: 0, ready_for_pr: 0, done: 0 };
-    tasks.forEach((task) => {
-      const key = task.status as TaskStatus;
+    const totals: Record<TaskStatusProp, number> = { open: 0, claimed: 0, running: 0, ready_for_pr: 0, done: 0 };
+    tasks.forEach((t) => {
+      const key = t.status as TaskStatusProp;
       if (key in totals) totals[key] += 1;
     });
     return totals;
   }, [tasks]);
 
-  const progressPercent = useMemo(() => {
-    return tasks.length ? Math.round((statusTotals.done / tasks.length) * 100) : 0;
-  }, [tasks, statusTotals.done]);
-
   const totalPending = tasks.length - statusTotals.done;
+  const progressPercent = tasks.length ? Math.round((statusTotals.done / tasks.length) * 100) : 0;
 
-  const capabilityIdeaMap = useMemo(() => {
-    const map = new Map<string, IdeaRow>();
-    IDEA_MAP.forEach((row) => map.set(row.capability, row));
-    return map;
-  }, []);
-
-  const getPhaseForCapability = (cap: string): string => {
-    return capabilityIdeaMap.get(cap)?.phase ?? "Uncategorised";
-  };
-
-  // Build phase data with intelligent sorting
+  // Group tasks by phase (from metadata) then by capability
   const phaseData = useMemo(() => {
-    const phaseMap = new Map<string, { capabilities: string[] }>();
-    PHASE_ORDER.forEach((phase) => phaseMap.set(phase, { capabilities: [] }));
-
-    const allCaps = new Set<string>();
-    capabilityTaskMap.forEach((_, cap) => allCaps.add(cap));
-    capabilityIdeaMap.forEach((_, cap) => allCaps.add(cap));
-
-    allCaps.forEach((cap) => {
-      const phase = getPhaseForCapability(cap);
-      if (!phaseMap.has(phase)) {
-        phaseMap.set(phase, { capabilities: [] });
-      }
-      phaseMap.get(phase)!.capabilities.push(cap);
+    const phaseMap = new Map<string, Map<string, FranchizeTask[]>>();
+    tasks.forEach((task) => {
+      const phase = extractPhase(task);
+      const cap = task.capability || "unknown";
+      if (!phaseMap.has(phase)) phaseMap.set(phase, new Map());
+      const capMap = phaseMap.get(phase)!;
+      if (!capMap.has(cap)) capMap.set(cap, []);
+      capMap.get(cap)!.push(task);
     });
 
-    // Sort capabilities within each phase by urgency (worst status first)
-    phaseMap.forEach((value) => {
-      value.capabilities.sort((a, b) => {
-        const tasksA = capabilityTaskMap.get(a) || [];
-        const tasksB = capabilityTaskMap.get(b) || [];
-        const worstA = tasksA.reduce((min, t) => Math.min(min, statusUrgency(t.status)), 4);
-        const worstB = tasksB.reduce((min, t) => Math.min(min, statusUrgency(t.status)), 4);
-        if (worstA !== worstB) return worstA - worstB;
-        return a.localeCompare(b);
-      });
-    });
-
-    // Sort phases by total undone tasks (descending), fully done phases last
-    const entries = [...phaseMap.entries()].sort(([phaseA, capsA], [phaseB, capsB]) => {
-      const undoneA = capsA.capabilities.reduce((sum, cap) => {
-        const tasks = capabilityTaskMap.get(cap) || [];
-        return sum + tasks.filter((t) => t.status !== "done").length;
-      }, 0);
-      const undoneB = capsB.capabilities.reduce((sum, cap) => {
-        const tasks = capabilityTaskMap.get(cap) || [];
-        return sum + tasks.filter((t) => t.status !== "done").length;
-      }, 0);
-
-      if (undoneA === 0 && undoneB === 0) return phaseA.localeCompare(phaseB);
-      if (undoneA === 0) return 1;
-      if (undoneB === 0) return -1;
+    // Sort phases: launch-blocker first, then by total undone tasks
+    const order = [
+      "launch-blocker",
+      "launch-quality",
+      "security",
+      "performance",
+      "polishing",
+      "ux-fix",
+      "seo",
+      "code-quality",
+      "tech-debt",
+      "post-launch",
+      "no-phase",
+    ];
+    const sortedPhases = [...phaseMap.entries()].sort((a, b) => {
+      const idxA = order.indexOf(a[0]) === -1 ? 999 : order.indexOf(a[0]);
+      const idxB = order.indexOf(b[0]) === -1 ? 999 : order.indexOf(b[0]);
+      if (idxA !== idxB) return idxA - idxB;
+      // then by undone task count
+      const undoneA = [...a[1].values()].flat().filter((t) => t.status !== "done").length;
+      const undoneB = [...b[1].values()].flat().filter((t) => t.status !== "done").length;
       return undoneB - undoneA;
     });
+    return sortedPhases;
+  }, [tasks]);
 
-    return entries;
-  }, [capabilityTaskMap, capabilityIdeaMap]);
-
-  // ---- Toggle helpers ----
   const togglePhase = useCallback((phase: string) => {
     setExpandedPhases((prev) => {
       const next = new Set(prev);
@@ -365,40 +223,6 @@ export default function FranchizeStatusPage() {
     });
   }, []);
 
-  const handleExpandAll = useCallback(() => {
-    const allPhases = new Set(phaseData.map(([phase]) => phase));
-    const allCaps = new Set<string>();
-    phaseData.forEach(([, { capabilities }]) => capabilities.forEach((c) => allCaps.add(c)));
-    const allTasks = new Set(tasks.map((t) => t.id));
-
-    setExpandedPhases(allPhases);
-    setExpandedCapabilities(allCaps);
-    setExpandedTasks(allTasks);
-    setAllExpanded(true);
-  }, [phaseData, tasks]);
-
-  const handleCollapseAll = useCallback(() => {
-    setExpandedPhases(new Set());
-    setExpandedCapabilities(new Set());
-    setExpandedTasks(new Set());
-    setAllExpanded(false);
-  }, []);
-
-  const jumpToFirstCritical = useCallback(() => {
-    const firstCritical = phaseData.find(([, { capabilities }]) => {
-      return capabilities.some((cap) => {
-        const tasks = capabilityTaskMap.get(cap) || [];
-        return tasks.some((t) => t.status !== "done");
-      });
-    });
-    if (firstCritical) {
-      const [phase] = firstCritical;
-      setExpandedPhases((prev) => new Set(prev).add(phase));
-      document.getElementById(`phase-${phase}`)?.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
-  }, [phaseData, capabilityTaskMap]);
-
-  // Load top priority tasks
   const handleLoadPriority = useCallback(() => {
     startPriorityTransition(async () => {
       const res = await getTopPriorityTasks();
@@ -411,7 +235,6 @@ export default function FranchizeStatusPage() {
     });
   }, []);
 
-  // ---- Render ----
   if (loading) {
     return (
       <div className="flex min-h-[50vh] items-center justify-center text-slate-200">
@@ -430,7 +253,7 @@ export default function FranchizeStatusPage() {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 sm:px-6 sm:py-6 lg:px-8">
-      {/* ---- Mobile sticky status bar ---- */}
+      {/* ---- Mobile sticky bar ---- */}
       <div className="sticky top-16 z-30 -mx-3 -mt-4 mb-4 flex items-center justify-between gap-2 rounded-b-2xl border-b border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
         <div className="flex items-center gap-2 text-xs">
           <Flame className="h-4 w-4 text-rose-400" />
@@ -440,59 +263,83 @@ export default function FranchizeStatusPage() {
           <span className="text-slate-400 dark:text-slate-500">|</span>
           <span className="text-emerald-600 dark:text-emerald-400">{statusTotals.done} сделано</span>
         </div>
-        <Button variant="ghost" size="sm" onClick={jumpToFirstCritical} className="h-7 text-xs">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            const first = document.querySelector("[data-phase]");
+            first?.scrollIntoView({ behavior: "smooth", block: "start" });
+          }}
+          className="h-7 text-xs"
+        >
           <Zap className="mr-1 h-3 w-3" /> К первому
         </Button>
       </div>
 
-      {/* ---- Hero Banner ---- */}
-      <section className="relative overflow-hidden rounded-3xl border border-slate-200/80 bg-[radial-gradient(circle_at_top_right,#0ea5e9_0%,#111827_42%,#020617_100%)] p-5 text-white shadow-lg dark:border-slate-700/80">
-        <div className="absolute -right-16 top-0 h-44 w-44 rounded-full bg-cyan-400/25 blur-3xl" aria-hidden />
-        <div className="absolute -bottom-16 left-8 h-32 w-32 rounded-full bg-amber-400/20 blur-3xl" aria-hidden />
-
-        <div className="relative flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.2em] text-cyan-100">
-          <Badge className="border border-cyan-300/40 bg-cyan-300/20 text-cyan-100">FRANCHIZE CONTROL DECK</Badge>
-          <span>crew alias: vip-bike</span>
-          <span>canonical slug: vip-bike</span>
-        </div>
-
-        <h1 className="relative mt-3 text-2xl font-semibold leading-tight sm:text-4xl">
-          SupaPlan • Franchize status board (human-first)
-        </h1>
-        <p className="relative mt-3 max-w-4xl text-sm text-slate-200 sm:text-base">
-          Сопоставили клиентские идеи и текущий SupaPlan. Здесь видно, какие эпики уже закрыты, какие в работе и где пора декомпозировать в более мелкие задачи во время реализации.
-        </p>
-
-        <div className="relative mt-4 flex flex-wrap gap-2 text-xs sm:text-sm">
-          <Link
-            href="/supaplan"
-            className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 hover:bg-white/15"
-          >
-            <ArrowLeft className="h-4 w-4" /> Назад в общий SupaPlan
-          </Link>
-          <Link
-            href="/nexus"
-            className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 hover:bg-white/15"
-          >
-            <Rocket className="h-4 w-4" /> Nexus
-          </Link>
-          <Link
-            href="/franchize/vip-bike/map-riders"
-            className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 hover:bg-white/15"
-          >
-            <Bike className="h-4 w-4" /> VIP Bike Map Riders
-          </Link>
+      {/* ---- Hero Section (overhauled) ---- */}
+      <section className="relative overflow-hidden rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-6 text-white shadow-2xl">
+        <div className="absolute -right-16 -top-16 h-64 w-64 rounded-full bg-cyan-500/20 blur-3xl" />
+        <div className="absolute -bottom-12 -left-12 h-48 w-48 rounded-full bg-amber-500/20 blur-3xl" />
+        <div className="relative z-10 grid gap-6 md:grid-cols-3">
+          <div className="md:col-span-2">
+            <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-cyan-300">
+              <Badge className="border-cyan-400/40 bg-cyan-400/20 text-cyan-100">FRANCHIZE CONTROL DECK</Badge>
+              <span>vip-bike crew</span>
+            </div>
+            <h1 className="text-3xl font-bold leading-tight sm:text-5xl">
+              <span className="bg-gradient-to-r from-cyan-400 via-amber-300 to-fuchsia-400 bg-clip-text text-transparent">
+                SupaPlan • Franchize
+              </span>
+              <br />
+              <span className="text-2xl sm:text-3xl">Live Status Board</span>
+            </h1>
+            <p className="mt-3 text-sm text-slate-300 sm:text-base">
+              Мгновенный срез по всем эпикам. Приоритеты, фазы, критические задачи — всё под рукой.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Link href="/supaplan" className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-xs hover:bg-white/15">
+                <ArrowLeft className="h-4 w-4" /> Общий SupaPlan
+              </Link>
+              <Link href="/nexus" className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-xs hover:bg-white/15">
+                <Rocket className="h-4 w-4" /> Nexus
+              </Link>
+              <Link href="/franchize/vip-bike/map-riders" className="inline-flex items-center gap-1 rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-xs hover:bg-white/15">
+                <Bike className="h-4 w-4" /> Map Riders
+              </Link>
+            </div>
+          </div>
+          <div className="flex items-center justify-center">
+            <div className="relative flex h-40 w-40 items-center justify-center">
+              <svg className="h-full w-full -rotate-90" viewBox="0 0 36 36">
+                <path
+                  className="text-slate-700"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                />
+                <path
+                  className="text-cyan-400 drop-shadow-[0_0_6px_#22d3ee]"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeDasharray={`${progressPercent}, 100`}
+                  d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                />
+              </svg>
+              <span className="absolute text-2xl font-bold text-cyan-300">{progressPercent}%</span>
+            </div>
+          </div>
         </div>
       </section>
 
       {/* ---- Status cards ---- */}
       <section className="grid grid-cols-2 gap-3 sm:grid-cols-5">
-        {(["open", "claimed", "running", "ready_for_pr", "done"] as TaskStatus[]).map((status) => (
+        {(["open", "claimed", "running", "ready_for_pr", "done"] as TaskStatusProp[]).map((status) => (
           <Card key={status} className="border-slate-800/70 bg-slate-950 text-slate-100">
             <CardHeader className="space-y-1 pb-1">
-              <CardDescription className="text-xs text-slate-400">
-                {STATUS_LABEL[status].label}
-              </CardDescription>
+              <CardDescription className="text-xs text-slate-400">{STATUS_LABEL[status].label}</CardDescription>
               <CardTitle className="text-2xl">{statusTotals[status]}</CardTitle>
             </CardHeader>
           </Card>
@@ -501,14 +348,12 @@ export default function FranchizeStatusPage() {
 
       {/* ---- Progress bar ---- */}
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
-            <Timer className="h-4 w-4 text-emerald-300" /> Прогресс ({progressPercent}%)
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
+        <CardContent className="pt-4">
           <div className="h-2 overflow-hidden rounded-full bg-slate-800">
-            <div className="h-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-fuchsia-400" style={{ width: `${progressPercent}%` }} />
+            <div
+              className="h-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-fuchsia-400"
+              style={{ width: `${progressPercent}%` }}
+            />
           </div>
           <p className="mt-2 text-sm text-slate-300">
             Выполнено: <span className="font-semibold text-emerald-300">{statusTotals.done}/{tasks.length}</span> задач. Осталось критических:{" "}
@@ -517,7 +362,7 @@ export default function FranchizeStatusPage() {
         </CardContent>
       </Card>
 
-      {/* 🔥 TOP-5 PRIORITY SECTION */}
+      {/* 🔥 Top-5 priority */ }
       <section>
         <Button
           variant="outline"
@@ -534,34 +379,29 @@ export default function FranchizeStatusPage() {
           ) : (
             <>
               <Sparkles className="h-4 w-4" />
-              Загрузить ТОП-5 приоритетных задач
+              ТОП-5 приоритетных задач (AI‑ранжирование)
             </>
           )}
         </Button>
 
         {showPriority && priorityTasks.length > 0 && (
-          <Card className="border-amber-500/50 bg-gradient-to-br from-amber-950/60 to-slate-950 text-slate-100 shadow shadow-amber-500/10">
+          <Card className="border-amber-500/50 bg-gradient-to-br from-amber-950/60 to-slate-950 text-slate-100 shadow-lg shadow-amber-500/10">
             <CardHeader className="pb-2">
               <div className="flex items-center justify-between">
                 <CardTitle className="flex items-center gap-2 text-lg text-amber-300">
                   <Flame className="h-5 w-5" /> ТОП-5 критических задач
                 </CardTitle>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setShowPriority(false)}
-                  className="text-slate-400 hover:text-slate-200"
-                >
+                <Button variant="ghost" size="sm" onClick={() => setShowPriority(false)} className="text-slate-400 hover:text-slate-200">
                   Скрыть
                 </Button>
               </div>
               <CardDescription className="text-slate-400">
-                Умная сортировка: статус × фаза × важность способности. Обнови в любой момент.
+                Формула: статус × фаза × важность способности × приоритет × свежесть + быстрые победы.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid gap-2 sm:grid-cols-2">
               {priorityTasks.map((pt) => {
-                const taskMeta = STATUS_LABEL[pt.status as TaskStatus] || STATUS_LABEL.open;
+                const taskMeta = STATUS_LABEL[pt.status as TaskStatusProp] || STATUS_LABEL.open;
                 const fullTask = tasks.find((t) => t.id === pt.id);
                 return (
                   <div key={pt.id} className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm">
@@ -599,41 +439,20 @@ export default function FranchizeStatusPage() {
         )}
       </section>
 
-      {/* ---- Global expand/collapse ---- */}
-      <div className="flex flex-wrap items-center gap-2">
-        <Button variant="outline" size="sm" onClick={handleExpandAll} className="text-xs">
-          Развернуть всё
-        </Button>
-        <Button variant="outline" size="sm" onClick={handleCollapseAll} className="text-xs">
-          Свернуть всё
-        </Button>
-        <span className="ml-auto text-xs text-slate-400">Фазы упорядочены по критичности</span>
-      </div>
-
       {/* ---- Phase → Capability → Task tree ---- */}
       <div className="space-y-3">
-        {phaseData.map(([phase, { capabilities }]) => {
+        {phaseData.map(([phase, capMap]) => {
           const phaseExpanded = expandedPhases.has(phase);
-          // Calculate undone tasks and total tasks in this phase
-          const { undone: phaseUndone, total: phaseTotal } = capabilities.reduce(
-            (acc, cap) => {
-              const capTasks = capabilityTaskMap.get(cap) || [];
-              acc.undone += capTasks.filter((t) => t.status !== "done").length;
-              acc.total += capTasks.length;
-              return acc;
-            },
-            { undone: 0, total: 0 }
-          );
-          // Only show fully done badge if there are tasks and none are undone
-          const isPhaseFullyDone = phaseTotal > 0 && phaseUndone === 0;
-          const phaseHasAnyTasks = phaseTotal > 0;
-
+          const phaseTasks = [...capMap.values()].flat();
+          const undone = phaseTasks.filter((t) => t.status !== "done").length;
+          const total = phaseTasks.length;
+          const fullyDone = total > 0 && undone === 0;
           return (
             <Card
               key={phase}
-              id={`phase-${phase}`}
-              className={`border-slate-800/70 bg-slate-950 text-slate-100 scroll-mt-28 ${
-                isPhaseFullyDone ? "ring-1 ring-emerald-500/30" : ""
+              data-phase={phase}
+              className={`border-l-4 border-slate-800/70 bg-slate-950 text-slate-100 scroll-mt-28 ${
+                fullyDone ? "ring-1 ring-emerald-500/30" : ""
               }`}
             >
               <button
@@ -647,26 +466,24 @@ export default function FranchizeStatusPage() {
                   ) : (
                     <ChevronRight className="h-5 w-5 text-cyan-300 flex-shrink-0" />
                   )}
-                  <h2 className="text-lg font-semibold uppercase tracking-wide">{phase}</h2>
-                  <div className="flex flex-wrap gap-1">
-                    <Badge variant="outline" className="border-slate-600 text-slate-300 text-xs">
-                      {capabilities.length} идеи
-                    </Badge>
-                    {phaseHasAnyTasks && phaseUndone > 0 && (
-                      <Badge className="bg-rose-500/20 text-rose-300 text-xs">
-                        {phaseUndone} не завершено
+                  <h2 className="text-lg font-semibold capitalize">{phase}</h2>
+                  {total > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      <Badge variant="outline" className="border-slate-600 text-slate-300 text-xs">
+                        {capMap.size} способности
                       </Badge>
-                    )}
-                    {isPhaseFullyDone && (
-                      <Badge className="bg-emerald-500/20 text-emerald-300 text-xs">
-                        Все сделано ✓
-                      </Badge>
-                    )}
-                  </div>
+                      {undone > 0 && (
+                        <Badge className="bg-rose-500/20 text-rose-300 text-xs">{undone} не завершено</Badge>
+                      )}
+                      {fullyDone && (
+                        <Badge className="bg-emerald-500/20 text-emerald-300 text-xs">все сделано ✓</Badge>
+                      )}
+                    </div>
+                  )}
                 </div>
-                {phaseHasAnyTasks && (
+                {total > 0 && (
                   <span className="text-xs text-slate-400">
-                    {phaseTotal - phaseUndone}/{phaseTotal}
+                    {total - undone}/{total}
                   </span>
                 )}
               </button>
@@ -674,9 +491,7 @@ export default function FranchizeStatusPage() {
               {phaseExpanded && (
                 <CardContent className="pt-0">
                   <div className="space-y-3">
-                    {capabilities.map((cap) => {
-                      const capTasks = capabilityTaskMap.get(cap) || [];
-                      const idea = capabilityIdeaMap.get(cap);
+                    {[...capMap.entries()].map(([cap, capTasks]) => {
                       const capExpanded = expandedCapabilities.has(cap);
                       const doneCount = capTasks.filter((t) => t.status === "done").length;
                       const allDone = capTasks.length > 0 && doneCount === capTasks.length;
@@ -685,8 +500,7 @@ export default function FranchizeStatusPage() {
                             statusUrgency(t.status) < statusUrgency(worst) ? t.status : worst
                           , capTasks[0].status)
                         : "open";
-                      const worstMeta = STATUS_LABEL[worstStatus as TaskStatus] || STATUS_LABEL.open;
-
+                      const worstMeta = STATUS_LABEL[worstStatus as TaskStatusProp] || STATUS_LABEL.open;
                       return (
                         <div key={cap} className="rounded-xl border border-slate-800 bg-slate-900/70">
                           <button
@@ -700,10 +514,8 @@ export default function FranchizeStatusPage() {
                               ) : (
                                 <ChevronRight className="h-4 w-4 text-amber-300 flex-shrink-0" />
                               )}
-                              <span className="text-sm font-medium">{idea?.idea || cap}</span>
-                              {allDone && (
-                                <CheckCircle2 className="h-4 w-4 text-emerald-400" />
-                              )}
+                              <span className="text-sm font-medium">{cap}</span>
+                              {allDone && <CheckCircle2 className="h-4 w-4 text-emerald-400" />}
                             </div>
                             <div className="flex items-center gap-2">
                               <Badge className={worstMeta.className}>{worstMeta.label}</Badge>
@@ -715,39 +527,17 @@ export default function FranchizeStatusPage() {
 
                           {capExpanded && (
                             <div className="border-t border-slate-800 px-3 pb-3 pt-2">
-                              {idea && (
-                                <div className="mb-2 text-xs text-slate-400">
-                                  <p className="text-slate-300">{idea.note}</p>
-                                  <div className="mt-1 flex flex-wrap gap-1">
-                                    {idea.routes.map((r) => (
-                                      <code
-                                        key={r}
-                                        className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300"
-                                      >
-                                        {r}
-                                      </code>
-                                    ))}
-                                  </div>
-                                </div>
-                              )}
-
                               {capTasks.length === 0 ? (
-                                <p className="flex items-center gap-1 text-xs text-amber-300">
-                                  <AlertCircle className="h-3.5 w-3.5" /> Нет задач – нужно создать.
-                                </p>
+                                <p className="text-xs text-amber-300">Нет задач</p>
                               ) : (
                                 <ul className="space-y-2">
                                   {capTasks
                                     .sort((a, b) => statusUrgency(a.status) - statusUrgency(b.status))
                                     .map((task) => {
                                       const taskExpanded = expandedTasks.has(task.id);
-                                      const taskMeta =
-                                        STATUS_LABEL[task.status as TaskStatus] || STATUS_LABEL.open;
+                                      const taskMeta = STATUS_LABEL[task.status as TaskStatusProp] || STATUS_LABEL.open;
                                       return (
-                                        <li
-                                          key={task.id}
-                                          className="rounded border border-slate-700/70 bg-slate-950/70 p-2"
-                                        >
+                                        <li key={task.id} className="rounded border border-slate-700/70 bg-slate-950/70 p-2">
                                           <button
                                             type="button"
                                             onClick={() => toggleTask(task.id)}
@@ -761,27 +551,18 @@ export default function FranchizeStatusPage() {
                                               )}
                                               <span className="text-sm text-slate-200">{task.title}</span>
                                             </div>
-                                            <Badge className={taskMeta.className}>
-                                              {taskMeta.label}
-                                            </Badge>
+                                            <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
                                           </button>
                                           {taskExpanded && (
                                             <div className="mt-2 space-y-1 pl-5 text-xs text-slate-400">
                                               <p>ID: {task.id}</p>
-                                              {task.todo_path && (
-                                                <p>todo_path: {task.todo_path}</p>
-                                              )}
+                                              {task.todo_path && <p>todo_path: {task.todo_path}</p>}
                                               <p>updated_at (UTC): {formatIso(task.updated_at)}</p>
                                               {task.body && (
-                                                <p className="text-slate-300">{task.body}</p>
+                                                <p className="max-w-lg truncate text-slate-300">{task.body}</p>
                                               )}
                                               {task.pr_url && (
-                                                <a
-                                                  className="text-cyan-300 underline underline-offset-2"
-                                                  href={task.pr_url}
-                                                  target="_blank"
-                                                  rel="noreferrer"
-                                                >
+                                                <a className="text-cyan-300 underline underline-offset-2" href={task.pr_url} target="_blank" rel="noreferrer">
                                                   PR: {task.pr_url}
                                                 </a>
                                               )}
@@ -805,7 +586,7 @@ export default function FranchizeStatusPage() {
         })}
       </div>
 
-      {/* ---- Collapsible Board Legend ---- */}
+      {/* ---- Legend (overhauled) ---- */}
       <div className="mt-8 border-t border-slate-800 pt-4">
         <button
           type="button"
@@ -818,62 +599,40 @@ export default function FranchizeStatusPage() {
 
         {legendOpen && (
           <div className="mt-3 space-y-4 text-sm text-slate-300">
-            {/* Task types */}
             <div>
               <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                Типы задач
+                Приоритеты (scoring)
               </h4>
-              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-                {Object.entries(TASK_TYPE_DESCRIPTIONS).map(([type, desc]) => (
-                  <div
-                    key={type}
-                    className="rounded-xl border border-slate-700/50 bg-slate-900/50 p-3"
-                  >
-                    <strong className="text-slate-200">{type}</strong>
-                    <p className="text-slate-400">{desc}</p>
-                  </div>
-                ))}
-              </div>
+              <p className="text-slate-400">
+                critical ×2.5, high ×2.0, medium ×1.5, low ×1.0. P0/p1/p2 в теле задачи действуют аналогично.
+              </p>
             </div>
-
-            {/* Statuses */}
             <div>
               <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                Статусы задач
+                Фазы и их множители
               </h4>
               <div className="flex flex-wrap gap-2">
-                {(Object.keys(STATUS_LABEL) as TaskStatus[]).map((status) => (
-                  <Badge
-                    key={status}
-                    className={`${STATUS_LABEL[status].className} text-xs`}
-                  >
-                    {STATUS_LABEL[status].label}
+                {Object.entries(PHASE_COLORS).map(([p, cls]) => (
+                  <Badge key={p} className={`border-l-2 bg-slate-800/50 ${cls}`}>
+                    {p}
                   </Badge>
                 ))}
               </div>
             </div>
-
-            {/* Priority formula */}
             <div>
-              <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                Приоритет (ТОП-5)
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Типы задач (capabilities)
               </h4>
-              <p className="text-slate-400">
-                <code className="rounded bg-slate-800 px-1 text-cyan-300">статус (Open=10, …, Ready for PR=3)</code> ×{" "}
-                <code className="rounded bg-slate-800 px-1 text-cyan-300">фаза (Апрель=1.5 … 2027=0.7)</code> ×{" "}
-                <code className="rounded bg-slate-800 px-1 text-cyan-300">важность способности (0.7‑1.4)</code> +{" "}
-                <code className="rounded bg-slate-800 px-1 text-cyan-300">бонус за возраст (+0.5 если старше 7 дней)</code>
-              </p>
-            </div>
-
-            {/* Phases */}
-            <div>
-              <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                Фазы (дорожная карта)
-              </h4>
-              <p className="text-slate-400">
-                {PHASE_ORDER.join(" → ")} – фазы упорядочены по количеству незавершённых задач.
-              </p>
+              <div className="flex flex-wrap gap-2">
+                {[...new Set(tasks.map((t) => t.capability))]
+                  .filter(Boolean)
+                  .sort()
+                  .map((cap) => (
+                    <Badge key={cap} variant="outline" className="text-xs">
+                      {cap}
+                    </Badge>
+                  ))}
+              </div>
             </div>
           </div>
         )}
@@ -881,20 +640,20 @@ export default function FranchizeStatusPage() {
 
       {/* ---- Runtime checks ---- */}
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
             <Wrench className="h-4 w-4 text-cyan-300" /> Runtime checks
           </CardTitle>
           <CardDescription className="text-slate-400">
-            Текущая выборка из supaplan_tasks (capability like `franchize.%`).
+            {tasks.length} franchize‑задач загружено (greenbox исключены).
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-2 text-sm text-slate-300">
           <p className="flex items-center gap-2">
-            <CheckCircle2 className="h-4 w-4 text-emerald-300" /> Задач найдено: {tasks.length}
+            <CheckCircle2 className="h-4 w-4 text-emerald-300" /> Готово: {statusTotals.done}
           </p>
           <p className="flex items-center gap-2">
-            <Clock3 className="h-4 w-4 text-cyan-300" /> Обновлено: {new Date().toISOString()}
+            <Clock3 className="h-4 w-4 text-cyan-300" /> Последнее обновление: {new Date().toISOString()}
           </p>
         </CardContent>
       </Card>

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import {
   AlertCircle,
@@ -13,6 +13,9 @@ import {
   ExternalLink,
   Flame,
   HelpCircle,
+  Layers3,
+  Megaphone,
+  Rocket,
   Sparkles,
   Wrench,
   Zap,
@@ -64,12 +67,42 @@ const STATUS_LABEL: Record<TaskStatusProp, { label: string; className: string }>
   done: { label: "Done", className: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
 };
 
-const STATUS_GLOW: Record<TaskStatusProp, string> = {
-  open: "shadow-sky-500/10",
-  claimed: "shadow-indigo-500/10",
-  running: "shadow-amber-500/10",
-  ready_for_pr: "shadow-fuchsia-500/10",
-  done: "shadow-emerald-500/10",
+const STATUS_CARD_CONFIG: Record<TaskStatusProp, {
+  icon: React.ElementType;
+  gradient: string;
+  border: string;
+  countColor: string;
+}> = {
+  open: {
+    icon: Layers3,
+    gradient: "from-sky-500/20 to-sky-600/5",
+    border: "border-sky-500/30",
+    countColor: "text-sky-300",
+  },
+  claimed: {
+    icon: Rocket,
+    gradient: "from-indigo-500/20 to-indigo-600/5",
+    border: "border-indigo-500/30",
+    countColor: "text-indigo-300",
+  },
+  running: {
+    icon: Clock3,
+    gradient: "from-amber-500/20 to-amber-600/5",
+    border: "border-amber-500/30",
+    countColor: "text-amber-300",
+  },
+  ready_for_pr: {
+    icon: Megaphone,
+    gradient: "from-fuchsia-500/20 to-fuchsia-600/5",
+    border: "border-fuchsia-500/30",
+    countColor: "text-fuchsia-300",
+  },
+  done: {
+    icon: CheckCircle2,
+    gradient: "from-emerald-500/20 to-emerald-600/5",
+    border: "border-emerald-500/30",
+    countColor: "text-emerald-300",
+  },
 };
 
 const PHASE_ORDER = ["Апрель", "Май", "Июнь", "Лето", "2027"] as const;
@@ -226,6 +259,43 @@ function buildTaskCopyText(task: PriorityTask, fullTask?: FranchizeTask): string
   return parts.join("\n");
 }
 
+/**
+ * Custom hook to animate a number from 0 to target over a given duration.
+ */
+function useCountUp(target: number, duration = 600) {
+  const [display, setDisplay] = useState(0);
+  const frameRef = useRef<number>(0);
+  const startTimeRef = useRef<number | null>(null);
+
+  const step = useCallback(
+    (timestamp: number) => {
+      if (!startTimeRef.current) startTimeRef.current = timestamp;
+      const elapsed = timestamp - startTimeRef.current;
+      const progress = Math.min(elapsed / duration, 1);
+      // easeOutCubic
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setDisplay(Math.round(eased * target));
+
+      if (progress < 1) {
+        frameRef.current = requestAnimationFrame(step);
+      }
+    },
+    [target, duration]
+  );
+
+  useEffect(() => {
+    if (target === 0) {
+      setDisplay(0);
+      return;
+    }
+    startTimeRef.current = null;
+    frameRef.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(frameRef.current);
+  }, [target, step]);
+
+  return display;
+}
+
 /* ========================================================================== */
 /*  Page Component                                                            */
 /* ========================================================================== */
@@ -246,6 +316,7 @@ export default function FranchizeStatusPage() {
   const [priorityTasks, setPriorityTasks] = useState<PriorityTask[]>([]);
   const [isPriorityLoading, startPriorityTransition] = useTransition();
   const [copied, setCopied] = useState(false);
+  const [copyAllCelebration, setCopyAllCelebration] = useState(false);
 
   // 1. Fetch all franchize tasks on mount
   useEffect(() => {
@@ -294,9 +365,15 @@ export default function FranchizeStatusPage() {
     return totals;
   }, [tasks]);
 
+  // Animated display values for status cards (the surprise!)
+  const animatedOpen = useCountUp(statusTotals.open);
+  const animatedClaimed = useCountUp(statusTotals.claimed);
+  const animatedRunning = useCountUp(statusTotals.running);
+  const animatedReady = useCountUp(statusTotals.ready_for_pr);
+  const animatedDone = useCountUp(statusTotals.done);
+
   const totalPending = tasks.length - statusTotals.done;
   const progressPercent = tasks.length ? Math.round((statusTotals.done / tasks.length) * 100) : 0;
-  const circumference = 2 * Math.PI * 15.9155; // ~100
 
   // ----- Phase grouping -----
   const phaseData = useMemo(() => {
@@ -370,8 +447,8 @@ export default function FranchizeStatusPage() {
     });
     const fullText = texts.join("\n\n");
     await navigator.clipboard.writeText(fullText);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    setCopyAllCelebration(true);
+    setTimeout(() => setCopyAllCelebration(false), 1500);
   }, [priorityTasks, tasks]);
 
   // ----- Render states -----
@@ -395,17 +472,17 @@ export default function FranchizeStatusPage() {
   /*  Render                                                                   */
   /* ======================================================================== */
   return (
-    <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 pb-20 sm:px-6 sm:py-8 lg:px-8">
+    <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 pb-20 pt-20 sm:px-6 sm:py-8 lg:px-8">
       {/* ==================================================================== */}
-      {/*  HERO – cyber command deck                                           */}
+      {/*  HERO                                                                 */}
       {/* ==================================================================== */}
       <section className="relative rounded-3xl border border-slate-700/80 bg-gradient-to-br from-slate-900 via-indigo-950/90 to-slate-900 p-5 text-white shadow-2xl sm:p-6">
-        {/* Background glows – no overflow‑hidden on the parent so they render fully */}
-        <div className="pointer-events-none absolute -right-10 -top-10 h-56 w-56 rounded-full bg-cyan-500/20 blur-3xl" />
-        <div className="pointer-events-none absolute -bottom-10 -left-10 h-44 w-44 rounded-full bg-purple-500/15 blur-3xl" />
+        {/* Glows */}
+        <div className="pointer-events-none absolute -right-8 -top-8 h-52 w-52 rounded-full bg-cyan-500/20 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-8 -left-8 h-44 w-44 rounded-full bg-purple-500/15 blur-3xl" />
 
         <div className="relative z-10 grid gap-6 md:grid-cols-3">
-          {/* Left column: title + meta */}
+          {/* Left column */}
           <div className="md:col-span-2">
             <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-cyan-300">
               <Badge className="border-cyan-400/40 bg-cyan-400/20 text-cyan-100">FRANCHIZE CONTROL DECK</Badge>
@@ -431,20 +508,25 @@ export default function FranchizeStatusPage() {
               >
                 <ArrowLeft className="h-4 w-4" /> Общий SupaPlan
               </Link>
-              <a
-                href="https://chatgpt.com/codex/cloud"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 rounded-lg border border-purple-400/30 bg-purple-400/10 px-3 py-2 text-xs text-purple-200 transition hover:bg-purple-400/20"
-              >
-                <ExternalLink className="h-4 w-4" /> Codex Cloud
-              </a>
+              <div className="group relative inline-flex">
+                <a
+                  href="https://chatgpt.com/codex/cloud"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 rounded-lg border border-purple-400/30 bg-purple-400/10 px-3 py-2 text-xs text-purple-200 transition hover:bg-purple-400/20"
+                >
+                  <ExternalLink className="h-4 w-4" /> Codex Cloud
+                </a>
+                <span className="absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-[10px] text-white opacity-0 transition-opacity group-hover:opacity-100">
+                  🚀 Deploy to Codex
+                </span>
+              </div>
             </div>
           </div>
 
           {/* Right column: progress ring */}
           <div className="flex items-center justify-center">
-            <div className="relative flex h-36 w-36 items-center justify-center">
+            <div className="relative flex h-36 w-36 items-center justify-center overflow-visible">
               <svg className="h-full w-full -rotate-90" viewBox="0 0 36 36" aria-hidden>
                 <circle
                   className="text-slate-700"
@@ -454,7 +536,11 @@ export default function FranchizeStatusPage() {
                   cx="18" cy="18" r="15.9155"
                 />
                 <circle
-                  className="text-cyan-400 drop-shadow-[0_0_6px_#22d3ee] transition-all duration-700"
+                  className={
+                    statusTotals.done === tasks.length && tasks.length > 0
+                      ? "text-emerald-400 drop-shadow-[0_0_8px_#34d399] animate-pulse"
+                      : "text-cyan-400 drop-shadow-[0_0_6px_#22d3ee]"
+                  }
                   fill="none"
                   stroke="currentColor"
                   strokeWidth="2"
@@ -472,24 +558,41 @@ export default function FranchizeStatusPage() {
       </section>
 
       {/* ==================================================================== */}
-      {/*  STATUS CARDS – enhanced                                             */}
+      {/*  ANIMATED STATUS CARDS                                               */}
       {/* ==================================================================== */}
       <section className="grid grid-cols-2 gap-2 sm:grid-cols-5 sm:gap-3">
-        {(["open", "claimed", "running", "ready_for_pr", "done"] as TaskStatusProp[]).map((status) => (
-          <Card
-            key={status}
-            className={`border-slate-800/70 bg-slate-950 text-slate-100 transition hover:-translate-y-0.5 hover:shadow-lg ${STATUS_GLOW[status]}`}
-          >
-            <CardHeader className="space-y-1 p-3 pb-1 sm:p-4 sm:pb-1">
-              <CardDescription className="text-[11px] uppercase tracking-wide text-slate-400">
-                {STATUS_LABEL[status].label}
-              </CardDescription>
-              <CardTitle className="text-3xl font-bold tabular-nums tracking-tight">
-                {statusTotals[status]}
-              </CardTitle>
-            </CardHeader>
-          </Card>
-        ))}
+        {(["open", "claimed", "running", "ready_for_pr", "done"] as TaskStatusProp[]).map((status) => {
+          const config = STATUS_CARD_CONFIG[status];
+          const Icon = config.icon;
+          const rawValue = statusTotals[status];
+          // choose animated value based on status
+          let animatedValue = rawValue;
+          if (status === "open") animatedValue = animatedOpen;
+          else if (status === "claimed") animatedValue = animatedClaimed;
+          else if (status === "running") animatedValue = animatedRunning;
+          else if (status === "ready_for_pr") animatedValue = animatedReady;
+          else if (status === "done") animatedValue = animatedDone;
+
+          return (
+            <Card
+              key={status}
+              className={`relative overflow-hidden border ${config.border} bg-gradient-to-br ${config.gradient} bg-slate-950 text-white transition hover:-translate-y-1 hover:shadow-lg`}
+            >
+              <Icon className="absolute -right-2 -top-2 h-16 w-16 opacity-10 rotate-12" />
+              <CardHeader className="space-y-1 p-3 pb-1 sm:p-4 sm:pb-1">
+                <CardDescription className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-slate-400">
+                  <Icon className="h-3.5 w-3.5" />
+                  {STATUS_LABEL[status].label}
+                </CardDescription>
+                <CardTitle
+                  className={`text-3xl font-bold tabular-nums tracking-tight transition-colors ${config.countColor}`}
+                >
+                  {animatedValue}
+                </CardTitle>
+              </CardHeader>
+            </Card>
+          );
+        })}
       </section>
 
       {/* ==================================================================== */}
@@ -503,19 +606,25 @@ export default function FranchizeStatusPage() {
               style={{ width: `${progressPercent}%` }}
             />
           </div>
-          <p className="mt-2 text-sm text-slate-300">
-            Выполнено:{" "}
-            <span className="font-semibold text-emerald-300">
-              {statusTotals.done}/{tasks.length}
-            </span>{" "}
-            задач. Осталось критических:{" "}
-            <span className="font-semibold text-rose-400">{totalPending}</span>.
+          <p className="mt-2 flex items-baseline gap-2 text-sm text-slate-300">
+            <span>
+              Выполнено:{" "}
+              <span className="font-semibold text-emerald-300">
+                {statusTotals.done}/{tasks.length}
+              </span>{" "}
+              задач.
+            </span>
+            <span className="text-slate-500">·</span>
+            <span>
+              Осталось критических:{" "}
+              <span className="font-semibold text-rose-400">{totalPending}</span>
+            </span>
           </p>
         </CardContent>
       </Card>
 
       {/* ==================================================================== */}
-      {/*  TOP‑5 PRIORITY – auto‑loaded, no hide button                        */}
+      {/*  TOP‑5 PRIORITY (auto‑loaded)                                        */}
       {/* ==================================================================== */}
       {isPriorityLoading && priorityTasks.length === 0 && (
         <div className="flex items-center gap-2 text-sm text-slate-400">
@@ -540,11 +649,8 @@ export default function FranchizeStatusPage() {
                   className="h-auto px-2 py-1 text-xs text-amber-300 hover:text-amber-100 disabled:opacity-50"
                 >
                   <Copy className="mr-1 h-3.5 w-3.5" />
-                  {copied ? "Скопировано!" : "Копировать все 5"}
+                  {copyAllCelebration ? "🎉 Скопировано!" : "Копировать все 5"}
                 </Button>
-                <span className="rounded-full bg-amber-400/10 px-2 py-0.5 text-[11px] text-amber-400/80">
-                  авто‑обновление
-                </span>
               </div>
             </div>
             <CardDescription className="text-slate-400">
@@ -599,7 +705,7 @@ export default function FranchizeStatusPage() {
       )}
 
       {/* ==================================================================== */}
-      {/*  PHASE → CAPABILITY → TASK TREE                                      */}
+      {/*  PHASE TREE                                                          */}
       {/* ==================================================================== */}
       <div className="space-y-3">
         {phaseData.map(([phase, capMap]) => {
@@ -892,7 +998,7 @@ export default function FranchizeStatusPage() {
       </Card>
 
       {/* ==================================================================== */}
-      {/*  BOTTOM STICKY BAR (mobile only)                                     */}
+      {/*  BOTTOM STICKY BAR (mobile)                                          */}
       {/* ==================================================================== */}
       <div className="fixed inset-x-0 bottom-0 z-40 flex items-center justify-between gap-2 border-t border-slate-200/40 bg-white/90 px-3 py-2 shadow backdrop-blur dark:border-slate-700/80 dark:bg-slate-950/90 sm:hidden">
         <div className="flex items-center gap-2 text-xs">

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -527,7 +527,7 @@ export default function FranchizeStatusPage() {
           {/* Right column: progress ring */}
           <div className="flex items-center justify-center">
             <div className="relative flex h-36 w-36 items-center justify-center overflow-visible">
-              <svg className="h-full w-full -rotate-90" viewBox="0 0 36 36" aria-hidden>
+              <svg className="h-full w-full -rotate-90" viewBox="0 0 36 36" overflow="visible" aria-hidden>
                 <circle
                   className="text-slate-700"
                   fill="none"

--- a/app/supaplan/franchize/page.tsx
+++ b/app/supaplan/franchize/page.tsx
@@ -1,9 +1,14 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   AlertCircle,
   ArrowLeft,
   Bike,
   CheckCircle2,
+  ChevronDown,
+  ChevronRight,
   Clock3,
   Layers3,
   Milestone,
@@ -12,9 +17,13 @@ import {
   Wrench,
 } from "lucide-react";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { supabaseAdmin } from "@/hooks/supabase";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { supabaseAnon } from "@/hooks/supabase";
+
+/* -------------------------------------------------------------------------- */
+/*  Types & constants                                                         */
+/* -------------------------------------------------------------------------- */
 
 type TaskStatus = "open" | "claimed" | "running" | "ready_for_pr" | "done";
 
@@ -33,7 +42,7 @@ type FranchizeTask = {
 type IdeaRow = {
   idea: string;
   capability: string;
-  phase: "Апрель" | "Май" | "Июнь" | "Лето" | "2027";
+  phase: string; // we'll still use the existing phases, but allow new ones to fall into "Uncategorised"
   taskType: "R1 Contract" | "R2 Integration" | "R3 Ops UX" | "R4 Growth";
   routes: string[];
   note: string;
@@ -48,7 +57,7 @@ const STATUS_LABEL: Record<TaskStatus, { label: string; className: string }> = {
   done: { label: "Done", className: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
 };
 
-const PHASE_ORDER: IdeaRow["phase"][] = ["Апрель", "Май", "Июнь", "Лето", "2027"];
+const PHASE_ORDER = ["Апрель", "Май", "Июнь", "Лето", "2027"] as const;
 
 const IDEA_MAP: IdeaRow[] = [
   {
@@ -141,20 +150,38 @@ const IDEA_MAP: IdeaRow[] = [
     note: "Матчинг «идея ↔ capability ↔ task/status».",
     decompositionHint: "Регулярно спаунить детализацию эпиков при старте реализации.",
   },
+  // ---- NEW CAPABILITIES ----
+  {
+    idea: "UI/UX-дизайн для франшизы",
+    capability: "franchize.ui.ux",
+    phase: "Апрель",
+    taskType: "R3 Ops UX",
+    routes: ["/franchize/vip-bike/*"],
+    note: "Система дизайн-компонентов и UX-флоу для мобильных и веб-версий.",
+    decompositionHint: "Создать дизайн-систему и сверстать ключевые экраны.",
+  },
+  {
+    idea: "Бэкенд Supabase-инфраструктура франшизы",
+    capability: "franchize.backend.supabase",
+    phase: "Апрель",
+    taskType: "R1 Contract",
+    routes: ["/supabase", "/sql"],
+    note: "Настройка RLS, миграции, функции и API-роуты.",
+    decompositionHint: "Подготовить миграции схем данных, ролевую модель и хранимые процедуры.",
+  },
 ];
 
-function byStatusWeight(status: string): number {
+/* -------------------------------------------------------------------------- */
+/*  Helpers                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function statusWeight(status: string): number {
   switch (status) {
-    case "done":
-      return 4;
-    case "ready_for_pr":
-      return 3;
-    case "running":
-      return 2;
-    case "claimed":
-      return 1;
-    default:
-      return 0;
+    case "done": return 4;
+    case "ready_for_pr": return 3;
+    case "running": return 2;
+    case "claimed": return 1;
+    default: return 0;
   }
 }
 
@@ -169,43 +196,155 @@ function formatIso(iso: string): string {
   });
 }
 
-export default async function SupaPlanFranchizePage() {
-  const { data, error } = await supabaseAdmin
-    .from("supaplan_tasks")
-    .select("id,title,body,capability,status,todo_path,created_at,updated_at,pr_url")
-    .or("capability.like.franchize.%,capability.eq.greenbox.franchize")
-    .order("updated_at", { ascending: false });
+/* -------------------------------------------------------------------------- */
+/*  Page Component                                                            */
+/* -------------------------------------------------------------------------- */
 
-  const tasks: FranchizeTask[] = (data as FranchizeTask[] | null) ?? [];
+export default function FranchizeStatusPage() {
+  const [tasks, setTasks] = useState<FranchizeTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const capabilityMap = new Map<string, FranchizeTask[]>();
-  tasks.forEach((task) => {
-    if (!task.capability) return;
-    const prev = capabilityMap.get(task.capability) ?? [];
-    prev.push(task);
-    capabilityMap.set(task.capability, prev);
-  });
+  // Drill‑down states: which phase / capability / task is expanded
+  const [expandedPhases, setExpandedPhases] = useState<Set<string>>(new Set());
+  const [expandedCapabilities, setExpandedCapabilities] = useState<Set<string>>(new Set());
+  const [expandedTasks, setExpandedTasks] = useState<Set<string>>(new Set());
 
-  const statusTotals = tasks.reduce(
-    (acc, task) => {
-      const key = task.status as TaskStatus;
-      if (key in acc) {
-        acc[key] += 1;
+  // ---- Fetch all franchize tasks ----
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error } = await supabaseAnon
+          .from("supaplan_tasks")
+          .select("id,title,body,capability,status,todo_path,created_at,updated_at,pr_url")
+          .or("capability.like.franchize.%,capability.eq.greenbox.franchize")
+          .order("updated_at", { ascending: false });
+
+        if (error) throw error;
+        setTasks((data as FranchizeTask[]) || []);
+      } catch (err: any) {
+        setError(err.message || "Не удалось загрузить задачи");
+      } finally {
+        setLoading(false);
       }
-      return acc;
-    },
-    { open: 0, claimed: 0, running: 0, ready_for_pr: 0, done: 0 }
-  );
+    };
+    fetchData();
+  }, []);
 
-  const progressPercent = tasks.length ? Math.round((statusTotals.done / tasks.length) * 100) : 0;
+  // ---- Group tasks by capability ----
+  const capabilityTaskMap = useMemo(() => {
+    const map = new Map<string, FranchizeTask[]>();
+    tasks.forEach((task) => {
+      if (!task.capability) return;
+      const prev = map.get(task.capability) || [];
+      prev.push(task);
+      map.set(task.capability, prev);
+    });
+    return map;
+  }, [tasks]);
 
-  const roadmapByPhase = PHASE_ORDER.map((phase) => ({
-    phase,
-    items: IDEA_MAP.filter((row) => row.phase === phase),
-  })).filter((phaseBlock) => phaseBlock.items.length > 0);
+  // ---- Stats ----
+  const statusTotals = useMemo(() => {
+    const totals: Record<TaskStatus, number> = { open: 0, claimed: 0, running: 0, ready_for_pr: 0, done: 0 };
+    tasks.forEach((task) => {
+      const key = task.status as TaskStatus;
+      if (key in totals) totals[key] += 1;
+    });
+    return totals;
+  }, [tasks]);
+
+  const progressPercent = useMemo(() => {
+    return tasks.length ? Math.round((statusTotals.done / tasks.length) * 100) : 0;
+  }, [tasks, statusTotals.done]);
+
+  // ---- Map capabilities to phases (using IDEA_MAP + fallback) ----
+  const capabilityIdeaMap = useMemo(() => {
+    const map = new Map<string, IdeaRow>();
+    IDEA_MAP.forEach((row) => map.set(row.capability, row));
+    return map;
+  }, []);
+
+  const getPhaseForCapability = (cap: string): string => {
+    return capabilityIdeaMap.get(cap)?.phase ?? "Uncategorised";
+  };
+
+  // ---- Build data per phase ----
+  const phaseData = useMemo(() => {
+    const phaseMap = new Map<string, { capabilities: string[] }>();
+
+    PHASE_ORDER.forEach((phase) => phaseMap.set(phase, { capabilities: [] }));
+
+    // All capabilities present in tasks (or the map)
+    const allCaps = new Set<string>();
+    capabilityTaskMap.forEach((_, cap) => allCaps.add(cap));
+    capabilityIdeaMap.forEach((_, cap) => allCaps.add(cap)); // even empty ideas
+
+    allCaps.forEach((cap) => {
+      const phase = getPhaseForCapability(cap);
+      if (!phaseMap.has(phase)) {
+        phaseMap.set(phase, { capabilities: [] });
+      }
+      phaseMap.get(phase)!.capabilities.push(cap);
+    });
+
+    // Sort capabilities inside each phase (alphabetically, or by some weight)
+    phaseMap.forEach((value) => {
+      value.capabilities.sort((a, b) => a.localeCompare(b));
+    });
+
+    return phaseMap;
+  }, [capabilityTaskMap, capabilityIdeaMap]);
+
+  // ---- Toggle helpers ----
+  const togglePhase = useCallback((phase: string) => {
+    setExpandedPhases((prev) => {
+      const next = new Set(prev);
+      if (next.has(phase)) next.delete(phase);
+      else next.add(phase);
+      return next;
+    });
+  }, []);
+
+  const toggleCapability = useCallback((cap: string) => {
+    setExpandedCapabilities((prev) => {
+      const next = new Set(prev);
+      if (next.has(cap)) next.delete(cap);
+      else next.add(cap);
+      return next;
+    });
+  }, []);
+
+  const toggleTask = useCallback((taskId: string) => {
+    setExpandedTasks((prev) => {
+      const next = new Set(prev);
+      if (next.has(taskId)) next.delete(taskId);
+      else next.add(taskId);
+      return next;
+    });
+  }, []);
+
+  // ---- Rendering ----
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center text-slate-200">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-600 border-t-cyan-400" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center text-rose-300">
+        <AlertCircle className="mr-2 h-5 w-5" /> Ошибка: {error}
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-3 py-4 sm:px-6 sm:py-6 lg:px-8">
+      {/* ---- Hero Banner (unchanged structure) ---- */}
       <section className="relative overflow-hidden rounded-3xl border border-slate-200/80 bg-[radial-gradient(circle_at_top_right,#0ea5e9_0%,#111827_42%,#020617_100%)] p-5 text-white shadow-lg dark:border-slate-700/80">
         <div className="absolute -right-16 top-0 h-44 w-44 rounded-full bg-cyan-400/25 blur-3xl" aria-hidden />
         <div className="absolute -bottom-16 left-8 h-32 w-32 rounded-full bg-amber-400/20 blur-3xl" aria-hidden />
@@ -238,6 +377,7 @@ export default async function SupaPlanFranchizePage() {
         </div>
       </section>
 
+      {/* ---- Status cards ---- */}
       <section className="grid grid-cols-2 gap-3 sm:grid-cols-5">
         {(["open", "claimed", "running", "ready_for_pr", "done"] as TaskStatus[]).map((status) => (
           <Card key={status} className="border-slate-800/70 bg-slate-950 text-slate-100">
@@ -249,12 +389,28 @@ export default async function SupaPlanFranchizePage() {
         ))}
       </section>
 
+      {/* ---- Progress & Legend ---- */}
+      <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
+            <Timer className="h-4 w-4 text-emerald-300" /> Прогресс по всем задачам
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-2 overflow-hidden rounded-full bg-slate-800">
+            <div className="h-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-fuchsia-400" style={{ width: `${progressPercent}%` }} />
+          </div>
+          <p className="mt-2 text-sm text-slate-300">
+            Выполнено: <span className="font-semibold text-emerald-300">{progressPercent}%</span> ({statusTotals.done}/{tasks.length}) задач.
+          </p>
+        </CardContent>
+      </Card>
+
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
             <Milestone className="h-4 w-4 text-cyan-300" /> Legend — типы задач и статусов
           </CardTitle>
-          <CardDescription className="text-slate-400">Легенда по слоям задач и приоритету детализации эпиков.</CardDescription>
         </CardHeader>
         <CardContent className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
           <div className="rounded-xl border border-cyan-500/30 bg-cyan-500/10 p-3">
@@ -276,145 +432,181 @@ export default async function SupaPlanFranchizePage() {
         </CardContent>
       </Card>
 
-      <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
-            <Layers3 className="h-4 w-4 text-amber-300" /> Epic decomposition cues
-          </CardTitle>
-          <CardDescription className="text-slate-400">Текущие задачи в основном как эпики — при старте реализации спаунить дочерние subtasks.</CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-3 text-sm lg:grid-cols-2">
-          {IDEA_MAP.map((row) => (
-            <div key={`${row.capability}-decomp`} className="rounded-xl border border-slate-800 bg-slate-900/70 p-3">
-              <p className="font-medium text-slate-100">{row.capability}</p>
-              <p className="mt-1 text-slate-300">{row.decompositionHint}</p>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+      {/* ---- Double-collapsible phase → capability → task ---- */}
+      <div className="space-y-3">
+        {[...phaseData.entries()]
+          .sort(([phaseA], [phaseB]) => {
+            const idxA = PHASE_ORDER.indexOf(phaseA as any);
+            const idxB = PHASE_ORDER.indexOf(phaseB as any);
+            if (idxA !== -1 && idxB !== -1) return idxA - idxB;
+            if (idxA !== -1) return -1;
+            if (idxB !== -1) return 1;
+            return phaseA.localeCompare(phaseB);
+          })
+          .map(([phase, { capabilities }]) => {
+            const phaseExpanded = expandedPhases.has(phase);
+            // Count tasks per phase for a small summary
+            const phaseTaskCount = capabilities.reduce((sum, cap) => sum + (capabilityTaskMap.get(cap)?.length || 0), 0);
+            return (
+              <Card key={phase} className="border-slate-800/70 bg-slate-950 text-slate-100">
+                {/* Phase header */}
+                <button
+                  type="button"
+                  onClick={() => togglePhase(phase)}
+                  className="flex w-full items-center justify-between p-4 text-left"
+                >
+                  <div className="flex items-center gap-3">
+                    {phaseExpanded ? (
+                      <ChevronDown className="h-5 w-5 text-cyan-300" />
+                    ) : (
+                      <ChevronRight className="h-5 w-5 text-cyan-300" />
+                    )}
+                    <h2 className="text-lg font-semibold uppercase tracking-wide">{phase}</h2>
+                    <Badge variant="outline" className="border-slate-600 text-slate-300">
+                      {capabilities.length} идеи · {phaseTaskCount} задач
+                    </Badge>
+                  </div>
+                </button>
 
-      <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
-            <Timer className="h-4 w-4 text-emerald-300" /> План по фазам: апрель → 2027
-          </CardTitle>
-          <CardDescription className="text-slate-400">Покрытие текущих идей из брифа с маршрутом в SupaPlan и деталями задач.</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="h-2 overflow-hidden rounded-full bg-slate-800">
-            <div className="h-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-fuchsia-400" style={{ width: `${progressPercent}%` }} />
-          </div>
-          <p className="text-sm text-slate-300">
-            Выполнено: <span className="font-semibold text-emerald-300">{progressPercent}%</span> ({statusTotals.done}/{tasks.length}) franchize-задач.
-          </p>
-        </CardContent>
-      </Card>
+                {/* Collapsible content */}
+                {phaseExpanded && (
+                  <CardContent className="pt-0">
+                    <div className="space-y-3">
+                      {capabilities.map((cap) => {
+                        const capTasks = capabilityTaskMap.get(cap) || [];
+                        const idea = capabilityIdeaMap.get(cap);
+                        const capExpanded = expandedCapabilities.has(cap);
 
-      {roadmapByPhase.map((phase) => (
-        <section key={phase.phase} className="space-y-3">
-          <h2 className="text-lg font-semibold text-slate-200">{phase.phase}</h2>
-          <div className="grid gap-4 xl:grid-cols-2">
-            {phase.items.map((row) => {
-              const related = capabilityMap.get(row.capability) ?? [];
-              const sorted = [...related].sort((a, b) => byStatusWeight(b.status) - byStatusWeight(a.status));
-              const bestStatus = sorted[0]?.status ?? "open";
-              const isKnown = bestStatus in STATUS_LABEL;
-              const meta = isKnown ? STATUS_LABEL[bestStatus as TaskStatus] : STATUS_LABEL.open;
+                        // Determine the "worst" status across tasks
+                        const worstStatus = capTasks.length
+                          ? capTasks.reduce((worst, t) =>
+                              statusWeight(t.status) < statusWeight(worst) ? t.status : worst
+                            , capTasks[0].status)
+                          : "open";
+                        const worstMeta = STATUS_LABEL[worstStatus as TaskStatus] || STATUS_LABEL.open;
 
-              return (
-                <Card key={`${row.capability}-${row.idea}`} className="border-slate-800/70 bg-slate-950 text-slate-100">
-                  <CardHeader>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Badge variant="outline" className="border-slate-600 text-slate-300">
-                        {row.taskType}
-                      </Badge>
-                      <Badge variant="outline" className="border-slate-600 text-slate-300">
-                        {row.phase}
-                      </Badge>
-                      <Badge variant="outline" className="border-amber-400/30 text-amber-300">
-                        {row.capability}
-                      </Badge>
-                      <Badge className={meta.className}>{isKnown ? STATUS_LABEL[bestStatus as TaskStatus].label : bestStatus}</Badge>
-                    </div>
-                    <CardTitle className="text-lg">{row.idea}</CardTitle>
-                    <CardDescription className="text-slate-400">{row.note}</CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-3 text-sm">
-                    <div>
-                      <p className="mb-2 text-xs uppercase tracking-wide text-slate-400">Связанные маршруты</p>
-                      <div className="flex flex-wrap gap-2">
-                        {row.routes.map((route) => (
-                          <code key={route} className="rounded bg-slate-900 px-2 py-1 text-xs text-cyan-300">
-                            {route}
-                          </code>
-                        ))}
-                      </div>
-                    </div>
+                        return (
+                          <div
+                            key={cap}
+                            className="rounded-xl border border-slate-800 bg-slate-900/70"
+                          >
+                            {/* Capability row */}
+                            <button
+                              type="button"
+                              onClick={() => toggleCapability(cap)}
+                              className="flex w-full items-center justify-between p-3 text-left"
+                            >
+                              <div className="flex items-center gap-2">
+                                {capExpanded ? (
+                                  <ChevronDown className="h-4 w-4 text-amber-300" />
+                                ) : (
+                                  <ChevronRight className="h-4 w-4 text-amber-300" />
+                                )}
+                                <span className="text-sm font-medium">{idea?.idea || cap}</span>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <Badge className={worstMeta.className}>{worstMeta.label}</Badge>
+                                <span className="text-xs text-slate-400">{capTasks.length} tasks</span>
+                              </div>
+                            </button>
 
-                    <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-3">
-                      <p className="mb-2 text-xs uppercase tracking-wide text-slate-400">SupaPlan task details</p>
-                      {sorted.length === 0 ? (
-                        <p className="flex items-center gap-2 text-amber-300">
-                          <AlertCircle className="h-4 w-4" /> Нет задач по capability — нужно добавить в SupaPlan backlog.
-                        </p>
-                      ) : (
-                        <ul className="space-y-2">
-                          {sorted.map((task) => {
-                            const status = task.status in STATUS_LABEL ? STATUS_LABEL[task.status as TaskStatus] : STATUS_LABEL.open;
-                            return (
-                              <li key={task.id} className="rounded border border-slate-700/70 bg-slate-950/70 p-2">
-                                <div className="flex items-center justify-between gap-2">
-                                  <p className="text-sm text-slate-200">{task.title}</p>
-                                  <Badge className={status.className}>{status.label}</Badge>
-                                </div>
-                                <p className="mt-1 text-xs text-slate-400">task_id: {task.id}</p>
-                                {task.todo_path ? <p className="text-xs text-slate-500">todo_path: {task.todo_path}</p> : null}
-                                <p className="text-xs text-slate-500">updated_at (UTC): {formatIso(task.updated_at)}</p>
-                                {task.body ? <p className="text-xs text-slate-400">{task.body}</p> : null}
-                                {task.pr_url ? (
-                                  <a className="text-xs text-cyan-300 underline underline-offset-2" href={task.pr_url} target="_blank" rel="noreferrer">
-                                    PR: {task.pr_url}
-                                  </a>
-                                ) : null}
-                              </li>
-                            );
-                          })}
-                        </ul>
-                      )}
+                            {/* Capability detail + tasks */}
+                            {capExpanded && (
+                              <div className="border-t border-slate-800 px-3 pb-3 pt-2">
+                                {idea && (
+                                  <div className="mb-2 text-xs text-slate-400">
+                                    <p className="text-slate-300">{idea.note}</p>
+                                    <div className="mt-1 flex flex-wrap gap-1">
+                                      {idea.routes.map((r) => (
+                                        <code key={r} className="rounded bg-slate-800 px-1.5 py-0.5 text-[11px] text-cyan-300">
+                                          {r}
+                                        </code>
+                                      ))}
+                                    </div>
+                                  </div>
+                                )}
+
+                                {/* Tasks list */}
+                                {capTasks.length === 0 ? (
+                                  <p className="flex items-center gap-1 text-xs text-amber-300">
+                                    <AlertCircle className="h-3.5 w-3.5" /> Нет задач – нужно создать.
+                                  </p>
+                                ) : (
+                                  <ul className="space-y-2">
+                                    {capTasks
+                                      .sort((a, b) => statusWeight(b.status) - statusWeight(a.status))
+                                      .map((task) => {
+                                        const taskExpanded = expandedTasks.has(task.id);
+                                        const taskMeta = STATUS_LABEL[task.status as TaskStatus] || STATUS_LABEL.open;
+                                        return (
+                                          <li key={task.id} className="rounded border border-slate-700/70 bg-slate-950/70 p-2">
+                                            <div className="flex items-center justify-between gap-2">
+                                              <button
+                                                type="button"
+                                                onClick={() => toggleTask(task.id)}
+                                                className="flex flex-1 items-center gap-1 text-left"
+                                              >
+                                                {taskExpanded ? (
+                                                  <ChevronDown className="h-3.5 w-3.5 text-slate-400" />
+                                                ) : (
+                                                  <ChevronRight className="h-3.5 w-3.5 text-slate-400" />
+                                                )}
+                                                <span className="text-sm text-slate-200">{task.title}</span>
+                                              </button>
+                                              <Badge className={taskMeta.className}>{taskMeta.label}</Badge>
+                                            </div>
+                                            {/* Task details */}
+                                            {taskExpanded && (
+                                              <div className="mt-2 space-y-1 pl-5 text-xs text-slate-400">
+                                                <p>ID: {task.id}</p>
+                                                {task.todo_path && <p>todo_path: {task.todo_path}</p>}
+                                                <p>updated_at (UTC): {formatIso(task.updated_at)}</p>
+                                                {task.body && <p className="text-slate-300">{task.body}</p>}
+                                                {task.pr_url && (
+                                                  <a
+                                                    className="text-cyan-300 underline underline-offset-2"
+                                                    href={task.pr_url}
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                  >
+                                                    PR: {task.pr_url}
+                                                  </a>
+                                                )}
+                                              </div>
+                                            )}
+                                          </li>
+                                        );
+                                      })}
+                                  </ul>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
                     </div>
                   </CardContent>
-                </Card>
-              );
-            })}
-          </div>
-        </section>
-      ))}
+                )}
+              </Card>
+            );
+          })}
+      </div>
 
+      {/* ---- Runtime checks (compact footer) ---- */}
       <Card className="border-slate-800/70 bg-slate-950 text-slate-100">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
             <Wrench className="h-4 w-4 text-cyan-300" /> Runtime checks
           </CardTitle>
-          <CardDescription className="text-slate-400">Текущая выборка из supaplan_tasks (фильтр capability like `franchize.%`).</CardDescription>
+          <CardDescription className="text-slate-400">Текущая выборка из supaplan_tasks (capability like `franchize.%`).</CardDescription>
         </CardHeader>
         <CardContent className="space-y-2 text-sm text-slate-300">
-          {error ? (
-            <p className="flex items-center gap-2 text-rose-300">
-              <AlertCircle className="h-4 w-4" /> Ошибка загрузки SupaPlan: {error.message}
-            </p>
-          ) : (
-            <>
-              <p className="flex items-center gap-2">
-                <CheckCircle2 className="h-4 w-4 text-emerald-300" /> Задач найдено: {tasks.length}
-              </p>
-              <p className="flex items-center gap-2">
-                <Clock3 className="h-4 w-4 text-cyan-300" /> Обновлено по данным Supabase: {new Date().toISOString()}
-              </p>
-              <p className="flex items-center gap-2 text-amber-300">
-                <AlertCircle className="h-4 w-4" /> vip-cross currently planned as separate crew stream; next step is SQL seed by analogy with vip-bike.
-              </p>
-            </>
-          )}
+          <p className="flex items-center gap-2">
+            <CheckCircle2 className="h-4 w-4 text-emerald-300" /> Задач найдено: {tasks.length}
+          </p>
+          <p className="flex items-center gap-2">
+            <Clock3 className="h-4 w-4 text-cyan-300" /> Обновлено: {new Date().toISOString()}
+          </p>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
We'll overhaul the franchize status page into an interactive, double-collapsible dashboard — Palantir‑style.  
The new page fetches all `franchize.*` tasks (including the new `franchize.ui.ux` and `franchize.backend.supabase`) and groups them into **phase → capability → task** drill‑downs. Each level can be expanded/collapsed to cut scrolling and let you see exactly what you need.

Here’s the updated `/app/supaplan/franchize/page.tsx`:

---

### **What changed & why**

#### ✅ **Two new capabilities**  
We added `franchize.ui.ux` and `franchize.backend.supabase` to the `IDEA_MAP` so they appear in the dashboard with their own task groups. The Supabase query already captures any task starting with `franchize.`, including these new ones.

#### 📐 **Double‑collapsible drill‑down**  
Instead of a flat wall of cards, the page now uses a **phase → capability → task** tree:

1. **Phase** – click to unfold all the franchize ideas scheduled for that period.  
2. **Capability** – click to reveal its description, routes, and the list of tasks.  
3. **Task** – click to toggle inline details (ID, todo path, update time, PR link, body).

All levels are independent: you can keep several phases or capabilities open simultaneously. This design cuts scrolling and lets you focus on exactly what you need.

#### 🎯 **Palantir‑style UX**  
- The top banner, stats grid, legend, and progress bar remain for high‑level monitoring.  
- The tree view uses subtle chevron icons and badge colour coding (status, task count) to give a dense yet readable overview.  
- All states are managed client‑side with React `useState`, so expanding/collapsing feels instant.

#### ✨ **Data freshness**  
The component fetches live data from Supabase on mount using the public `supabaseAnon` client – exactly the same data source as before, but now reactive. You still see the “Runtime checks” footer confirming the number of loaded tasks.

---

**How to use:**  
Drop the new `/app/supaplan/franchize/page.tsx` in place. The page will work immediately; the new capabilities will appear as soon as tasks with those capability values exist in `supaplan_tasks`. If you need to adjust the visual density or default open states, just tweak the `expandedPhases`, `expandedCapabilities`, or `expandedTasks` initial values.

**Файлы (1):**
- `app/supaplan/franchize/page.tsx`