### PR TITLE
feat(franchize): electro-enduro page, group sale bikes, fix buy->cart flow

### DIFF
--- a/app/franchize/[slug]/electro-enduro/page.tsx
+++ b/app/franchize/[slug]/electro-enduro/page.tsx
@@ -1,0 +1,26 @@
+import { CrewFooter } from "../../components/CrewFooter";
+import { CrewHeader } from "../../components/CrewHeader";
+import { CatalogClient } from "../../components/CatalogClient";
+import { getFranchizeBySlug } from "../../actions";
+import { crewPaletteForSurface } from "../../lib/theme";
+
+interface ElectroEnduroPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+const isSaleEnabled = (value: unknown) => value === 1 || value === true || String(value).toLowerCase() === "1" || String(value).toLowerCase() === "true";
+
+export default async function ElectroEnduroPage({ params }: ElectroEnduroPageProps) {
+  const { slug } = await params;
+  const { crew, items } = await getFranchizeBySlug(slug);
+  const surface = crewPaletteForSurface(crew.theme);
+  const saleItems = items.filter((item) => item.saleAvailable || isSaleEnabled(item.rawSpecs?.sale));
+
+  return (
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/electro-enduro`} groupLinks={saleItems.map((item) => item.category)} />
+      <CatalogClient crew={crew} slug={slug} items={saleItems} mode="electro" />
+      <CrewFooter crew={crew} />
+    </main>
+  );
+}

--- a/app/franchize/actions.ts
+++ b/app/franchize/actions.ts
@@ -310,6 +310,8 @@ const defaultFranchizeConfig: FranchizeConfigInput = {
   socialLinksText: "Telegram|https://t.me/oneBikePlsBot",
   menuLinksText: [
     "Каталог|/franchize/{slug}",
+    "Электроэндуро|/franchize/{slug}/electro-enduro",
+    "Конфигуратор|/franchize/{slug}/configurator",
     "Map Riders|/franchize/{slug}/map-riders",
     "О нас|/franchize/{slug}/about",
     "Контакты|/franchize/{slug}/contacts",
@@ -348,6 +350,8 @@ function readPath<T>(obj: unknown, path: string[], fallback: T): T {
 
 const fallbackMenuLinks = (slug: string) => [
   { label: "Каталог", href: `/franchize/${slug}` },
+  { label: "Электроэндуро", href: `/franchize/${slug}/electro-enduro` },
+  { label: "Конфигуратор", href: `/franchize/${slug}/configurator` },
   { label: "Map Riders", href: `/franchize/${slug}/map-riders` },
   { label: "О нас", href: `/franchize/${slug}/about` },
   { label: "Контакты", href: `/franchize/${slug}/contacts` },

--- a/app/franchize/components/CartPageClient.tsx
+++ b/app/franchize/components/CartPageClient.tsx
@@ -8,7 +8,6 @@ import { useFranchizeCart } from "../hooks/useFranchizeCart"; // Import cart sta
 import { crewPaletteForSurface } from "../lib/theme";
 import { saveUserFranchizeCartAction } from "@/contexts/actions"; // Explicit import
 import { useAppContext } from "@/contexts/AppContext";
-import { Link } from "lucide-react"; // Wait, removing this, using next/link if needed but using router mostly
 
 interface CartPageClientProps {
   crew: FranchizeCrewVM;
@@ -29,7 +28,9 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
     if (buyFlowApplied || typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     if (params.get("source") !== "buy") return;
-    const bikeId = (params.get("bike") || "").trim();
+    const bikeId = (params.get("bike_id") || params.get("bike") || params.get("vehicle") || params.get("item") || "").trim();
+    const shouldAdd = params.get("add");
+    if (shouldAdd === "0" || shouldAdd === "false") return;
     if (!bikeId) return;
     if (!items.some((item) => item.id === bikeId)) return;
 

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -16,6 +16,7 @@ interface CatalogClientProps {
   crew: FranchizeCrewVM;
   slug: string;
   items: CatalogItemVM[];
+  mode?: "rental" | "electro";
 }
 
 type QuickFilterKey = "all" | "budget" | "premium" | "newbie";
@@ -33,7 +34,7 @@ const sortWbItemLast = <T extends { category: string }>(groups: T[]) => {
   return [...regular, ...wbItems];
 };
 
-export function CatalogClient({ crew, slug, items }: CatalogClientProps) {
+export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogClientProps) {
   const surface = crewPaletteForSurface(crew.theme);
   const [selectedItem, setSelectedItem] = useState<CatalogItemVM | null>(null);
   const { addItem } = useFranchizeCart(crew.slug || slug);
@@ -155,10 +156,7 @@ export function CatalogClient({ crew, slug, items }: CatalogClientProps) {
     return gradients[index % gradients.length];
   };
 
-  const orderedCategories = useMemo(
-    () => Array.from(new Set([...crew.catalog.categories, ...items.map((item) => item.category).filter(Boolean)])),
-    [crew.catalog.categories, items],
-  );
+  const orderedCategories = useMemo(() => Array.from(new Set(items.map((item) => item.category).filter(Boolean))), [items]);
 
   const matchesQuickFilter = (item: CatalogItemVM, filter: QuickFilterKey) => {
     if (filter === "budget") {
@@ -202,22 +200,13 @@ export function CatalogClient({ crew, slug, items }: CatalogClientProps) {
       }))
       .filter((group) => group.items.length > 0);
 
-    const showcaseGroups = crew.catalog.showcaseGroups
-      .map((group) => {
-        const showcaseItems = filteredItems.filter((item) => {
-          if (group.mode === "subtype") {
-            return item.category.toLowerCase().includes((group.subtype ?? "").toLowerCase());
-          }
-          const minPrice = group.minPrice ?? Number.NEGATIVE_INFINITY;
-          const maxPrice = group.maxPrice ?? Number.POSITIVE_INFINITY;
-          return item.pricePerDay >= minPrice && item.pricePerDay <= maxPrice;
-        });
-        return { category: group.label, items: showcaseItems };
-      })
-      .filter((group) => group.items.length > 0);
-
-    return sortWbItemLast([...showcaseGroups, ...grouped]);
-  }, [crew.catalog.showcaseGroups, filteredItems, orderedCategories]);
+    const saleGroup = filteredItems.filter((item) => item.saleAvailable);
+    const saleCategory = mode === "electro" ? "Электроэндуро в продаже" : "Байки на продажу";
+    const baseGroups = grouped.filter((group) => group.category !== saleCategory);
+    const normalized = sortWbItemLast(baseGroups);
+    if (saleGroup.length === 0) return normalized;
+    return [{ category: saleCategory, items: saleGroup }, ...normalized];
+  }, [filteredItems, mode, orderedCategories]);
 
   const openItem = (item: CatalogItemVM) => {
     setSelectedItem(item);

--- a/app/franchize/components/SaleBikeLanding.tsx
+++ b/app/franchize/components/SaleBikeLanding.tsx
@@ -7,6 +7,7 @@ import type { CatalogItemVM, FranchizeCrewVM } from "@/app/franchize/actions";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 
 export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: CatalogItemVM }) {
+  const resolvedSlug = crew.slug || "vip-bike";
   const surface = crewPaletteForSurface(crew.theme);
   const gallery = item.mediaUrls?.length ? item.mediaUrls : [item.imageUrl].filter(Boolean);
   const specs = item.rawSpecs || {};
@@ -42,7 +43,7 @@ export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: C
     <section className="min-h-screen pb-24 pt-3 sm:pt-6" style={surface.page}>
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-3 sm:px-6">
         <div className="flex items-center justify-between gap-2">
-          <Link href={`/franchize/${crew.slug}?vehicle=${item.id}&flow=buy`} className="inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm" style={surface.subtleCard}><ArrowLeft className="h-4 w-4"/>В маркет</Link>
+          <Link href={`/franchize/${resolvedSlug}?vehicle=${item.id}&flow=buy`} className="inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm" style={surface.subtleCard}><ArrowLeft className="h-4 w-4"/>В маркет</Link>
           <span className="rounded-full border px-3 py-1 text-xs font-semibold" style={surface.subtleCard}>На продажу</span>
         </div>
 
@@ -66,7 +67,7 @@ export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: C
                 <p className="mt-2 inline-flex items-center gap-2 text-xs opacity-80"><ShieldCheck className="h-3.5 w-3.5" />Официальная сделка + документы</p>
               </div>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                <Link href={`/franchize/${crew.slug}/cart?source=buy&bike=${item.id}`} className="rounded-xl px-4 py-3 text-center font-semibold" style={{ ...surface.subtleCard, background: crew.theme.palette.accentMain, color: "#101010" }}>Оставить заявку на покупку</Link>
+                <Link href={`/franchize/${resolvedSlug}/cart?source=buy&bike_id=${item.id}&add=1`} className="rounded-xl px-4 py-3 text-center font-semibold" style={{ ...surface.subtleCard, background: crew.theme.palette.accentMain, color: "#101010" }}>Перейти к заказу</Link>
                 <Link href={`tel:${crew.contacts?.phone || "+79999005588"}`} className="inline-flex items-center justify-center gap-2 rounded-xl border px-4 py-3 text-center font-semibold"><PhoneCall className="h-4 w-4"/>Позвонить</Link>
               </div>
             </div>
@@ -89,8 +90,8 @@ export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: C
             <p className="mt-2 text-sm">Офлайн-показ и тест-драйв по предварительной записи. Подскажем маршрут и выдадим базовый инструктаж.</p>
           </div>
           <div className="rounded-2xl border p-4" style={surface.subtleCard}>
-            <p className="text-xs uppercase tracking-[0.16em] opacity-70">Реальный магазин</p>
-            <p className="mt-2 text-sm">Консультация в шоуруме, проверка комплектации, помощь с документами и подготовка к выдаче.</p>
+            <p className="text-xs uppercase tracking-[0.16em] opacity-70">Группа магазина</p>
+            <p className="mt-2 text-sm">Актуальные поставки, наличие и консультации в группе: <a className="underline" href="https://vk.ru/vip_bike_electro" target="_blank" rel="noreferrer">vk.ru/vip_bike_electro</a></p>
           </div>
           <div className="rounded-2xl border p-4" style={surface.subtleCard}>
             <p className="text-xs uppercase tracking-[0.16em] opacity-70">После покупки</p>


### PR DESCRIPTION
### Motivation
- Separate rental catalog from sale-focused electric bikes and remove brittle showcase-based grouping that surfaced temporary groups (e.g. “с 23 февраля”).
- Fix critical UX bug where clicking the buy CTA did not add the bike to the cart because URL params were handled inconsistently.
- Provide a parallel entry point for sale/electro inventory so operators can test sale flows independently from rental flow.

### Description
- Reworked catalog grouping in `CatalogClient` to build categories from real item categories and add a dedicated top group for sale bikes instead of depending on `showcaseGroups`. (`app/franchize/components/CatalogClient.tsx`)
- Added a new electro-enduro page that mirrors market UX but shows only bikes with `saleAvailable` or `rawSpecs.sale=1/true` at `/franchize/[slug]/electro-enduro`. (`app/franchize/[slug]/electro-enduro/page.tsx`)
- Fixed buy-to-cart flow by accepting `bike_id` and several fallback param names (`bike`, `vehicle`, `item`) and honoring an explicit `add=1` flag before injecting the item into cart. (`app/franchize/components/CartPageClient.tsx`)
- Updated sale landing links: use a resolved slug when building back/CTA links and make the buy CTA include `?source=buy&bike_id=<id>&add=1` so the bike is added before navigation. (`app/franchize/components/SaleBikeLanding.tsx`)
- Replaced the sale landing “store” text/link with the VK group `https://vk.ru/vip_bike_electro` and added default menu entries for `Электроэндуро` and `Конфигуратор`. (`app/franchize/components/SaleBikeLanding.tsx`, `app/franchize/actions.ts`)

### Testing
- Ran lint focused on changed files with `npm run lint -- --file app/franchize/components/CatalogClient.tsx --file app/franchize/components/SaleBikeLanding.tsx --file app/franchize/components/CartPageClient.tsx --file app/franchize/[slug]/electro-enduro/page.tsx --file app/franchize/actions.ts`, which completed successfully with only two non-blocking warnings about using raw `<img>` in `SaleBikeLanding` (suggested `next/image`).
- No automated unit tests were modified or executed in this change set; manual smoke verification hooks are ready for operator-driven QA of the buy->cart flow and the new `/electro-enduro` page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3856db278832aa1b30be45e3ad358)