### PR TITLE
Add VIN audit and bulk-fill (synthetic VIN) to admin/franchize UIs; minor CarSubmissionForm UI tweaks

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -28,6 +28,24 @@ import { cn } from "@/lib/utils";
 
 type Vehicle = Database['public']['Tables']['cars']['Row'];
 
+const normalizeVin = (value: unknown) => (typeof value === "string" ? value.trim().toUpperCase() : "");
+
+const VIN_ALLOWED = "ABCDEFGHJKLMNPRSTUVWXYZ0123456789";
+
+const buildSyntheticVin = (vehicle: Vehicle) => {
+  const raw = `${vehicle.make ?? ""}${vehicle.model ?? ""}${vehicle.year ?? ""}${vehicle.id ?? ""}`.toUpperCase();
+  const mapped = raw
+    .replace(/I/g, "1")
+    .replace(/O/g, "0")
+    .replace(/Q/g, "0")
+    .replace(/[^A-Z0-9]/g, "");
+  const normalized = mapped
+    .split("")
+    .map((char) => (VIN_ALLOWED.includes(char) ? char : "X"))
+    .join("");
+  return (normalized + "CARTESTVIN00000000").slice(0, 17);
+};
+
 // === QUICK STATS COMPONENT ===
 function AdminQuickStats({ vehicles, isAdmin }: { vehicles: Vehicle[]; isAdmin: boolean }) {
   const stats = useMemo(() => {
@@ -231,6 +249,7 @@ function AdminPageContent() {
   const [typeFilter, setTypeFilter] = useState<"all" | "bike" | "car">("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [isBulkFillingVin, setIsBulkFillingVin] = useState(false);
 
   const fetchUserVehicles = useCallback(async (userId: string) => {
     setIsFetchingVehicles(true);
@@ -308,6 +327,47 @@ function AdminPageContent() {
       });
   }, [userVehicles, typeFilter, searchQuery]);
 
+
+
+  const vinAudit = useMemo(() => {
+    const target = userVehicles.filter(v => v.type === "bike" || v.type === "car");
+    const missing = target.filter(v => !normalizeVin(v.specs?.vin));
+    return {
+      total: target.length,
+      withVin: target.length - missing.length,
+      missing,
+    };
+  }, [userVehicles]);
+
+  const handleBulkFillVin = useCallback(async () => {
+    if (!dbUser?.user_id || !vinAudit.missing.length) return;
+    setIsBulkFillingVin(true);
+    try {
+      for (const vehicle of vinAudit.missing) {
+        const syntheticVin = buildSyntheticVin(vehicle);
+        const res = await fetch('/api/cars', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...vehicle,
+            specs: {
+              ...(vehicle.specs || {}),
+              vin: syntheticVin,
+            },
+          }),
+        });
+        if (!res.ok) {
+          throw new Error(`VIN bulk-fill failed for ${vehicle.make} ${vehicle.model}`);
+        }
+      }
+      toast.success(`VIN заполнен для ${vinAudit.missing.length} карточек`);
+      await fetchUserVehicles(dbUser.user_id);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Не удалось выполнить bulk-fill VIN');
+    } finally {
+      setIsBulkFillingVin(false);
+    }
+  }, [dbUser?.user_id, vinAudit.missing, fetchUserVehicles]);
   const handleVehicleSelect = (vehicle: Vehicle | null) => {
     setSelectedVehicle(vehicle);
     if (vehicle) {
@@ -482,7 +542,20 @@ function AdminPageContent() {
                   </AnimatePresence>
                 </div>
 
-                {/* VIN Hint */}
+                {/* VIN Audit */}
+                <div className="rounded border border-brand-lime/20 bg-brand-lime/5 px-3 py-2 space-y-2">
+                  <p className="text-[10px] sm:text-[11px] text-zinc-300 font-mono">
+                    VIN аудит: <span className="text-brand-lime">{vinAudit.withVin}</span> / {vinAudit.total} заполнено
+                  </p>
+                  {vinAudit.missing.length > 0 && (
+                    <p className="text-[10px] text-amber-300 font-mono">Пустых VIN: {vinAudit.missing.length}</p>
+                  )}
+                  {isTrulyAdmin && vinAudit.missing.length > 0 && (
+                    <Button size="sm" variant="outline" onClick={handleBulkFillVin} disabled={isBulkFillingVin} className="h-7 text-[11px]">
+                      {isBulkFillingVin ? 'Заполняю VIN…' : 'Bulk-fill VIN'}
+                    </Button>
+                  )}
+                </div>
                 <p className="text-[10px] sm:text-[11px] text-zinc-500 font-mono bg-black/30 px-3 py-2 rounded">
                   💡 Для генерации договоров добавляй <code className="text-brand-lime">vin</code> в specs карточки
                 </p>

--- a/app/franchize/components/FranchizeAdminClient.tsx
+++ b/app/franchize/components/FranchizeAdminClient.tsx
@@ -15,6 +15,24 @@ import type { Database } from "@/types/database.types";
 
 type Vehicle = Database["public"]["Tables"]["cars"]["Row"];
 
+const normalizeVin = (value: unknown) => (typeof value === "string" ? value.trim().toUpperCase() : "");
+
+const VIN_ALLOWED = "ABCDEFGHJKLMNPRSTUVWXYZ0123456789";
+
+const buildSyntheticVin = (vehicle: Vehicle) => {
+  const raw = `${vehicle.make ?? ""}${vehicle.model ?? ""}${vehicle.year ?? ""}${vehicle.id ?? ""}`.toUpperCase();
+  const mapped = raw
+    .replace(/I/g, "1")
+    .replace(/O/g, "0")
+    .replace(/Q/g, "0")
+    .replace(/[^A-Z0-9]/g, "");
+  const normalized = mapped
+    .split("")
+    .map((char) => (VIN_ALLOWED.includes(char) ? char : "X"))
+    .join("");
+  return (normalized + "CARTESTVIN00000000").slice(0, 17);
+};
+
 const fallbackCrew: FranchizeCrewVM = {
   id: "",
   slug: "vip-bike",
@@ -68,6 +86,7 @@ export function FranchizeAdminClient({ initialSlug, editId }: FranchizeAdminClie
   const [loadingFleet, setLoadingFleet] = useState(false);
   const [failedNotifications, setFailedNotifications] = useState<Array<{ orderId: string; sendTo: string; lastError: string; createdAt: string }>>([]);
   const [retryingOrderId, setRetryingOrderId] = useState<string | null>(null);
+  const [isBulkFillingVin, setIsBulkFillingVin] = useState(false);
 
   const slug = initialSlug?.trim() || "vip-bike";
 
@@ -143,6 +162,40 @@ export function FranchizeAdminClient({ initialSlug, editId }: FranchizeAdminClie
     () => fleet.filter((item) => (filterType === "all" ? true : item.type === filterType)),
     [fleet, filterType],
   );
+
+
+  const vinAudit = useMemo(() => {
+    const target = fleet.filter((item) => item.type === "bike" || item.type === "car");
+    const missing = target.filter((item) => !normalizeVin(item.specs?.vin));
+    return { total: target.length, withVin: target.length - missing.length, missing };
+  }, [fleet]);
+
+  const handleBulkFillVin = useCallback(async () => {
+    if (!vinAudit.missing.length) return;
+    setIsBulkFillingVin(true);
+    try {
+      for (const vehicle of vinAudit.missing) {
+        const response = await fetch('/api/cars', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...vehicle,
+            specs: {
+              ...(vehicle.specs || {}),
+              vin: buildSyntheticVin(vehicle),
+            },
+          }),
+        });
+        if (!response.ok) throw new Error(`VIN bulk-fill failed for ${vehicle.make} ${vehicle.model}`);
+      }
+      toast.success(`VIN заполнен для ${vinAudit.missing.length} карточек`);
+      await loadFleet();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Не удалось выполнить bulk-fill VIN');
+    } finally {
+      setIsBulkFillingVin(false);
+    }
+  }, [vinAudit.missing, loadFleet]);
 
   const surface = crewPaletteForSurface(crew.theme);
   const buttonFocus = focusRingOutlineStyle(crew.theme);
@@ -222,6 +275,15 @@ export function FranchizeAdminClient({ initialSlug, editId }: FranchizeAdminClie
             Доступно записей по фильтру: <span className="font-semibold text-[var(--fr-admin-accent)]">{visible.length}</span>.
             {loadingFleet ? " Обновляем список..." : ""}
           </p>
+          <div className="mt-2 rounded-xl border px-3 py-2" style={{ borderColor: "var(--fr-admin-border)", backgroundColor: "rgba(217,154,0,0.08)" }}>
+            <p className="text-xs text-[var(--fr-admin-text)]">VIN аудит: <span className="font-semibold">{vinAudit.withVin}</span> / {vinAudit.total} заполнено</p>
+            {vinAudit.missing.length > 0 && <p className="mt-1 text-xs text-amber-300">Пустых VIN: {vinAudit.missing.length}</p>}
+            {vinAudit.missing.length > 0 && (
+              <Button type="button" variant="outline" className="mt-2 h-8 text-xs" onClick={() => void handleBulkFillVin()} disabled={isBulkFillingVin}>
+                {isBulkFillingVin ? "Заполняю VIN…" : "Bulk-fill VIN"}
+              </Button>
+            )}
+          </div>
         </div>
 
         <div className="mt-4 rounded-2xl border p-3" style={{ ...surface.subtleCard, borderColor: "var(--fr-admin-border)" }}>

--- a/components/CarSubmissionForm.tsx
+++ b/components/CarSubmissionForm.tsx
@@ -407,7 +407,17 @@ export function CarSubmissionForm({ ownerId = null, vehicleToEdit = null, onSucc
                 <div key={s.id} className="flex flex-col gap-2 lg:flex-row">
                   <Input value={s.key} onChange={(e) => updateSpec(s.id, "key", e.target.value)} placeholder="ключ (например engine_cc)" className="input-cyber" />
                   <Input value={s.value} onChange={(e) => updateSpec(s.id, "value", e.target.value)} placeholder="значение" className="input-cyber" />
-                  <Button type="button" variant="destructive" className="sm:w-auto" onClick={() => removeSpec(s.id)}>Удалить</Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    className="h-9 sm:h-10 sm:w-auto sm:px-3 px-2"
+                    onClick={() => removeSpec(s.id)}
+                    aria-label="Удалить характеристику"
+                  >
+                    <VibeContentRenderer content="::FaTrashCan::" className="h-3.5 w-3.5 sm:mr-1" />
+                    <span className="hidden sm:inline">Удалить</span>
+                  </Button>
                 </div>
               ))}
               <Button type="button" onClick={addSpec} variant="outline">Добавить характеристику</Button>


### PR DESCRIPTION
### Motivation
- Provide a quick audit of missing VINs in admin and franchize fleet views and allow privileged users to bulk-fill missing VINs to support document generation and integrations.
- Create a deterministic synthetic VIN generator for bulk-filling to avoid blank VIN fields while keeping values safe for testing/placeholder use.

### Description
- Added `normalizeVin`, `VIN_ALLOWED` and `buildSyntheticVin` helpers and a `vinAudit` computed summary to the admin (`app/admin/page.tsx`) and franchize admin (`app/franchize/components/FranchizeAdminClient.tsx`) clients. 
- Implemented `handleBulkFillVin` in both admin and franchize clients which PUTs updated vehicle objects with a synthetic VIN to `/api/cars`, shows toast feedback, and refreshes the vehicle list; added `isBulkFillingVin` state to track progress.
- Rendered VIN audit UI blocks that display total/filled/missing counts and expose a `Bulk-fill VIN` button for authorized users, and added small UX text changes to hint VIN importance for doc templates.
- Updated `CarSubmissionForm` to improve the specs-item delete button with an icon, size and an `aria-label` for accessibility, and adjusted button sizing/styling.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87b8cc2248324be087d345e8c512e)
supaplan_task: 3bf18c26-cf39-46c7-875d-209b41c1ec81