### PR TITLE
Enable 'buy' flow for sale-marked bikes: API flag, buy page, prefill/digest actions and migration

### DIFF
--- a/app/api/startapp/vehicle/route.ts
+++ b/app/api/startapp/vehicle/route.ts
@@ -15,12 +15,12 @@ export async function GET(request: NextRequest) {
 
   const { data: car } = await supabaseAdmin
     .from("cars")
-    .select("id, crew_id, owner_id")
+    .select("id, crew_id, owner_id, specs")
     .eq("id", vehicle)
     .maybeSingle();
 
   if (!car) {
-    return NextResponse.json({ slug: "vip-bike", vehicleId: vehicle, flow });
+    return NextResponse.json({ slug: "vip-bike", vehicleId: vehicle, flow, saleAvailable: false });
   }
 
   let slug = "vip-bike";
@@ -47,5 +47,8 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  return NextResponse.json({ slug, vehicleId: car.id, flow });
+  const rawSale = (car as { specs?: Record<string, unknown> }).specs?.sale;
+  const saleAvailable = rawSale === 1 || rawSale === true || String(rawSale).toLowerCase() === "1" || String(rawSale).toLowerCase() === "true";
+
+  return NextResponse.json({ slug, vehicleId: car.id, flow, saleAvailable });
 }

--- a/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
+++ b/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getFranchizeBySlug } from "@/app/franchize/actions";
+import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { SaleBikeLanding } from "@/app/franchize/components/SaleBikeLanding";
+
+interface BuyBikePageProps {
+  params: Promise<{ slug: string; bike_id: string }>;
+}
+
+const isSaleEnabled = (value: unknown) => value === 1 || value === true || String(value).toLowerCase() === "1" || String(value).toLowerCase() === "true";
+
+export default async function BuyBikePage({ params }: BuyBikePageProps) {
+  const { slug, bike_id } = await params;
+  const { crew, items } = await getFranchizeBySlug(slug);
+  const item = items.find((candidate) => candidate.id === bike_id);
+
+  if (!item) notFound();
+  if (!isSaleEnabled(item.rawSpecs?.sale)) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center gap-4 p-6 text-center" style={crewPaletteForSurface(crew.theme).page}>
+        <h1 className="text-2xl font-semibold">Этот байк не помечен как продажа</h1>
+        <p className="text-sm opacity-80">Откройте карточку через маркет и выберите аренду.</p>
+        <Link href={`/franchize/${slug}?vehicle=${encodeURIComponent(bike_id)}&flow=rent`} className="rounded-xl border px-4 py-2 text-sm font-semibold">Вернуться в маркет</Link>
+      </main>
+    );
+  }
+
+  return <SaleBikeLanding crew={crew} item={item} />;
+}

--- a/app/franchize/[slug]/profile/page.tsx
+++ b/app/franchize/[slug]/profile/page.tsx
@@ -13,6 +13,11 @@ import {
   grantFranchizeAchievementAction,
   type FranchizeAchievementDefinition,
   type FranchizeProfileState,
+  type FranchizeActivityDigest,
+  type FranchizeFormPrefill,
+  getFranchizeActivityDigestAction,
+  getFranchizeFormPrefillAction,
+  saveFranchizeFormPrefillAction,
 } from "@/app/franchize/profile-actions";
 
 export default function FranchizeProfilePage() {
@@ -23,6 +28,8 @@ export default function FranchizeProfilePage() {
   const [profile, setProfile] = useState<FranchizeProfileState | null>(null);
   const [capabilityContract, setCapabilityContract] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
+  const [digest, setDigest] = useState<FranchizeActivityDigest | null>(null);
+  const [prefill, setPrefill] = useState<FranchizeFormPrefill>({ fullName: "", phone: "", preferredTime: "", deliveryMode: "pickup", comment: "" });
 
   useEffect(() => {
     const run = async () => {
@@ -36,6 +43,12 @@ export default function FranchizeProfilePage() {
       setCatalog(result.catalog || []);
       const capabilities = await getFranchizeCapabilityContractAction();
       setCapabilityContract(capabilities);
+      const [digestRes, prefillRes] = await Promise.all([
+        getFranchizeActivityDigestAction({ slug, userId: dbUser.user_id }),
+        getFranchizeFormPrefillAction({ slug, userId: dbUser.user_id }),
+      ]);
+      if (digestRes.success && digestRes.data) setDigest(digestRes.data);
+      if (prefillRes.success && prefillRes.data) setPrefill(prefillRes.data);
       await grantFranchizeAchievementAction({
         slug,
         userId: dbUser.user_id,
@@ -50,6 +63,11 @@ export default function FranchizeProfilePage() {
 
   const unlockedSet = useMemo(() => new Set(Object.keys(profile?.achievements || {})), [profile?.achievements]);
   const unlockedCount = catalog.filter((item) => unlockedSet.has(item.id)).length;
+  const handlePrefillSave = async () => {
+    if (!dbUser?.user_id) return;
+    const res = await saveFranchizeFormPrefillAction({ slug, userId: dbUser.user_id, prefill });
+    if (!res.success) setError(res.error || "Не удалось сохранить поля.");
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-dark-bg via-black to-dark-card text-light-text p-4 pb-16">
@@ -110,6 +128,34 @@ export default function FranchizeProfilePage() {
               <p key={key} className="font-mono text-xs text-muted-foreground">
                 <span className="text-brand-cyan">{key}:</span> {value}
               </p>
+            ))}
+          </CardContent>
+        </Card>
+        <Card className="border-brand-green/30 bg-dark-card/70">
+          <CardHeader><CardTitle className="font-orbitron text-brand-green text-base">Префилл данных для аренды/покупки</CardTitle></CardHeader>
+          <CardContent className="grid grid-cols-1 gap-2 md:grid-cols-2">
+            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="ФИО" value={prefill.fullName} onChange={(e) => setPrefill((p) => ({ ...p, fullName: e.target.value }))} />
+            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="Телефон" value={prefill.phone} onChange={(e) => setPrefill((p) => ({ ...p, phone: e.target.value }))} />
+            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="Удобное время" value={prefill.preferredTime} onChange={(e) => setPrefill((p) => ({ ...p, preferredTime: e.target.value }))} />
+            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="Комментарий по умолчанию" value={prefill.comment} onChange={(e) => setPrefill((p) => ({ ...p, comment: e.target.value }))} />
+            <Button className="md:col-span-2" onClick={handlePrefillSave}>Сохранить профильные поля</Button>
+          </CardContent>
+        </Card>
+        <Card className="border-brand-yellow/30 bg-dark-card/70">
+          <CardHeader><CardTitle className="font-orbitron text-brand-yellow text-base">Аренды и покупки</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-xs text-muted-foreground">Текущие аренды</p>
+            {(digest?.rentals || []).slice(0, 5).map((r) => (
+              <Link key={r.rentalId} href={r.docLink} className="block rounded border p-2 text-sm">
+                <span className="font-semibold">{r.vehicleLabel}</span> · <span className="opacity-80">{r.status}</span>
+              </Link>
+            ))}
+            <p className="pt-2 text-xs text-muted-foreground">Планируемые покупки (sale)</p>
+            {(digest?.buyOrders || []).slice(0, 5).map((o) => (
+              <Link key={o.orderId} href={o.docLink} className="block rounded border p-2 text-sm">
+                Заказ #{o.orderId} · {o.status} · {o.vehicleIds.join(", ")}
+                {o.docFileName ? <span className="mt-1 block text-xs text-muted-foreground">Документ: {o.docFileName}</span> : null}
+              </Link>
             ))}
           </CardContent>
         </Card>

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -494,6 +494,7 @@ export function CatalogClient({ crew, slug, items }: CatalogClientProps) {
 
       <ItemModal
         item={selectedItem}
+        slug={crew.slug || slug}
         theme={crew.theme}
         options={selectedOptions}
         auctionOptions={auctionTickOptions}

--- a/app/franchize/components/OrderPageClient.tsx
+++ b/app/franchize/components/OrderPageClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { addDays } from "date-fns";
 import { toast } from "sonner";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -12,6 +12,7 @@ import type { CatalogItemVM, FranchizeCrewVM } from "../actions";
 import { createFranchizeOrderCheckout } from "../actions";
 import { useFranchizeCartLines } from "../hooks/useFranchizeCartLines";
 import { crewPaletteForSurface, focusRingOutlineStyle } from "../lib/theme";
+import { getFranchizeFormPrefillAction } from "../profile-actions";
 
 interface OrderPageClientProps {
   crew: FranchizeCrewVM;
@@ -85,7 +86,7 @@ type OrderFormValues = z.infer<typeof orderFormSchema>;
 const EMPTY_SELECTED_EXTRAS: string[] = [];
 
 export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientProps) {
-  const { user } = useAppContext();
+  const { user, dbUser } = useAppContext();
   const { cartLines, subtotal } = useFranchizeCartLines(slug, items);
   const [isSubmitting, startSubmitTransition] = useTransition();
   const form = useForm<OrderFormValues>({
@@ -133,6 +134,7 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
   const isCartEmpty = cartLines.length === 0;
   const saleLinesCount = useMemo(() => cartLines.filter((line) => line.saleAvailable).length, [cartLines]);
   const flowType: "rental" | "sale" | "mixed" = saleLinesCount === 0 ? "rental" : saleLinesCount === cartLines.length ? "sale" : "mixed";
+  const flowLabel = flowType === "sale" ? "покупки" : flowType === "mixed" ? "аренды/покупки" : "аренды";
   const selectedExtraItems = useMemo(
     () => orderExtras.filter((extra) => selectedExtras.includes(extra.id)),
     [selectedExtras],
@@ -156,11 +158,11 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
     () => [
       { id: "cart", label: "Байк выбран", done: !isCartEmpty },
       { id: "contact", label: "Контакт заполнен", done: recipient.trim().length > 1 && phone.trim().length > 5 && time.trim().length > 0 },
-      { id: "dates", label: "Период аренды выбран", done: Boolean(rentalStartDate) },
+      { id: "dates", label: `Период ${flowLabel} выбран`, done: Boolean(rentalStartDate) },
       { id: "signature", label: "Электронная подпись задана", done: signatureName.trim().length > 2 },
-      { id: "consent", label: "Условия подтверждены", done: consent },
+      { id: "consent", label: `Условия ${flowLabel} подтверждены`, done: consent },
     ],
-    [consent, isCartEmpty, phone, recipient, rentalStartDate, signatureName, time],
+    [consent, flowLabel, isCartEmpty, phone, recipient, rentalStartDate, signatureName, time],
   );
   const completedMilestones = checkoutMilestones.filter((step) => step.done).length;
   const readinessPercent = Math.round((completedMilestones / checkoutMilestones.length) * 100);
@@ -170,12 +172,12 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
       { id: "recipient", label: "Укажите имя получателя", active: recipient.trim().length <= 1 },
       { id: "phone", label: "Добавьте контактный номер", active: phone.trim().length <= 5 },
       { id: "time", label: "Выберите удобное время", active: time.trim().length === 0 },
-      { id: "dates", label: "Выберите дату начала аренды", active: !rentalStartDate },
+      { id: "dates", label: `Выберите дату начала ${flowLabel}`, active: !rentalStartDate },
       { id: "signature", label: "Введите ФИО для электронной подписи", active: signatureName.trim().length <= 2 },
-      { id: "consent", label: "Подтвердите условия аренды", active: !consent },
+      { id: "consent", label: `Подтвердите условия ${flowLabel}`, active: !consent },
       { id: "telegram", label: "Для Stars откройте страницу через Telegram WebApp", active: requiresTelegram && !hasTelegramUser },
     ].filter((item) => item.active),
-    [consent, hasTelegramUser, isCartEmpty, phone, recipient, rentalStartDate, requiresTelegram, signatureName, time],
+    [consent, flowLabel, hasTelegramUser, isCartEmpty, phone, recipient, rentalStartDate, requiresTelegram, signatureName, time],
   );
   const nextAction = checkoutBlockers[0];
 
@@ -218,14 +220,28 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
   const submitHint = isSubmitting
     ? "Проверяем данные и отправляем действие оплаты. Обычно это занимает несколько секунд."
     : isCartEmpty
-      ? "Добавьте хотя бы один байк в корзину, чтобы перейти к подтверждению."
+      ? `Добавьте хотя бы один байк в корзину, чтобы перейти к подтверждению ${flowLabel}.`
       : !consent
-        ? "Подтвердите согласие с условиями аренды, чтобы отправить заказ."
+        ? `Подтвердите согласие с условиями ${flowLabel}, чтобы отправить заказ.`
         : requiresTelegram && !hasTelegramUser
           ? "Для оплаты Stars откройте оформление из Telegram WebApp и повторите попытку."
           : payment === "telegram_xtr"
             ? "XTR-счёт будет рассчитан как 1% от полной суммы (с учётом доп. опций)."
             : "Проверьте контакты и способ получения, затем подтверждайте заказ.";
+
+  useEffect(() => {
+    const loadPrefill = async () => {
+      if (!dbUser?.user_id) return;
+      const res = await getFranchizeFormPrefillAction({ userId: dbUser.user_id, slug });
+      if (!res.success || !res.data) return;
+      setValue("recipient", res.data.fullName || "");
+      setValue("phone", res.data.phone || "");
+      setValue("time", res.data.preferredTime || "");
+      setValue("comment", res.data.comment || "");
+      setValue("deliveryMode", res.data.deliveryMode || "pickup");
+    };
+    void loadPrefill();
+  }, [dbUser?.user_id, setValue, slug]);
 
   const onSubmitValid = (values: OrderFormValues) => {
     if (isSubmitting || !canSubmit) {

--- a/app/franchize/components/SaleBikeLanding.tsx
+++ b/app/franchize/components/SaleBikeLanding.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { ArrowLeft, Gauge, Battery, Zap, Weight, Timer, ShoppingBag, PhoneCall, Tag } from "lucide-react";
+import type { CatalogItemVM, FranchizeCrewVM } from "@/app/franchize/actions";
+import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+
+export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: CatalogItemVM }) {
+  const surface = crewPaletteForSurface(crew.theme);
+  const gallery = item.mediaUrls?.length ? item.mediaUrls : [item.imageUrl].filter(Boolean);
+  const specs = item.rawSpecs || {};
+  const buyPrice = Number(specs.price_rub || specs.sale_price || 0);
+
+  const cards = [
+    { label: "Тип", value: item.category, icon: Tag },
+    { label: "Мощность", value: String(specs.power_kw || specs.motor_peak_kw || "—"), icon: Zap },
+    { label: "Батарея", value: String(specs.battery || "—"), icon: Battery },
+    { label: "Запас хода", value: `${specs.range_km || "—"} км`, icon: Gauge },
+    { label: "Макс. скорость", value: `${specs.top_speed_kmh || "—"} км/ч`, icon: Gauge },
+    { label: "Вес", value: `${specs.weight_kg || "—"} кг`, icon: Weight },
+    { label: "Зарядка", value: `${specs.charge_time_h || "—"} ч`, icon: Timer },
+    { label: "Привод", value: String(specs.drive || "—"), icon: ShoppingBag },
+  ];
+
+  return (
+    <main className="min-h-screen p-3 pb-24 sm:p-6" style={surface.page}>
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+        <div className="flex items-center justify-between gap-2">
+          <Link href={`/franchize/${crew.slug}?vehicle=${item.id}&flow=buy`} className="inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm" style={surface.subtleCard}><ArrowLeft className="h-4 w-4"/>В маркет</Link>
+          <span className="rounded-full border px-3 py-1 text-xs font-semibold" style={surface.subtleCard}>На продажу</span>
+        </div>
+
+        <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className="overflow-hidden rounded-3xl border" style={surface.card}>
+          <div className="grid lg:grid-cols-[1.35fr_1fr]">
+            <div className="space-y-2 p-2">
+              <div className="aspect-[9/16] w-full overflow-hidden rounded-2xl bg-black/30">
+                <img src={gallery[0]} alt={item.title} className="h-full w-full object-cover" />
+              </div>
+              <div className="grid grid-cols-4 gap-2">
+                {gallery.slice(0, 4).map((img, i) => <img key={`${img}-${i}`} src={img} alt={`${item.title}-${i}`} className="aspect-[9/16] w-full rounded-xl object-cover" />)}
+              </div>
+            </div>
+            <div className="flex flex-col gap-3 p-4">
+              <h1 className="text-3xl font-semibold">{item.title}</h1>
+              <p className="text-sm opacity-80">{item.description}</p>
+              <div className="rounded-2xl border p-4" style={surface.subtleCard}>
+                <p className="text-xs opacity-70">Цена продажи</p>
+                <p className="text-3xl font-bold">{buyPrice > 0 ? `${buyPrice.toLocaleString("ru-RU")} ₽` : "по запросу"}</p>
+              </div>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <Link href={`/franchize/${crew.slug}/cart?source=buy&bike=${item.id}`} className="rounded-xl px-4 py-3 text-center font-semibold" style={{ ...surface.subtleCard, background: crew.theme.palette.accentMain, color: "#101010" }}>Написать продавцу</Link>
+                <Link href={`tel:${crew.contacts?.phone || "+79999005588"}`} className="inline-flex items-center justify-center gap-2 rounded-xl border px-4 py-3 text-center font-semibold"><PhoneCall className="h-4 w-4"/>Позвонить</Link>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2 p-3 sm:grid-cols-4">
+            {cards.map((card) => (
+              <div key={card.label} className="rounded-2xl border p-3" style={surface.subtleCard}>
+                <card.icon className="mb-2 h-4 w-4 opacity-80" />
+                <p className="text-xs opacity-70">{card.label}</p>
+                <p className="text-sm font-semibold">{card.value}</p>
+              </div>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </main>
+  );
+}

--- a/app/franchize/modals/Item.tsx
+++ b/app/franchize/modals/Item.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Info, X } from "lucide-react";
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CatalogItemVM, FranchizeTheme } from "../actions";
 import { ItemGallery } from "../components/ItemGallery";
@@ -8,6 +9,7 @@ import { crewPaletteForSurface } from "../lib/theme";
 
 interface ItemModalProps {
   item: CatalogItemVM | null;
+  slug: string;
   theme: FranchizeTheme;
   options: {
     package: string;
@@ -71,7 +73,7 @@ function OptionChips({
   );
 }
 
-export function ItemModal({ item, theme, options, auctionOptions, onChangeOption, onClose, onAddToCart }: ItemModalProps) {
+export function ItemModal({ item, slug, theme, options, auctionOptions, onChangeOption, onClose, onAddToCart }: ItemModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [activeMediaIndex, setActiveMediaIndex] = useState(0);
@@ -235,6 +237,15 @@ export function ItemModal({ item, theme, options, auctionOptions, onChangeOption
                 ))}
               </div>
             </div>
+            {item.saleAvailable && (
+              <Link
+                href={`/franchize/${slug}/market/${item.id}/buy`}
+                className="inline-flex w-full items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium transition hover:opacity-90"
+                style={surface.subtleCard}
+              >
+                Открыть страницу покупки
+              </Link>
+            )}
 
             <OptionChips title="Пакет" options={packageOptions} selected={options.package} onSelect={(v) => onChangeOption("package", v)} />
             <OptionChips title="Срок" options={durationOptions} selected={options.duration} onSelect={(v) => onChangeOption("duration", v)} />

--- a/app/franchize/profile-actions.ts
+++ b/app/franchize/profile-actions.ts
@@ -24,6 +24,19 @@ export type FranchizeProfileState = {
   lastActivityAt: string;
 };
 
+export type FranchizeFormPrefill = {
+  fullName: string;
+  phone: string;
+  preferredTime: string;
+  deliveryMode: "pickup" | "delivery";
+  comment: string;
+};
+
+export type FranchizeActivityDigest = {
+  rentals: Array<{ rentalId: string; status: string; vehicleId: string; vehicleLabel: string; docLink: string }>;
+  buyOrders: Array<{ orderId: string; status: string; vehicleIds: string[]; docLink: string; createdAt: string; docFileName?: string }>;
+};
+
 const FRANCHIZE_ACHIEVEMENT_CAPABILITIES = {
   onboarding: "Tracks onboarding participation (/start survey completion) and marks crew-level readiness.",
   operations: "Tracks recurring crew operations and delivery signals for franchize execution.",
@@ -42,6 +55,14 @@ const DEFAULT_PROFILE = (slug: string): FranchizeProfileState => ({
   counters: {},
   lastActivityAt: new Date(0).toISOString(),
 });
+
+const DEFAULT_PREFILL: FranchizeFormPrefill = {
+  fullName: "",
+  phone: "",
+  preferredTime: "",
+  deliveryMode: "pickup",
+  comment: "",
+};
 
 function getCatalogBySlug(slug: string): FranchizeAchievementDefinition[] {
   const shared: FranchizeAchievementDefinition[] = [
@@ -177,4 +198,68 @@ export async function grantFranchizeAchievementAction(params: {
 
   if (updateError) return { success: false, error: updateError.message };
   return { success: true, alreadyUnlocked };
+}
+
+export async function getFranchizeFormPrefillAction(params: { userId: string; slug: string }): Promise<{ success: boolean; data?: FranchizeFormPrefill; error?: string }> {
+  const { data: user, error } = await supabaseAdmin.from("users").select("metadata").eq("user_id", params.userId).maybeSingle();
+  if (error) return { success: false, error: error.message };
+  const metadata = (user?.metadata || {}) as Record<string, any>;
+  const prefill = metadata.franchizeFormPrefill?.[params.slug] ?? metadata.franchizeFormPrefill?.default ?? DEFAULT_PREFILL;
+  return { success: true, data: { ...DEFAULT_PREFILL, ...(prefill as Record<string, unknown>) } as FranchizeFormPrefill };
+}
+
+export async function saveFranchizeFormPrefillAction(params: { userId: string; slug: string; prefill: FranchizeFormPrefill }): Promise<{ success: boolean; error?: string }> {
+  const { data: user, error } = await supabaseAdmin.from("users").select("metadata").eq("user_id", params.userId).maybeSingle();
+  if (error) return { success: false, error: error.message };
+  const metadata = (user?.metadata || {}) as Record<string, any>;
+  const next = {
+    ...metadata,
+    franchizeFormPrefill: {
+      ...(metadata.franchizeFormPrefill || {}),
+      [params.slug]: params.prefill,
+    },
+  };
+  const { error: updateError } = await supabaseAdmin.from("users").update({ metadata: next, updated_at: new Date().toISOString() }).eq("user_id", params.userId);
+  return updateError ? { success: false, error: updateError.message } : { success: true };
+}
+
+export async function getFranchizeActivityDigestAction(params: { userId: string; slug: string }): Promise<{ success: boolean; data?: FranchizeActivityDigest; error?: string }> {
+  const { data: rentals, error: rentalsError } = await supabaseAdmin
+    .from("rentals")
+    .select("rental_id,status,vehicle_id,vehicle:cars(make,model)")
+    .or(`user_id.eq.${params.userId},owner_id.eq.${params.userId}`)
+    .order("created_at", { ascending: false })
+    .limit(20);
+  if (rentalsError) return { success: false, error: rentalsError.message };
+
+  const { data: orders, error: ordersError } = await supabaseAdmin
+    .from("franchize_order_notifications")
+    .select("order_id,send_status,payload,created_at,doc_file_name")
+    .eq("slug", params.slug)
+    .order("created_at", { ascending: false })
+    .limit(20);
+  if (ordersError) return { success: false, error: ordersError.message };
+
+  return {
+    success: true,
+    data: {
+      rentals: (rentals || []).map((r: any) => ({
+        rentalId: r.rental_id,
+        status: r.status || "unknown",
+        vehicleId: r.vehicle_id || "",
+        vehicleLabel: `${r.vehicle?.make || "Bike"} ${r.vehicle?.model || ""}`.trim(),
+        docLink: `/rentals/${r.rental_id}`,
+      })),
+      buyOrders: (orders || [])
+        .filter((o: any) => ["sale", "mixed"].includes(String(o?.payload?.flowType || "")))
+        .map((o: any) => ({
+          orderId: o.order_id,
+          status: o.send_status || "pending",
+          vehicleIds: Array.isArray(o?.payload?.cartLines) ? o.payload.cartLines.map((l: any) => String(l.itemId || "")) : [],
+          docLink: `/franchize/${params.slug}/order/${o.order_id}`,
+          createdAt: o.created_at,
+          docFileName: typeof o.doc_file_name === "string" ? o.doc_file_name : "",
+        })),
+    },
+  };
 }

--- a/hooks/useStartParamRouter.ts
+++ b/hooks/useStartParamRouter.ts
@@ -115,6 +115,10 @@ export function useStartParamRouter() {
         const slug = (data.slug || "vip-bike").trim() || "vip-bike";
         const resolvedVehicle = (data.vehicleId || vehicleId).trim().toLowerCase();
         const resolvedFlow = data.flow === "buy" ? "buy" : "rent";
+        const saleAvailable = Boolean((data as { saleAvailable?: boolean }).saleAvailable);
+        if (resolvedFlow === "buy" && saleAvailable) {
+          return `/franchize/${slug}/market/${encodeURIComponent(resolvedVehicle)}/buy`;
+        }
         return `/franchize/${slug}?vehicle=${encodeURIComponent(resolvedVehicle)}&flow=${resolvedFlow}`;
       } catch (error) {
         logger.warn("[ClientLayout] failed to resolve vehicle deep-link, using vip-bike fallback", { rawParam, error });

--- a/supabase/migrations/20260430110000_fix_sale_bikes_yvolt_falcon.sql
+++ b/supabase/migrations/20260430110000_fix_sale_bikes_yvolt_falcon.sql
@@ -1,0 +1,87 @@
+-- Correct sale bikes set: 3 Y-VOLT variants + 1 Falcon GT (source-corrected)
+DELETE FROM public.cars WHERE id IN (
+  'yvolt-surge-v-pro',
+  'falcon-gt-2025',
+  'yvolt-surge-v-core',
+  'yvolt-surge-v-street',
+  'yvolt-surge-v-trail'
+);
+
+INSERT INTO public.cars (
+  id, make, model, description, daily_price, image_url, rent_link, is_test_result, type, specs, owner_id, crew_id
+)
+VALUES
+(
+  'yvolt-surge-v-core', 'Y-VOLT', 'Surge V Core',
+  'Электромотоцикл Y-VOLT Surge V из официальной линейки. Подходит для города и легкого бездорожья.',
+  4200,
+  'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/yvolt-surge-v-core/image_1.png',
+  '/rent/yvolt-surge-v-core', false, 'bike',
+  jsonb_build_object(
+    'type','Electric','subtitle','Y-VOLT Surge V Core','bike_subtype','Electric Enduro','sale',1,'price_rub',420000,
+    'power_kw','15','motor_peak_kw','35','battery','97.2V 45Ah (4.3 kWh, Samsung)','range_km','120-150','top_speed_kmh','110',
+    'torque_nm','900+','weight_kg','92','charge_time_h','3','seat_height_mm','900','drive','Chain',
+    'brand_type','official','year','2025','source','https://www.yvolt.com/products/surge-v',
+    'gallery',jsonb_build_array('https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/yvolt-surge-v-core/image_1.png')
+  ),
+  '356282674','2d5fde70-1dd3-4f0d-8d72-66ccf6908746'
+),
+(
+  'yvolt-surge-v-street', 'Y-VOLT', 'Surge V Street',
+  'Электромотоцикл Y-VOLT Surge V из официальной линейки. Подходит для города и легкого бездорожья.',
+  4500,
+  'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/yvolt-surge-v-street/image_1.png',
+  '/rent/yvolt-surge-v-street', false, 'bike',
+  jsonb_build_object(
+    'type','Electric','subtitle','Y-VOLT Surge V Street','bike_subtype','Electric Enduro','sale',1,'price_rub',450000,
+    'power_kw','15','motor_peak_kw','35','battery','97.2V 45Ah (4.3 kWh, Samsung)','range_km','120-150','top_speed_kmh','110',
+    'torque_nm','900+','weight_kg','92','charge_time_h','3','seat_height_mm','900','drive','Chain',
+    'brand_type','official','year','2025','source','https://www.yvolt.com/products/surge-v',
+    'gallery',jsonb_build_array('https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/yvolt-surge-v-street/image_1.png')
+  ),
+  '356282674','2d5fde70-1dd3-4f0d-8d72-66ccf6908746'
+),
+(
+  'yvolt-surge-v-trail', 'Y-VOLT', 'Surge V Trail',
+  'Электромотоцикл Y-VOLT Surge V из официальной линейки. Подходит для города и легкого бездорожья.',
+  4700,
+  'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/yvolt-surge-v-trail/image_1.png',
+  '/rent/yvolt-surge-v-trail', false, 'bike',
+  jsonb_build_object(
+    'type','Electric','subtitle','Y-VOLT Surge V Trail','bike_subtype','Electric Enduro','sale',1,'price_rub',470000,
+    'power_kw','15','motor_peak_kw','35','battery','97.2V 45Ah (4.3 kWh, Samsung)','range_km','120-150','top_speed_kmh','110',
+    'torque_nm','900+','weight_kg','92','charge_time_h','3','seat_height_mm','900','drive','Chain',
+    'brand_type','official','year','2025','source','https://www.yvolt.com/products/surge-v',
+    'gallery',jsonb_build_array('https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/yvolt-surge-v-trail/image_1.png')
+  ),
+  '356282674','2d5fde70-1dd3-4f0d-8d72-66ccf6908746'
+),
+(
+  'falcon-gt-2025', '79BIKE', 'Falcon GT',
+  'Мощный электрический эндуро-байк для бездорожья. Высокая динамика, легкий вес и адаптивная электроника.',
+  0,
+  'https://falcon-bike.ru/assets/images/falcon-gt.jpg',
+  '/rent/falcon-gt-2025', false, 'bike',
+  jsonb_build_object(
+    'type','Electric','subtitle','Falcon GT 2025','bike_subtype','Electric Enduro','sale',1,'price_rub',420000,
+    'power_kw','16-17','motor_peak_kw','17','battery','72V 40Ah (Samsung 50S)','range_km','120','top_speed_kmh','100',
+    'torque_nm','610','weight_kg','69','charge_time_h','3-4','seat_height_mm','820','drive','Chain',
+    'brand_type','official_reseller','year','2025',
+    'features',jsonb_build_array('NFC старт','FOC контроллер','FASTACE подвеска'),
+    'source','https://falcon-bike.ru/falcongt',
+    'gallery',jsonb_build_array('https://falcon-bike.ru/assets/images/falcon-gt.jpg')
+  ),
+  '356282674','2d5fde70-1dd3-4f0d-8d72-66ccf6908746'
+)
+ON CONFLICT (id) DO UPDATE SET
+  make = EXCLUDED.make,
+  model = EXCLUDED.model,
+  description = EXCLUDED.description,
+  daily_price = EXCLUDED.daily_price,
+  image_url = EXCLUDED.image_url,
+  rent_link = EXCLUDED.rent_link,
+  is_test_result = EXCLUDED.is_test_result,
+  type = EXCLUDED.type,
+  specs = EXCLUDED.specs,
+  owner_id = EXCLUDED.owner_id,
+  crew_id = EXCLUDED.crew_id;


### PR DESCRIPTION
### Motivation
- Enable a proper purchase (buy) flow for bikes that are marked for sale, surface a dedicated landing page and deep-link directly to it. 
- Persist and reuse user prefill values for order forms and surface a compact activity digest in franchize profile to surface recent rentals and buy orders. 
- Pass contextual slug to item modals so the UI can link to the new buy pages. 
- Ensure database has correct sale-marked bikes via a migration.

### Description
- Updated `/api/startapp/vehicle` to select `specs` from `cars` and return a normalized `saleAvailable` boolean derived from `specs.sale`. 
- Enhanced client deep-link resolver in `useStartParamRouter` to route `flow=buy` to `/franchize/{slug}/market/{vehicle}/buy` when `saleAvailable` is true. 
- Passed `slug` from `CatalogClient` into `ItemModal` and added a buy link and adjusted CTAs in `ItemModal` that render when `item.saleAvailable` is true. 
- Added `SaleBikeLanding` component and a new page at `app/franchize/[slug]/market/[bike_id]/buy/page.tsx` that validates the item sale flag and renders a sale landing or a message directing users back to rental flow. 
- Extended `profile-actions.ts` with `FranchizeFormPrefill` and `FranchizeActivityDigest` types, plus `getFranchizeFormPrefillAction`, `saveFranchizeFormPrefillAction` and `getFranchizeActivityDigestAction` server actions to load/save prefill and to produce a compact activity digest. 
- Wired profile and order UI: `FranchizeProfilePage` now loads digest and prefill and exposes a prefill editor, and `OrderPageClient` fetches and applies saved prefill values and updates labels/messages to reflect rental/sale/mixed flows. 
- Added a supabase migration `20260430110000_fix_sale_bikes_yvolt_falcon.sql` to insert/update a corrected set of sale-marked bikes (Y-VOLT variants and Falcon GT). 

### Testing
- Ran TypeScript type-check and a Next.js build (`tsc` / `next build`) against the modified code and the build completed successfully. 
- No automated unit tests were added, and existing test suites were not changed as part of this patch. 
- Basic automated API response shape checks were validated by the type-check/build process and reported no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f306ddc4948324b7e5ec36b1a106bc)