### PR TITLE
Fix franchize buy-flow cart pricing and hydration-safe add-to-cart

### DIFF
--- a/app/franchize/components/SaleBikeLanding.tsx
+++ b/app/franchize/components/SaleBikeLanding.tsx
@@ -26,7 +26,7 @@ export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: C
     { label: "Привод", value: String(specs.drive || "—"), icon: ShoppingBag },
   ];
 
-  const { addItem } = useFranchizeCart(resolvedSlug);
+  const { addItem, isHydrated } = useFranchizeCart(resolvedSlug);
   const [addedOnce, setAddedOnce] = useState(false);
 
   const buyFaq = [
@@ -75,6 +75,7 @@ export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: C
                 <button
                   type="button"
                   onClick={() => {
+                    if (!isHydrated) return;
                     addItem(
                       item.id,
                       {
@@ -87,10 +88,11 @@ export function SaleBikeLanding({ crew, item }: { crew: FranchizeCrewVM; item: C
                     );
                     setAddedOnce(true);
                   }}
-                  className="rounded-xl px-4 py-3 text-center font-semibold transition hover:brightness-105 active:scale-[0.99]"
+                  disabled={!isHydrated}
+                  className="rounded-xl px-4 py-3 text-center font-semibold transition hover:brightness-105 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
                   style={{ ...surface.subtleCard, background: crew.theme.palette.accentMain, color: "#101010" }}
                 >
-                  {addedOnce ? "Добавлено в корзину" : "Добавить в корзину"}
+                  {!isHydrated ? "Подготовка корзины..." : addedOnce ? "Добавлено в корзину" : "Добавить в корзину"}
                 </button>
                 <Link href={`tel:${crew.contacts?.phone || "+79999005588"}`} className="inline-flex items-center justify-center gap-2 rounded-xl border px-4 py-3 text-center font-semibold"><PhoneCall className="h-4 w-4"/>Позвонить</Link>
               </div>

--- a/app/franchize/hooks/useFranchizeCartLines.ts
+++ b/app/franchize/hooks/useFranchizeCartLines.ts
@@ -28,6 +28,23 @@ const perkSurcharge: Record<string, number> = {
   "full gear": 1800,
 };
 
+
+
+function resolveSalePrice(item: CatalogItemVM | null): number {
+  if (!item) return 0;
+  const specs = item.rawSpecs ?? {};
+  const raw = Number(
+    specs.price_rub ?? specs.sale_price ?? specs.purchase_price ?? specs.total_price ?? specs.price ?? 0,
+  );
+  if (!Number.isFinite(raw) || raw <= 0) return 0;
+  return Math.round(raw);
+}
+
+function isBuyFlow(options: { package: string; duration: string; perk: string; auction: string }): boolean {
+  const values = [options.package, options.duration, options.perk, options.auction]
+    .map((v) => String(v || '').toLowerCase());
+  return values.some((v) => v.includes('покуп') || v.includes('buy'));
+}
 function parseDurationDays(rawDuration: string): number {
   const normalized = rawDuration.toLowerCase();
   const numericMatch = normalized.match(/\d+/);
@@ -75,6 +92,23 @@ export function useFranchizeCartLines(
       .filter(([, line]) => line.qty > 0)
       .map(([lineId, line]) => {
         const item = itemById.get(line.itemId) ?? null;
+        const inBuyFlow = isBuyFlow(line.options);
+        const salePrice = resolveSalePrice(item);
+
+        if (inBuyFlow && salePrice > 0) {
+          return {
+            lineId,
+            itemId: line.itemId,
+            qty: line.qty,
+            item,
+            pricePerDay: salePrice,
+            lineTotal: salePrice * line.qty,
+            rentalDays: 1,
+            saleAvailable: Boolean(item?.saleAvailable),
+            options: line.options,
+          };
+        }
+
         const basePricePerDay = item?.pricePerDay ?? 0;
         const rentalDays = parseDurationDays(line.options.duration);
         const packageFactor = packageMultiplier[line.options.package.toLowerCase()] ?? 1;


### PR DESCRIPTION
### Motivation
- Users adding a bike from the franchize “buy” page saw incorrect/zero totals because buy items were priced using the rent/day formula instead of the bike’s sale price from specs. 
- The add-to-cart CTA on `SaleBikeLanding` could show success before cart hydration completed, causing lost writes on slow first loads (Telegram WebApp/mobile).

### Description
- Add `resolveSalePrice` and `isBuyFlow` helpers in `useFranchizeCartLines` and use them to detect buy-flow lines and return the bike sale price (from `rawSpecs` fields like `price_rub`, `sale_price`, `purchase_price`, `total_price`, `price`) as the line price and total when present, leaving rental logic unchanged for non-buy flows. 
- Update `useFranchizeCartLines` cart line shape so buy-flow entries use `rentalDays: 1`, `pricePerDay = salePrice`, and `lineTotal = salePrice * qty`.
- Gate `addItem` usage in `app/franchize/components/SaleBikeLanding.tsx` on the cart hydration flag by reading `isHydrated` from `useFranchizeCart`, disabling the CTA and showing a temporary `Подготовка корзины...` label until hydration completes, and add disabled styles to the button.
- Commit message: `fix(cart): use sale price for buy flow and gate add-to-cart on hydration`.

### Testing
- Ran `npm run -s lint` and targeted lint attempts; lint exposed pre-existing repo-wide warnings and errors and the run failed due to unrelated Next/ESLint issues, so no clean lint pass could be reported for the repo. 
- Changes were committed and a PR payload was prepared with the title and summary above; local manual smoke scenarios (adding a buy item then viewing cart) were the validation intent but automated lint constraints prevented a full green CI in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ad77b9488325ab4901a0ea6146d0)