### PR TITLE
Fix buy page sale detection, startapp buy deep-links, and profile digest privacy

### DIFF
--- a/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
+++ b/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
@@ -16,7 +16,7 @@ export default async function BuyBikePage({ params }: BuyBikePageProps) {
   const item = items.find((candidate) => candidate.id === bike_id);
 
   if (!item) notFound();
-  if (!isSaleEnabled(item.rawSpecs?.sale)) {
+  if (!item.saleAvailable && !isSaleEnabled(item.rawSpecs?.sale)) {
     return (
       <main className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center gap-4 p-6 text-center" style={crewPaletteForSurface(crew.theme).page}>
         <h1 className="text-2xl font-semibold">Этот байк не помечен как продажа</h1>

--- a/app/franchize/actions.ts
+++ b/app/franchize/actions.ts
@@ -94,6 +94,7 @@ export interface CatalogItemVM {
   saleAvailable: boolean;
   salePrice: number | null;
   specs: Array<{ label: string; value: string }>;
+  rawSpecs?: Record<string, unknown>;
 }
 
 export interface FranchizeCrewVM {
@@ -740,6 +741,7 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
             : Number(readPath(specs, ["purchase_price"], 0)) > 0
               ? Number(readPath(specs, ["purchase_price"], 0))
               : null,
+        rawSpecs: specs,
         specs: Object.entries(specs)
           .filter(([, value]) => typeof value === "string" || typeof value === "number")
           .filter(([key]) => !["subtitle", "description", "segment", "subtype", "bike_subtype", "type"].includes(key))

--- a/app/franchize/components/SaleBikeLanding.tsx
+++ b/app/franchize/components/SaleBikeLanding.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { ArrowLeft, Gauge, Battery, Zap, Weight, Timer, ShoppingBag, PhoneCall, Tag } from "lucide-react";
+import { ArrowLeft, Gauge, Battery, Zap, Weight, Timer, ShoppingBag, PhoneCall, Tag, Sparkles, ShieldCheck } from "lucide-react";
 import type { CatalogItemVM, FranchizeCrewVM } from "@/app/franchize/actions";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 
@@ -42,14 +42,16 @@ export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: C
               </div>
             </div>
             <div className="flex flex-col gap-3 p-4">
-              <h1 className="text-3xl font-semibold">{item.title}</h1>
+              <div className="inline-flex w-fit items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold" style={surface.subtleCard}><Sparkles className="h-3.5 w-3.5" />Premium eMoto</div>
+              <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">{item.title}</h1>
               <p className="text-sm opacity-80">{item.description}</p>
               <div className="rounded-2xl border p-4" style={surface.subtleCard}>
-                <p className="text-xs opacity-70">Цена продажи</p>
-                <p className="text-3xl font-bold">{buyPrice > 0 ? `${buyPrice.toLocaleString("ru-RU")} ₽` : "по запросу"}</p>
+                <p className="text-xs uppercase tracking-[0.16em] opacity-70">Цена продажи</p>
+                <p className="text-3xl font-bold sm:text-4xl">{buyPrice > 0 ? `${buyPrice.toLocaleString("ru-RU")} ₽` : "по запросу"}</p>
+                <p className="mt-2 inline-flex items-center gap-2 text-xs opacity-80"><ShieldCheck className="h-3.5 w-3.5" />Официальная сделка + документы</p>
               </div>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                <Link href={`/franchize/${crew.slug}/cart?source=buy&bike=${item.id}`} className="rounded-xl px-4 py-3 text-center font-semibold" style={{ ...surface.subtleCard, background: crew.theme.palette.accentMain, color: "#101010" }}>Написать продавцу</Link>
+                <Link href={`/franchize/${crew.slug}/cart?source=buy&bike=${item.id}`} className="rounded-xl px-4 py-3 text-center font-semibold" style={{ ...surface.subtleCard, background: crew.theme.palette.accentMain, color: "#101010" }}>Оставить заявку на покупку</Link>
                 <Link href={`tel:${crew.contacts?.phone || "+79999005588"}`} className="inline-flex items-center justify-center gap-2 rounded-xl border px-4 py-3 text-center font-semibold"><PhoneCall className="h-4 w-4"/>Позвонить</Link>
               </div>
             </div>

--- a/app/franchize/profile-actions.ts
+++ b/app/franchize/profile-actions.ts
@@ -236,6 +236,7 @@ export async function getFranchizeActivityDigestAction(params: { userId: string;
     .from("franchize_order_notifications")
     .select("order_id,send_status,payload,created_at,doc_file_name")
     .eq("slug", params.slug)
+    .eq("payload->>telegramUserId", params.userId)
     .order("created_at", { ascending: false })
     .limit(20);
   if (ordersError) return { success: false, error: ordersError.message };

--- a/hooks/useStartParamRouter.ts
+++ b/hooks/useStartParamRouter.ts
@@ -116,12 +116,15 @@ export function useStartParamRouter() {
         const resolvedVehicle = (data.vehicleId || vehicleId).trim().toLowerCase();
         const resolvedFlow = data.flow === "buy" ? "buy" : "rent";
         const saleAvailable = Boolean((data as { saleAvailable?: boolean }).saleAvailable);
-        if (resolvedFlow === "buy" && saleAvailable) {
+        if (resolvedFlow === "buy") {
           return `/franchize/${slug}/market/${encodeURIComponent(resolvedVehicle)}/buy`;
         }
         return `/franchize/${slug}?vehicle=${encodeURIComponent(resolvedVehicle)}&flow=${resolvedFlow}`;
       } catch (error) {
         logger.warn("[ClientLayout] failed to resolve vehicle deep-link, using vip-bike fallback", { rawParam, error });
+        if (flow === "buy") {
+          return `/franchize/vip-bike/market/${encodeURIComponent(vehicleId)}/buy`;
+        }
         return `/franchize/vip-bike?vehicle=${encodeURIComponent(vehicleId)}&flow=${flow}`;
       }
     },


### PR DESCRIPTION
### Motivation
- The buy page could show a false-negative "not for sale" when `cars.specs.sale = 1` because the buy page relied on a raw-specs path that wasn't always present on the mapped item VM. 
- Telegram WebApp `startapp=buy_<id>` deep-links should open the bike's buy page directly instead of falling back to the generic franchize market view. 
- The franchize profile activity digest exposed order metadata across users because the notifications query was only scoped by `slug` and not by the requesting user.

### Description
- Added `rawSpecs?: Record<string, unknown>` to the `CatalogItemVM` and populated it from `cars.specs` in `getFranchizeBySlug` so the buy page can reliably inspect original JSON specs (`app/franchize/actions.ts`).
- Fixed buy visibility check in the buy page to use the normalized `saleAvailable` flag and preserve raw-specs fallback: `if (!item.saleAvailable && !isSaleEnabled(item.rawSpecs?.sale))` (`app/franchize/[slug]/market/[bike_id]/buy/page.tsx`).
- Updated startapp vehicle resolver so `buy_<bikeId>` resolves to `/franchize/{slug}/market/{bike_id}/buy` (no silent fallback to market) and added a buy-specific fallback path (`hooks/useStartParamRouter.ts`).
- Restricted franchize activity digest query to the requesting user by adding a Postgres JSON-path filter on the notification payload: `.eq("payload->>telegramUserId", params.userId)` to prevent cross-user exposure (`app/franchize/profile-actions.ts`).
- Polished the buy landing UI (`app/franchize/components/SaleBikeLanding.tsx`) with a premium badge, improved price block, trust cue, and updated CTA copy for a higher-quality presentation.

### Testing
- Ran `npm run -s lint`; the lint step failed due to pre-existing repo-wide rule violations and unrelated errors elsewhere in the project, not introduced by these changes. 
- Verified the modified files do not introduce new lint errors for the changed code paths based on the lint output inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f363d6ce188324a23c1720723f9821)