### PR TITLE
Support temporary franchize carts for unauthenticated Telegram users (temp table + client sync/consume)

### DIFF
--- a/app/franchize/components/FranchizeProfileButton.tsx
+++ b/app/franchize/components/FranchizeProfileButton.tsx
@@ -2,9 +2,11 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { ChevronDown, Palette, Settings, Shield, User, IdCard } from "lucide-react";
+import { ChevronDown, Palette, Settings, Shield, User, IdCard, MessageCircle } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { useAppContext } from "@/contexts/AppContext";
 import { useIsAdmin } from "@/app/franchize/hooks/useIsAdmin";
+import { isMockUserModeEnabled } from "@/lib/mockUserMode";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,7 +34,7 @@ function getInitials(name: string): string {
 }
 
 export function FranchizeProfileButton({ bgColor, textColor, borderColor, currentSlug }: FranchizeProfileButtonProps) {
-  const { dbUser, user, userCrewInfo } = useAppContext();
+  const { dbUser, user, userCrewInfo, isInTelegramContext } = useAppContext();
   const effectiveUser = dbUser || user;
   const displayName = effectiveUser?.username || effectiveUser?.full_name || effectiveUser?.first_name || "Operator";
   const avatarUrl = dbUser?.avatar_url || user?.photo_url;
@@ -40,6 +42,19 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
   const scopeSlug = currentSlug || userCrewInfo?.slug || "vip-bike";
   const franchizeAdminHref = `/franchize/${scopeSlug}/admin`;
   const franchizeProfileHref = `/franchize/${scopeSlug}/profile`;
+  const [tempCartId, setTempCartId] = useState<string | null>(null);
+  const canShowTelegramCartCta = !dbUser?.user_id && !isInTelegramContext && !isMockUserModeEnabled();
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !canShowTelegramCartCta) return;
+    const id = window.localStorage.getItem("franchize-temp-cart-id");
+    setTempCartId(id);
+  }, [canShowTelegramCartCta]);
+
+  const telegramCartHref = useMemo(() => {
+    if (!tempCartId) return null;
+    return `https://t.me/oneBikePlsBot/app?startapp=cart_id_${encodeURIComponent(tempCartId)}`;
+  }, [tempCartId]);
 
   return (
     <div style={{ isolation: "isolate" }}>
@@ -104,6 +119,21 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
               <span className="truncate">Franchize profile</span>
             </Link>
           </DropdownMenuItem>
+
+          {canShowTelegramCartCta && telegramCartHref ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem asChild>
+                <a href={telegramCartHref} target="_blank" rel="noreferrer" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                  <MessageCircle className="mr-2 h-4 w-4 shrink-0" />
+                  <span className="truncate">Перейти в Telegram — корзина сохранится</span>
+                </a>
+              </DropdownMenuItem>
+              <DropdownMenuLabel className="pt-0 text-[11px] font-normal text-muted-foreground">
+                Добавленные позиции уже сохранены
+              </DropdownMenuLabel>
+            </>
+          ) : null}
 
           {userCrewInfo?.slug && (
             <DropdownMenuItem asChild>

--- a/app/franchize/hooks/useFranchizeCart.ts
+++ b/app/franchize/hooks/useFranchizeCart.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAppContext } from "@/contexts/AppContext";
+import { upsertTempFranchizeCartAction } from "@/contexts/actions";
+import { isMockUserModeEnabled } from "@/lib/mockUserMode";
 
 export type FranchizeCartOptions = {
   package: string;
@@ -26,6 +28,7 @@ type CartEnvelope = {
 
 const CART_STORAGE_PREFIX = "franchize-cart";
 const CART_SYNC_EVENT = "franchize-cart-sync";
+const TEMP_CART_ID_KEY = "franchize-temp-cart-id";
 
 const DEFAULT_OPTIONS: FranchizeCartOptions = {
   package: "Базовый",
@@ -106,6 +109,7 @@ export const getFranchizeCartStorageKey = (slug: string) => `${CART_STORAGE_PREF
 
 export function useFranchizeCart(slug: string) {
   const { dbUser } = useAppContext();
+  const tempCartFeatureEnabled = !isMockUserModeEnabled();
   const storageKey = useMemo(() => getFranchizeCartStorageKey(slug), [slug]);
   const [cart, setCart] = useState<FranchizeCartState>({});
   const [isHydrated, setIsHydrated] = useState(false);
@@ -153,6 +157,25 @@ export function useFranchizeCart(slug: string) {
         window.dispatchEvent(new CustomEvent(CART_SYNC_EVENT, { detail: { storageKey } }));
     }
   }, [cart, storageKey, isHydrated]);
+
+  useEffect(() => {
+    if (!isHydrated || typeof window === "undefined") return;
+    if (dbUser?.user_id || !tempCartFeatureEnabled) return;
+
+    const existingCartId = window.localStorage.getItem(TEMP_CART_ID_KEY);
+    const cartId = existingCartId || `cart_${crypto.randomUUID()}`;
+    if (!existingCartId) {
+      window.localStorage.setItem(TEMP_CART_ID_KEY, cartId);
+    }
+
+    const syncHash = `franchize-temp-cart-sync:${slug}`;
+    const payloadBySlug = { [slug]: cart };
+    const nextHash = JSON.stringify(payloadBySlug);
+    if (window.sessionStorage.getItem(syncHash) === nextHash) return;
+    window.sessionStorage.setItem(syncHash, nextHash);
+
+    void upsertTempFranchizeCartAction({ cartId, cartBySlug: payloadBySlug });
+  }, [cart, dbUser?.user_id, isHydrated, slug, tempCartFeatureEnabled]);
 
   // 3. Sync Listener
   useEffect(() => {

--- a/contexts/actions.ts
+++ b/contexts/actions.ts
@@ -201,3 +201,97 @@ export async function saveUserFranchizeCartAction(
     return { ok: false, error: error instanceof Error ? error.message : "Unknown error" };
   }
 }
+
+export async function upsertTempFranchizeCartAction(input: {
+  cartId: string;
+  cartBySlug: Record<string, unknown>;
+}): Promise<{ ok: boolean; error?: string }> {
+  const cartId = input.cartId?.trim();
+  if (!cartId) return { ok: false, error: "Missing cartId" };
+  if (!input.cartBySlug || typeof input.cartBySlug !== "object" || Array.isArray(input.cartBySlug)) {
+    return { ok: false, error: "cartBySlug must be an object" };
+  }
+
+  try {
+    const { data: existing } = await supabaseAdmin
+      .from("temp_franchize_carts")
+      .select("cart_by_slug")
+      .eq("cart_id", cartId)
+      .maybeSingle();
+
+    const existingBySlug = ((existing?.cart_by_slug as Record<string, unknown> | null) ?? {});
+    const mergedBySlug = { ...existingBySlug, ...input.cartBySlug };
+
+    const { error } = await supabaseAdmin
+      .from("temp_franchize_carts")
+      .upsert({ cart_id: cartId, cart_by_slug: mergedBySlug, updated_at: new Date().toISOString() }, { onConflict: "cart_id" });
+    if (error) throw error;
+    return { ok: true };
+  } catch (error) {
+    logger.error("[upsertTempFranchizeCartAction] Failed:", error);
+    return { ok: false, error: error instanceof Error ? error.message : "Unknown error" };
+  }
+}
+
+export async function consumeTempFranchizeCartAction(input: {
+  cartId: string;
+  userId: string;
+}): Promise<{ ok: boolean; cartBySlug?: Record<string, unknown>; error?: string }> {
+  const cartId = input.cartId?.trim();
+  const userId = input.userId?.trim();
+  if (!cartId || !userId) return { ok: false, error: "Missing cartId or userId" };
+
+  try {
+    const { data: tempCart, error: tempCartError } = await supabaseAdmin
+      .from("temp_franchize_carts")
+      .select("cart_by_slug, consumed_at")
+      .eq("cart_id", cartId)
+      .maybeSingle();
+    if (tempCartError) throw tempCartError;
+
+    const cartBySlug = ((tempCart?.cart_by_slug as Record<string, unknown> | null) ?? {});
+
+    const { data: user, error: userError } = await supabaseAdmin
+      .from("users")
+      .select("metadata")
+      .eq("user_id", userId)
+      .single();
+    if (userError || !user) return { ok: false, error: "User not found" };
+
+    const currentMeta = (user.metadata as Record<string, any>) || {};
+    const currentSettings = (currentMeta.settings as Record<string, any>) || {};
+    const currentCarts = (currentSettings.franchizeCart as Record<string, any>) || {};
+    const mergedCarts = { ...currentCarts };
+    for (const [slug, incomingCart] of Object.entries(cartBySlug)) {
+      const currentSlugCart = (currentCarts[slug] as Record<string, any> | undefined) ?? {};
+      const incomingSlugCart = (incomingCart as Record<string, any> | undefined) ?? {};
+      mergedCarts[slug] = { ...currentSlugCart, ...incomingSlugCart };
+    }
+
+    const { error: updateError } = await supabaseAdmin
+      .from("users")
+      .update({
+        metadata: {
+          ...currentMeta,
+          settings: {
+            ...currentSettings,
+            franchizeCart: mergedCarts,
+          },
+        },
+        updated_at: new Date().toISOString(),
+      })
+      .eq("user_id", userId);
+    if (updateError) throw updateError;
+
+    const { error: consumeError } = await supabaseAdmin
+      .from("temp_franchize_carts")
+      .update({ consumed_by_user_id: userId, consumed_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .eq("cart_id", cartId);
+    if (consumeError) throw consumeError;
+
+    return { ok: true, cartBySlug };
+  } catch (error) {
+    logger.error("[consumeTempFranchizeCartAction] Failed:", error);
+    return { ok: false, error: error instanceof Error ? error.message : "Unknown error" };
+  }
+}

--- a/hooks/useStartParamRouter.ts
+++ b/hooks/useStartParamRouter.ts
@@ -8,6 +8,8 @@ import { useAppToast } from "@/hooks/useAppToast";
 import { debugLogger as logger } from "@/lib/debugLogger";
 import { setReferrer } from "@/app/bio30/ref_actions";
 import { applyReferralCode } from "@/app/wblanding/actions_view";
+import { consumeTempFranchizeCartAction } from "@/contexts/actions";
+import { isMockUserModeEnabled } from "@/lib/mockUserMode";
 
 const START_PARAM_PAGE_MAP: Record<string, string> = {
   elon: "/elon",
@@ -60,6 +62,7 @@ export function useStartParamRouter() {
   const { success: showToast } = useAppToast();
 
   const handledRef = useRef(false);
+  const consumedTempCartRef = useRef<string | null>(null);
 
   const handleBio30Referral = useCallback(
     async (referrerId: string, referrerCode: string) => {
@@ -147,6 +150,20 @@ export function useStartParamRouter() {
 
       if (paramToProcess === "wb_dashboard") {
         targetPath = userCrewInfo?.slug ? `/wb/${userCrewInfo.slug}` : "/wblanding";
+      } else if (paramToProcess.startsWith("cart_id_")) {
+        const mockEnabled = isMockUserModeEnabled();
+        const cartId = paramToProcess.slice("cart_id_".length).trim();
+        if (!mockEnabled && dbUser?.user_id && cartId && consumedTempCartRef.current !== cartId) {
+          consumedTempCartRef.current = cartId;
+          const consumed = await consumeTempFranchizeCartAction({ cartId, userId: dbUser.user_id });
+          if (consumed.ok && consumed.cartBySlug && typeof window !== "undefined") {
+            for (const [slug, cartState] of Object.entries(consumed.cartBySlug)) {
+              window.localStorage.setItem(`franchize-cart:${slug}`, JSON.stringify({ updatedAt: Date.now(), cart: cartState }));
+            }
+            window.dispatchEvent(new CustomEvent("franchize-cart-sync", { detail: { storageKey: "*" } }));
+          }
+        }
+        targetPath = pathname;
       } else if (paramToProcess.startsWith("buy_")) {
         targetPath = await resolveFranchizeVehicleLink(paramToProcess, "buy") ?? undefined;
       } else if (paramToProcess.startsWith("rent_")) {
@@ -222,6 +239,7 @@ export function useStartParamRouter() {
   }, [
     startParamPayload,
     searchParams,
+    dbUser?.user_id,
     isAppLoading,
     isAuthenticating,
     userCrewInfo?.slug,

--- a/lib/mockUserMode.ts
+++ b/lib/mockUserMode.ts
@@ -1,0 +1,5 @@
+export function isMockUserModeEnabled(): boolean {
+  const raw = String(process.env.NEXT_PUBLIC_MOCKUSER ?? process.env.MOCKUSER ?? "").trim().toLowerCase();
+  return ["1", "true", "yes"].includes(raw);
+}
+

--- a/supabase/migrations/20260504090000_temp_franchize_carts.sql
+++ b/supabase/migrations/20260504090000_temp_franchize_carts.sql
@@ -1,0 +1,23 @@
+create table if not exists public.temp_franchize_carts (
+  cart_id text primary key,
+  cart_by_slug jsonb not null default '{}'::jsonb,
+  consumed_by_user_id text null,
+  consumed_at timestamptz null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_temp_franchize_carts_consumed_by
+  on public.temp_franchize_carts(consumed_by_user_id);
+
+create index if not exists idx_temp_franchize_carts_updated_at
+  on public.temp_franchize_carts(updated_at desc);
+
+alter table public.temp_franchize_carts enable row level security;
+
+drop policy if exists "temp_franchize_carts_service_role_only" on public.temp_franchize_carts;
+create policy "temp_franchize_carts_service_role_only"
+  on public.temp_franchize_carts
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');


### PR DESCRIPTION
### Motivation
- Allow unauthenticated Telegram users to save a temporary franchize cart and restore it after they sign in via a Telegram deep link.
- Avoid infinite localStorage sync loops and skip temp-cart behavior in mock/test modes.
- Provide server-side persistence for temporary carts so carts can be consumed and merged into a real user account later.

### Description
- Added a new Supabase table migration `temp_franchize_carts` to store temporary carts with `cart_id`, `cart_by_slug`, and consumption metadata.
- Implemented server actions `upsertTempFranchizeCartAction` and `consumeTempFranchizeCartAction` in `contexts/actions.ts` to save and consume temporary carts on the server.
- Extended `useFranchizeCart` to generate/keep a `franchize-temp-cart-id` for anonymous users, `upsert` the cart state to the temp table via `upsertTempFranchizeCartAction`, and avoid doing this when mock user mode is enabled via the new `isMockUserModeEnabled` helper.
- Added a Telegram CTA in `FranchizeProfileButton` that appears when a temp cart id exists and the user is not in Telegram context, linking into the Telegram bot with the `cart_id` start param; and added UI/icon import for this action.
- Updated `useStartParamRouter` to detect `cart_id_{id}` start params, call `consumeTempFranchizeCartAction` for logged-in users (unless mock mode is enabled), merge consumed carts into localStorage keys like `franchize-cart:{slug}`, and dispatch a `franchize-cart-sync` event.
- Introduced `lib/mockUserMode.ts` and gates to disable temp-cart behavior during mock/test runs, and cleaned up localStorage sync logic to prevent write loops by only writing when content changes.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84d49ba988324a5f11fb5ad8c86b9)