### PR TITLE
Avoid duplicate invoice inserts and improve franchize order link/price handling

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -300,21 +300,35 @@ export async function sendTelegramInvoice(chatId: string, title: string, descrip
         throw new Error(`Telegram API error: ${data.description || "Failed to send invoice"}`);
     }
     
-    // Attempt to save the invoice to the DB after it's been sent
-    try { 
-      await supabaseAdmin.from("invoices").insert({ 
-        id: payload, 
-        user_id: chatId, 
-        amount: finalAmount, // Save the amount that was actually billed
-        type: payload.split("_")[0], 
-        status: "pending", 
-        metadata: { description, title, original_unrounded_amount: amount }, // Store original amount for reference
-        // ПРОАКТИВНОЕ ИСПРАВЛЕНИЕ: Используем `??` вместо `||` чтобы 0 не превращался в null
-        subscription_id: subscription_id ?? null 
-      }); 
-    } catch (dbError: any) { 
+    // Attempt to save the invoice to the DB after it's been sent.
+    // Some flows (e.g. franchize checkout) persist invoices before sending to Telegram,
+    // so we only insert when no existing row is found to avoid duplicate-key noise.
+    try {
+      const { data: existingInvoice, error: invoiceLookupError } = await supabaseAdmin
+        .from("invoices")
+        .select("id")
+        .eq("id", payload)
+        .maybeSingle();
+
+      if (invoiceLookupError) {
+        logger.warn(`Invoice lookup failed before insert (${payload}): ${invoiceLookupError.message}`);
+      }
+
+      if (!existingInvoice?.id) {
+        await supabaseAdmin.from("invoices").insert({
+          id: payload,
+          user_id: chatId,
+          amount: finalAmount, // Save the amount that was actually billed
+          type: payload.split("_")[0],
+          status: "pending",
+          metadata: { description, title, original_unrounded_amount: amount }, // Store original amount for reference
+          // ПРОАКТИВНОЕ ИСПРАВЛЕНИЕ: Используем `??` вместо `||` чтобы 0 не превращался в null
+          subscription_id: subscription_id ?? null,
+        });
+      }
+    } catch (dbError: any) {
       // This is not a fatal error for the user, but should be logged.
-      logger.error(`Failed to save invoice ${payload} to DB after sending: ${dbError.message}`); 
+      logger.error(`Failed to save invoice ${payload} to DB after sending: ${dbError.message}`);
     }
     
     return { success: true, data: data.result };

--- a/app/webhook-handlers/franchize-order.ts
+++ b/app/webhook-handlers/franchize-order.ts
@@ -115,8 +115,13 @@ export const franchizeOrderHandler: WebhookHandler = {
       })
       .eq("rental_id", rentalId);
 
-    const tgDeepLink = `https://t.me/oneBikePlsBot/app?startapp=rental-${rentalId}`;
-    const appLink = `https://v0-car-test.vercel.app/franchize/${slug}/rental/${rentalId}`;
+    const startParam = typeof metadata.startParam === "string" && metadata.startParam.trim().length > 0
+      ? metadata.startParam.trim()
+      : `${metadata.flowType === "sale" || metadata.flowType === "mixed" ? "sale" : "rental"}-${rentalId}`;
+    const tgDeepLink = `https://t.me/oneBikePlsBot/app?startapp=${startParam}`;
+    const appLink = typeof metadata.franchizeRentalLink === "string" && metadata.franchizeRentalLink.trim().length > 0
+      ? metadata.franchizeRentalLink.trim()
+      : `https://v0-car-test.vercel.app/franchize/${slug}/rental/${rentalId}`;
     const catalogLink = `https://v0-car-test.vercel.app/franchize/${slug}`;
 
     const cartLines = Array.isArray(metadata.cartLines) ? metadata.cartLines : [];
@@ -143,7 +148,7 @@ export const franchizeOrderHandler: WebhookHandler = {
       : "• базовый пакет";
 
     const extrasText = extras.length
-      ? extras.map((extra: any) => `• ${safeText(extra?.label)} (+${formatMoney(Number(extra?.price || 0))})`).join("\n")
+      ? extras.map((extra: any) => `• ${safeText(extra?.label)} (+${formatMoney(Number(extra?.amount ?? extra?.price ?? 0))})`).join("\n")
       : "• без допов";
 
     const userMessage = [


### PR DESCRIPTION
### Motivation
- Prevent duplicate-key noise and avoid overwriting or erroring when an invoice row may have been persisted by other flows before sending a Telegram invoice. 
- Make franchize order notifications more robust by deriving deep links and app links from provided metadata and ensuring extras prices display correctly.

### Description
- Before inserting a sent invoice into the `invoices` table, perform a lookup using `.maybeSingle()` and only insert if no existing row is found, while warning on lookup errors to reduce duplicate-key errors. 
- Preserve logging and error handling around Telegram `sendInvoice` responses and log the request body on failures for easier debugging. 
- Compute `startParam` from `metadata.startParam` (trimmed) or fall back to a value based on `metadata.flowType` and `rentalId`, and use `metadata.franchizeRentalLink` (trimmed) when available for the app link. 
- Use `extra.amount ?? extra.price ?? 0` when rendering extras to prefer an explicit `amount` field while falling back to `price` for backward compatibility.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f852238ca48324bf250916d8a973c4)