### PR TITLE
fix(franchize): two-step add-to-cart flow on buy landing

### DIFF
--- a/app/franchize/components/CartPageClient.tsx
+++ b/app/franchize/components/CartPageClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { CatalogItemVM, FranchizeCrewVM } from "../actions";
 import { useFranchizeCartLines } from "../hooks/useFranchizeCartLines";
 import { useFranchizeCart } from "../hooks/useFranchizeCart"; // Import cart state access
@@ -16,7 +16,7 @@ interface CartPageClientProps {
 }
 
 export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
-  const { cart, addItem, itemCount: rawItemCount, changeLineQty, removeLine, isHydrated } = useFranchizeCart(slug);
+  const { cart, itemCount: rawItemCount, changeLineQty, removeLine } = useFranchizeCart(slug);
   const { cartLines, subtotal, itemCount } = useFranchizeCartLines(slug, items, {
     cart,
     itemCount: rawItemCount,
@@ -27,32 +27,6 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
   const router = useRouter();
   const { dbUser } = useAppContext();
   const [isSaving, setIsSaving] = useState(false);
-  const [buyFlowApplied, setBuyFlowApplied] = useState(false);
-
-  useEffect(() => {
-    if (buyFlowApplied || typeof window === "undefined" || !isHydrated) return;
-    const params = new URLSearchParams(window.location.search);
-    if (params.get("source") !== "buy") return;
-    const bikeId = (params.get("bike_id") || params.get("bike") || params.get("vehicle") || params.get("item") || "").trim();
-    const shouldAdd = params.get("add");
-    if (shouldAdd === "0" || shouldAdd === "false") return;
-    if (!bikeId) return;
-    if (!items.some((item) => item.id === bikeId)) return;
-
-    addItem(
-      bikeId,
-      {
-        package: "Покупка",
-        duration: "Покупка",
-        perk: "Без допов",
-        auction: "Покупка",
-      },
-      1,
-    );
-    setBuyFlowApplied(true);
-    const cleaned = `${window.location.pathname}`;
-    window.history.replaceState({}, "", cleaned);
-  }, [addItem, buyFlowApplied, isHydrated, items]);
 
   const handleProceed = async () => {
     setIsSaving(true);

--- a/app/franchize/components/SaleBikeLanding.tsx
+++ b/app/franchize/components/SaleBikeLanding.tsx
@@ -2,9 +2,11 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
+import { useState } from "react";
 import { ArrowLeft, Gauge, Battery, Zap, Weight, Timer, ShoppingBag, PhoneCall, Tag, Sparkles, ShieldCheck } from "lucide-react";
 import type { CatalogItemVM, FranchizeCrewVM } from "@/app/franchize/actions";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { useFranchizeCart } from "@/app/franchize/hooks/useFranchizeCart";
 
 export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: CatalogItemVM }) {
   const resolvedSlug = crew.slug || "vip-bike";
@@ -23,6 +25,9 @@ export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: C
     { label: "Зарядка", value: `${specs.charge_time_h || "—"} ч`, icon: Timer },
     { label: "Привод", value: String(specs.drive || "—"), icon: ShoppingBag },
   ];
+
+  const { addItem } = useFranchizeCart(resolvedSlug);
+  const [addedOnce, setAddedOnce] = useState(false);
 
   const buyFaq = [
     {
@@ -67,7 +72,26 @@ export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: C
                 <p className="mt-2 inline-flex items-center gap-2 text-xs opacity-80"><ShieldCheck className="h-3.5 w-3.5" />Официальная сделка + документы</p>
               </div>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                <Link href={`/franchize/${resolvedSlug}/cart?source=buy&bike_id=${item.id}&add=1`} className="rounded-xl px-4 py-3 text-center font-semibold" style={{ ...surface.subtleCard, background: crew.theme.palette.accentMain, color: "#101010" }}>Перейти к заказу</Link>
+                <button
+                  type="button"
+                  onClick={() => {
+                    addItem(
+                      item.id,
+                      {
+                        package: "Покупка",
+                        duration: "Покупка",
+                        perk: "Без допов",
+                        auction: "Покупка",
+                      },
+                      1,
+                    );
+                    setAddedOnce(true);
+                  }}
+                  className="rounded-xl px-4 py-3 text-center font-semibold transition hover:brightness-105 active:scale-[0.99]"
+                  style={{ ...surface.subtleCard, background: crew.theme.palette.accentMain, color: "#101010" }}
+                >
+                  {addedOnce ? "Добавлено в корзину" : "Добавить в корзину"}
+                </button>
                 <Link href={`tel:${crew.contacts?.phone || "+79999005588"}`} className="inline-flex items-center justify-center gap-2 rounded-xl border px-4 py-3 text-center font-semibold"><PhoneCall className="h-4 w-4"/>Позвонить</Link>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- The buy landing attempted a one-step add+open via URL query parameters which proved unreliable and could be lost due to client hydration/race conditions. 
- Align the `/buy` experience with the proven market flow by making adding an explicit first step and leaving opening the cart to the floating cart control.

### Description
- Replaced the `/franchize/.../cart?source=buy...` CTA in `SaleBikeLanding` with an in-place `addItem(...)` call and added a local `addedOnce` state to provide immediate feedback. 
- Removed the query-parameter auto-add effect from `CartPageClient` so the cart page is a pure viewer/editor and no longer performs hidden side-effect additions on load. 
- Adjusted usages of `useFranchizeCart` in the affected components to remove coupling between the buy-flow URL magic and cart hydration.

### Testing
- Ran `npx eslint app/franchize/components/SaleBikeLanding.tsx app/franchize/components/CartPageClient.tsx` which completed with no errors and 2 warnings about `<img>` usage in unchanged markup. 
- No other automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3958404e08324b72900d94198af1e)