### PR TITLE
fix(franchize): stabilize buy→cart add flow after hydration

### DIFF
--- a/app/franchize/components/CartPageClient.tsx
+++ b/app/franchize/components/CartPageClient.tsx
@@ -16,7 +16,7 @@ interface CartPageClientProps {
 }
 
 export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
-  const { cart, addItem, itemCount: rawItemCount, changeLineQty, removeLine } = useFranchizeCart(slug);
+  const { cart, addItem, itemCount: rawItemCount, changeLineQty, removeLine, isHydrated } = useFranchizeCart(slug);
   const { cartLines, subtotal, itemCount } = useFranchizeCartLines(slug, items, {
     cart,
     itemCount: rawItemCount,
@@ -30,7 +30,7 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
   const [buyFlowApplied, setBuyFlowApplied] = useState(false);
 
   useEffect(() => {
-    if (buyFlowApplied || typeof window === "undefined") return;
+    if (buyFlowApplied || typeof window === "undefined" || !isHydrated) return;
     const params = new URLSearchParams(window.location.search);
     if (params.get("source") !== "buy") return;
     const bikeId = (params.get("bike_id") || params.get("bike") || params.get("vehicle") || params.get("item") || "").trim();
@@ -52,7 +52,7 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
     setBuyFlowApplied(true);
     const cleaned = `${window.location.pathname}`;
     window.history.replaceState({}, "", cleaned);
-  }, [addItem, buyFlowApplied, items]);
+  }, [addItem, buyFlowApplied, isHydrated, items]);
 
   const handleProceed = async () => {
     setIsSaving(true);

--- a/app/franchize/hooks/useFranchizeCart.ts
+++ b/app/franchize/hooks/useFranchizeCart.ts
@@ -239,5 +239,15 @@ export function useFranchizeCart(slug: string) {
 
   const itemCount = useMemo(() => Object.values(cart).reduce((sum, line) => sum + line.qty, 0), [cart]);
 
-  return { cart, itemCount, addItem, setLineQty, changeLineQty, removeLine, clear, defaultOptions: DEFAULT_OPTIONS };
+  return {
+    cart,
+    itemCount,
+    addItem,
+    setLineQty,
+    changeLineQty,
+    removeLine,
+    clear,
+    defaultOptions: DEFAULT_OPTIONS,
+    isHydrated,
+  };
 }


### PR DESCRIPTION
### Motivation
- There was a race where the buy-page auto-add flow (`?source=buy&bike_id=...`) could call `addItem(...)` before the cart hook finished hydrating from `localStorage`, causing the late hydration to overwrite the newly added line and leaving the cart empty.

### Description
- Exposed an `isHydrated` flag from `useFranchizeCart` and gated the buy-flow `useEffect` in `CartPageClient` so URL-driven auto-add runs only after `isHydrated === true`, and updated effect dependencies accordingly.
- Files changed: `app/franchize/hooks/useFranchizeCart.ts` and `app/franchize/components/CartPageClient.tsx`.

### Testing
- Ran `npx eslint app/franchize/hooks/useFranchizeCart.ts app/franchize/components/CartPageClient.tsx` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39127a3cc83249ef652176e8c358f)