### PR TITLE
feat(franchize): metadata-driven header logo landing route

### DIFF
--- a/app/franchize/actions.ts
+++ b/app/franchize/actions.ts
@@ -75,6 +75,7 @@ export interface FranchizeHeaderVM {
   brandName: string;
   tagline: string;
   logoUrl: string;
+  logoHref: string;
   menuLinks: Array<{ label: string; href: string }>;
 }
 
@@ -594,6 +595,7 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
         brandName: readPath(franchize, ["branding", "name"], crew.name ?? "Franchize"),
         tagline: readPath(franchize, ["branding", "tagline"], "Ride the vibe"),
         logoUrl: readPath(franchize, ["branding", "logoUrl"], crew.logo_url ?? ""),
+        logoHref: readPath(franchize, ["header", "logoHref"], `/franchize/${crew.slug ?? safeSlug}`),
         menuLinks,
       },
       contacts: {

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -24,6 +24,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
   const [isCompact, setIsCompact] = useState(false);
   const pathname = usePathname();
   const mainCatalogPath = `/franchize/${crew.slug}`;
+  const headerLogoHref = crew.header.logoHref || mainCatalogPath;
   const railRef = useRef<HTMLDivElement | null>(null);
   const prevPathnameRef = useRef<string | null>(null);
 
@@ -179,7 +180,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
 
           {/* HEADER LOGO — PURE SPA LINK */}
           <Link
-            href={mainCatalogPath}
+            href={headerLogoHref}
             className="relative z-10 mx-auto flex flex-col items-center text-center cursor-pointer hover:opacity-90 transition-opacity pointer-events-auto"
           >
             <div

--- a/app/franchize/components/FranchizeAdminClient.tsx
+++ b/app/franchize/components/FranchizeAdminClient.tsx
@@ -35,7 +35,7 @@ const fallbackCrew: FranchizeCrewVM = {
       borderSoft: "#24262E",
     },
   },
-  header: { brandName: "VIP BIKE", tagline: "Ride the vibe", logoUrl: "", menuLinks: [] },
+  header: { brandName: "VIP BIKE", tagline: "Ride the vibe", logoUrl: "", logoHref: "", menuLinks: [] },
   contacts: {
     phone: "",
     email: "",

--- a/docs/FRANCHIZE_METADATA_CONTRACT.md
+++ b/docs/FRANCHIZE_METADATA_CONTRACT.md
@@ -28,6 +28,7 @@ Expected stable blocks:
    - `palette.textSecondary: string`
    - `palette.borderSoft: string`
 3. `header`
+   - `logoHref?: string` (optional; if present, header logo redirects to this path, e.g. `/vipbikerental`)
    - `menuLinks: Array<{ label: string; href: string }>`
 4. `contacts`
    - `phone, email, address, telegram, workingHours: string`
@@ -47,6 +48,7 @@ Expected stable blocks:
 |---|---|---|
 | Theme palette | `theme.palette` or mode bucket (`theme.palette.light/dark`, `theme.palettes.light/dark`) | Pepperolli default palette in `app/franchize/actions.ts` |
 | Header menu | `header.menuLinks` | generated slug-aware defaults (`/franchize/{slug}`, `/about`, `/contacts`, `/cart`) |
+| Header logo click target | `header.logoHref` | `/franchize/{slug}` |
 | Contacts phone/email/address | `contacts.*` | `footer.*` -> crew DB fields (`hq_location`) |
 | Footer social links | `footer.socialLinks` | `footer.columns[].items[]` -> `contacts.telegram` -> `oneBikePlsBot` |
 | Catalog order | `catalog.groupOrder` | derive from catalog item subtype frequency |

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -42,3 +42,9 @@ For every task below, keep these fields updated:
 - Visual system + implementation blueprint: `docs/THE_FRANCHEEZEPLAN_BLUEPRINT.md`
 
 This root file stays intentionally compact so operators and agents can load it quickly in high-frequency loops.
+
+---
+
+## 2) Mini execution diary
+
+- 2026-05-04 — Added support for metadata-driven franchize header logo routing via `header.logoHref` with default fallback to `/franchize/{slug}`; seeded `vip-bike` to land on `/vipbikerental` instead of catalog. Next step: expose `header.logoHref` in admin configurator UI for non-SQL operators.

--- a/docs/sql/vip-bike-franchize-hydration.sql
+++ b/docs/sql/vip-bike-franchize-hydration.sql
@@ -108,6 +108,7 @@ set
           'showBackButton', false,
           'title', 'VIP BIKE RENTAL',
           'subtitle', 'Нижний Новгород',
+          'logoHref', '/vipbikerental',
           'menuLinks', jsonb_build_array(
             jsonb_build_object('label', 'Каталог', 'href', '/franchize/{slug}'),
             jsonb_build_object('label', 'О нас', 'href', '/franchize/{slug}/about'),


### PR DESCRIPTION
### Motivation

- Make the header logo click target configurable per-franchize via metadata instead of special-casing `vip-bike`, so each franchize can route its logo to a chosen landing page.
- Seed `vip-bike` should land on `/vipbikerental` as a product-friendly landing rather than the catalog.

### Description

- Added optional `header.logoHref` to the runtime view model (`FranchizeHeaderVM`) and hydrate it from metadata with a fallback to `/franchize/{slug}` via `readPath` in `app/franchize/actions.ts`.
- Updated `CrewHeader` (`app/franchize/components/CrewHeader.tsx`) to use `crew.header.logoHref || /franchize/{slug}` as the logo link target for SPA-safe navigation.
- Seeded VIP BIKE metadata in `docs/sql/vip-bike-franchize-hydration.sql` to include `'logoHref', '/vipbikerental'` so the vip-bike header routes to `/vipbikerental` by default.
- Added docs and bookkeeping: updated `docs/FRANCHIZE_METADATA_CONTRACT.md` to document `header.logoHref`, appended a diary note in `docs/THE_FRANCHEEZEPLAN.md`, and adjusted the admin mock in `FranchizeAdminClient` to include `logoHref`.

### Testing

- Ran `npm run -s lint`, which failed due to pre-existing repository lint/rule violations (including `react-hooks/rules-of-hooks` in `app/franchize/components/SaleBikeLandingClient.tsx`) and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87c539abc8324b03f2c27f3d1f693)