### PR TITLE
fix: restrict franchize buy-flow sentinel detection

### DIFF
--- a/app/franchize/hooks/useFranchizeCartLines.ts
+++ b/app/franchize/hooks/useFranchizeCartLines.ts
@@ -41,9 +41,11 @@ function resolveSalePrice(item: CatalogItemVM | null): number {
 }
 
 function isBuyFlow(options: { package: string; duration: string; perk: string; auction: string }): boolean {
-  const values = [options.package, options.duration, options.perk, options.auction]
-    .map((v) => String(v || '').toLowerCase());
-  return values.some((v) => v.includes('покуп') || v.includes('buy'));
+  const normalizedValues = [options.package, options.duration, options.perk, options.auction]
+    .map((value) => String(value ?? "").trim().toLowerCase());
+
+  const buySentinels = new Set(["покупка", "buy", "flow=buy"]);
+  return normalizedValues.some((value) => buySentinels.has(value));
 }
 function parseDurationDays(rawDuration: string): number {
   const normalized = rawDuration.toLowerCase();


### PR DESCRIPTION
### Motivation
- Prevent rental lines with auction labels like "Buyback" from being misclassified as purchase flow and priced with sale price, causing incorrect totals and checkout payloads.

### Description
- Tighten detection in `isBuyFlow` inside `app/franchize/hooks/useFranchizeCartLines.ts` by normalizing inputs with `trim().toLowerCase()` and matching only explicit sentinels (`"покупка"`, `"buy"`, `"flow=buy"`) instead of substring checks.

### Testing
- Ran `npx eslint app/franchize/hooks/useFranchizeCartLines.ts`, which completed without lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3cf39bd588325a4658ba567eacd08)