### PR TITLE
Add Franchize error pages and client-side ErrorBoundary; wrap catalog and rentals

### DIFF
--- a/app/franchize/[slug]/error.tsx
+++ b/app/franchize/[slug]/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { debugLogger } from "@/lib/debugLogger";
+
+export default function FranchizeSlugError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    debugLogger.error("[franchize/[slug]/error]", error);
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex min-h-[60vh] w-full max-w-2xl flex-col justify-center px-4 py-10">
+      <p className="text-xs uppercase tracking-[0.2em] text-red-400">crew shell error</p>
+      <h1 className="mt-2 text-2xl font-semibold">Экипаж временно недоступен</h1>
+      <p className="mt-3 text-sm text-muted-foreground">Не удалось загрузить страницу франшизы. Это может быть сетевой сбой или ошибка данных.</p>
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button type="button" onClick={reset} className="rounded-xl border px-3 py-1.5 text-sm">
+          Повторить
+        </button>
+        <Link href="/franchize" className="rounded-xl border px-3 py-1.5 text-sm">
+          Все франшизы
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/franchize/[slug]/page.tsx
+++ b/app/franchize/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { CrewFooter } from "../components/CrewFooter";
 import { CrewHeader } from "../components/CrewHeader";
 import { CatalogClient } from "../components/CatalogClient";
+import { FranchizeErrorBoundary } from "../components/ErrorBoundary";
 import { getFranchizeBySlug } from "../actions";
 import { crewPaletteForSurface } from "../lib/theme";
 
@@ -16,7 +17,14 @@ export default async function FranchizeSlugPage({ params }: FranchizeSlugPagePro
   return (
     <main className="min-h-screen" style={surface.page}>
       <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}`} groupLinks={items.map((item) => item.category)} />
-      <CatalogClient crew={crew} slug={slug} items={items} />
+      <FranchizeErrorBoundary
+        resetKey={slug}
+        fallbackTitle="Каталог недоступен"
+        fallbackHref={`/franchize/${crew.slug || slug}`}
+        fallbackLinkLabel="Обновить каталог экипажа"
+      >
+        <CatalogClient crew={crew} slug={slug} items={items} />
+      </FranchizeErrorBoundary>
       <CrewFooter crew={crew} />
     </main>
   );

--- a/app/franchize/[slug]/rentals/page.tsx
+++ b/app/franchize/[slug]/rentals/page.tsx
@@ -3,6 +3,7 @@ import { getFranchizeBySlug } from "../../actions";
 import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
 import { FranchizeRentalsBridge } from "../../components/FranchizeRentalsBridge";
+import { FranchizeErrorBoundary } from "../../components/ErrorBoundary";
 
 interface FranchizeRentalsPageProps {
   params: Promise<{ slug: string }>;
@@ -32,7 +33,14 @@ export default async function FranchizeRentalsPage({ params }: FranchizeRentalsP
           </Link>
         </div>
 
-        <FranchizeRentalsBridge />
+        <FranchizeErrorBoundary
+          resetKey={slug}
+          fallbackTitle="Раздел аренд временно недоступен"
+          fallbackHref={`/franchize/${crew.slug || slug}/rentals`}
+          fallbackLinkLabel="Остаться в арендном разделе"
+        >
+          <FranchizeRentalsBridge />
+        </FranchizeErrorBoundary>
       </section>
       <CrewFooter crew={crew} />
     </>

--- a/app/franchize/components/ErrorBoundary.tsx
+++ b/app/franchize/components/ErrorBoundary.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React, { Component, type ErrorInfo, type ReactNode } from "react";
+import Link from "next/link";
+import { debugLogger } from "@/lib/debugLogger";
+
+interface FranchizeErrorBoundaryProps {
+  children: ReactNode;
+  fallbackTitle?: string;
+  fallbackMessage?: string;
+  resetKey?: string | number;
+  fallbackHref?: string;
+  fallbackLinkLabel?: string;
+}
+
+interface FranchizeErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class FranchizeErrorBoundary extends Component<FranchizeErrorBoundaryProps, FranchizeErrorBoundaryState> {
+  state: FranchizeErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): FranchizeErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    debugLogger.error("[FranchizeErrorBoundary]", error, errorInfo);
+  }
+
+  componentDidUpdate(prevProps: FranchizeErrorBoundaryProps): void {
+    if (this.props.resetKey !== prevProps.resetKey && this.state.hasError) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <section className="mx-auto mt-4 w-full rounded-2xl border border-red-500/40 bg-red-950/20 p-4 text-red-50">
+        <p className="text-xs uppercase tracking-[0.2em] text-red-300">franchize error boundary</p>
+        <h2 className="mt-2 text-lg font-semibold">{this.props.fallbackTitle ?? "Что-то пошло не так"}</h2>
+        <p className="mt-2 text-sm text-red-100/90">
+          {this.props.fallbackMessage ??
+            "Похоже, виджет временно недоступен. Попробуйте повторить действие или вернуться в каталог."}
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2 text-sm">
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="rounded-xl border border-red-300/60 px-3 py-1.5 transition hover:bg-red-500/20"
+          >
+            Повторить
+          </button>
+          <Link
+            href={this.props.fallbackHref ?? "/franchize"}
+            className="rounded-xl border border-red-300/60 px-3 py-1.5 transition hover:bg-red-500/20"
+          >
+            {this.props.fallbackLinkLabel ?? "К списку франшиз"}
+          </Link>
+        </div>
+      </section>
+    );
+  }
+}

--- a/app/franchize/error.tsx
+++ b/app/franchize/error.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { debugLogger } from "@/lib/debugLogger";
+
+export default function FranchizeSegmentError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    debugLogger.error("[franchize/error]", error);
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex min-h-[60vh] w-full max-w-2xl flex-col justify-center px-4 py-10">
+      <p className="text-xs uppercase tracking-[0.2em] text-red-400">franchize route error</p>
+      <h1 className="mt-2 text-2xl font-semibold">Ошибка в разделе franchize</h1>
+      <p className="mt-3 text-sm text-muted-foreground">Мы уже получили сигнал о проблеме. Попробуйте перезагрузить экран или открыть раздел позже.</p>
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button type="button" onClick={reset} className="rounded-xl border px-3 py-1.5 text-sm">
+          Повторить
+        </button>
+        <Link href="/franchize" className="rounded-xl border px-3 py-1.5 text-sm">
+          К франшизам
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation

- Surface friendly client-side error UIs for the `franchize` route and per-slug pages so users see actionable messages when widgets fail.
- Improve resiliency of client widgets by isolating failures with an Error Boundary to avoid entire pages crashing.

### Description

- Added a client-side error page `app/franchize/error.tsx` that logs errors via `debugLogger` and offers retry and navigation to `/franchize`.
- Added a client-side per-slug error page `app/franchize/[slug]/error.tsx` that logs errors via `debugLogger` and provides retry and navigation back to the franchise list.
- Implemented a reusable class-based `FranchizeErrorBoundary` component at `app/franchize/components/ErrorBoundary.tsx` that logs caught errors, supports a `resetKey` prop to auto-reset, and renders a configurable fallback UI with retry and link actions.
- Wrapped `CatalogClient` in `FranchizeErrorBoundary` in `app/franchize/[slug]/page.tsx` and wrapped `FranchizeRentalsBridge` in `FranchizeErrorBoundary` in `app/franchize/[slug]/rentals/page.tsx` with descriptive fallback text and links.

### Testing

- Ran TypeScript type-check with `tsc --noEmit`, which completed successfully.
- Performed a production build with `next build`, which completed without errors for the modified files.
- Linting and existing automated tests were not changed by this PR and continued to pass in my environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8833e9b2883248f97f760fdaa7e6d)
supaplan_task: 18d6c92d-de5f-4e83-973f-8f0cc048ce45