### PR TITLE
feat(franchize): improve PC market layout and squarer item cards

### DIFF
--- a/app/franchize/[slug]/configurator/ConfiguratorClient.tsx
+++ b/app/franchize/[slug]/configurator/ConfiguratorClient.tsx
@@ -336,7 +336,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
         {/* ── HERO ── */}
         <div className="relative overflow-hidden border-b border-[#27272a]">
           <div className="absolute -top-40 left-1/2 h-[500px] w-[800px] -translate-x-1/2 rounded-full opacity-20" style={{ background: 'radial-gradient(ellipse, #00ffea 0%, transparent 70%)' }} />
-          <div className="relative mx-auto max-w-6xl px-4 pb-8 pt-10 sm:pt-14">
+          <div className="relative mx-auto max-w-7xl px-4 pb-8 pt-10 sm:pt-14 2xl:max-w-[1600px]">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
               <div>
                 <p className="cfg-mono mb-2 text-[11px] font-medium uppercase tracking-[0.25em] text-[#00ffea]">Конфигуратор</p>
@@ -354,7 +354,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
         </div>
 
         {/* ── CONTENT ── */}
-        <div className="mx-auto max-w-6xl px-4 py-6 pb-20 sm:pb-8">
+        <div className="mx-auto max-w-7xl px-4 py-6 pb-20 sm:pb-8 2xl:max-w-[1600px]">
           <StepBar current={tab} goTo={(s) => setTab(s as ConfigStep)} disabled={tabDisabled} />
 
           {/* ═══ STEP 1: MODEL ═══ */}
@@ -370,13 +370,13 @@ export function ConfiguratorClient({ crew, slug }: Props) {
               </div>
               <p className="cfg-mono text-xs text-[#71717a]">Найдено: <span className="font-bold text-white">{filteredBikes.length}</span> моделей</p>
 
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 cfg-stagger">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 cfg-stagger">
                 {filteredBikes.map((bike) => {
                   const isSelected = selectedBikeId === bike.id
                   return (
                     <article key={bike.id} className={['group relative overflow-hidden rounded-2xl border bg-[#111113] cfg-card-hover', isSelected ? 'cfg-selected-ring border-[#00ffea]' : 'border-[#27272a]'].join(' ')}>
                       <button type="button" className="block w-full text-left" onClick={() => selectBike(bike.id)}>
-                        <div className="cfg-img-wrap relative aspect-[4/3] w-full overflow-hidden">
+                        <div className="cfg-img-wrap relative aspect-[4/3] w-full overflow-hidden lg:aspect-square">
                           <Image src={bike.image_url} alt={`${bike.make} ${bike.model}`} fill className="object-cover transition-transform duration-700 group-hover:scale-105" unoptimized />
                           <div className="absolute inset-0 bg-gradient-to-t from-[#09090b] via-transparent to-transparent opacity-60" />
                           <div className="absolute left-3 top-3"><TierBadge tier={bike.specs.tier} /></div>

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -236,7 +236,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
   return (
     <>
       <section
-        className="mx-auto w-full max-w-4xl px-4 pb-6 pt-8"
+        className="mx-auto w-full max-w-7xl px-4 pb-6 pt-8 2xl:max-w-[1600px]"
         id="catalog-sections"
         style={{
           ["--catalog-accent" as string]: crew.theme.palette.accentMain,
@@ -395,7 +395,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
                     {group.items.length} шт.
                   </span>
                 </div>
-                <div className="grid grid-cols-2 gap-3">
+                <div className="grid grid-cols-2 gap-3 xl:grid-cols-3 2xl:grid-cols-4">
                   {group.items.map((item) => (
                     <article
                       key={item.id}
@@ -411,9 +411,9 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
                         onBlur={() => setFocusedItemId((prev) => (prev === item.id ? null : prev))}
                         style={focusedItemId === item.id ? interactionRingStyle(crew.theme) : undefined}
                       >
-                        <div className="relative h-28 w-full">
+                        <div className="relative aspect-[4/3] w-full lg:aspect-square">
                           {item.imageUrl ? (
-                            <Image src={item.imageUrl} alt={item.title} fill sizes="(max-width: 768px) 50vw, 280px" className="object-cover" unoptimized />
+                            <Image src={item.imageUrl} alt={item.title} fill sizes="(max-width: 768px) 50vw, (max-width: 1279px) 33vw, (max-width: 1535px) 24vw, 20vw" className="object-cover" unoptimized />
                           ) : (
                             <div className="flex h-full w-full items-center justify-center px-3 text-center text-xs" style={surface.mutedText}>Изображение байка скоро загрузим</div>
                           )}

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -413,7 +413,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
                       >
                         <div className="relative aspect-[4/3] w-full lg:aspect-square">
                           {item.imageUrl ? (
-                            <Image src={item.imageUrl} alt={item.title} fill sizes="(max-width: 768px) 50vw, (max-width: 1279px) 33vw, (max-width: 1535px) 24vw, 20vw" className="object-cover" unoptimized />
+                            <Image src={item.imageUrl} alt={item.title} fill sizes="(max-width: 1279px) 50vw, (max-width: 1535px) 33vw, 25vw" className="object-cover" unoptimized />
                           ) : (
                             <div className="flex h-full w-full items-center justify-center px-3 text-center text-xs" style={surface.mutedText}>Изображение байка скоро загрузим</div>
                           )}

--- a/app/franchize/components/CrewFooter.tsx
+++ b/app/franchize/components/CrewFooter.tsx
@@ -31,7 +31,7 @@ export function CrewFooter({ crew }: CrewFooterProps) {
         ["--footer-sub-bg" as string]: "#cd940d",
       }}
     >
-      <div className="mx-auto grid w-full max-w-4xl gap-x-8 gap-y-10 px-4 py-8 md:grid-cols-2">
+      <div className="mx-auto grid w-full max-w-7xl gap-x-8 gap-y-10 px-4 py-8 md:grid-cols-2">
         <section>
           <h3 className="text-3xl font-semibold leading-none text-[var(--footer-text)]">Контакты</h3>
           <ul className="mt-5 space-y-1 text-base">
@@ -86,7 +86,7 @@ export function CrewFooter({ crew }: CrewFooterProps) {
       </div>
 
       <div className="border-t border-[var(--footer-border)] bg-[var(--footer-sub-bg)]">
-        <div className="mx-auto flex w-full max-w-4xl items-center justify-between px-4 py-3 text-xs">
+        <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-4 py-3 text-xs">
           <span>{new Date().getFullYear()} © {crew.header.brandName}</span>
           <span>Версия: FR-PEP-02</span>
         </div>

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -148,7 +148,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
         color: crew.theme.palette.textPrimary,
       }}
     >
-      <div className="mx-auto w-full max-w-4xl overflow-hidden">
+      <div className="mx-auto w-full max-w-7xl overflow-hidden">
         <div
           style={{
             display: "grid",
@@ -224,7 +224,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
           {/* Добавлен класс 'relative' для корректного расчета offsetLeft дочерних элементов */}
           <div
             ref={railRef}
-            className="relative mx-auto flex w-full max-w-4xl gap-2 overflow-x-auto no-scrollbar pb-1 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden snap-x snap-mandatory"
+            className="relative mx-auto flex w-full max-w-7xl gap-2 overflow-x-auto no-scrollbar pb-1 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden snap-x snap-mandatory"
           >
             {visibleRailLinks.map((linkLabel) => {
               const targetId = toCategoryId(linkLabel);


### PR DESCRIPTION
### Motivation
- Make the franchize market view use wider desktop/ultra-wide screens and improve card proportions so item images look squarer on PC layouts.

### Description
- Increased the catalog container cap from `max-w-4xl` to `max-w-7xl` and added a larger `2xl:max-w-[1600px]` cap for ultra-wide screens in `app/franchize/components/CatalogClient.tsx`.
- Expanded the product grid responsiveness by adding `xl:grid-cols-3` and `2xl:grid-cols-4` so more cards appear per row on larger viewports.
- Replaced the fixed short banner image area (`h-28`) with an aspect-aware container (`aspect-[4/3] w-full lg:aspect-square`) to produce squarer media on large screens.
- Updated the responsive `sizes` attribute on `next/image` to match the new grid breakpoints for better image selection and performance.

### Testing
- No automated tests were executed for this change because it is a UI-only Tailwind/layout tweak; visual verification is recommended in a desktop browser or storybook preview.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f883a2c344832499d5bbe20b2c2d4a)