### PR TITLE
Disable confirm while deleting and show meetup owner info in confirm modal

### DIFF
--- a/app/franchize/components/FranchizeConfirmModal.tsx
+++ b/app/franchize/components/FranchizeConfirmModal.tsx
@@ -19,6 +19,7 @@ type FranchizeConfirmModalProps = {
   confirmText?: string;
   cancelText?: string;
   variant?: "danger" | "default";
+  confirmDisabled?: boolean;
 };
 
 export function FranchizeConfirmModal({
@@ -30,6 +31,7 @@ export function FranchizeConfirmModal({
   confirmText = "Подтвердить",
   cancelText = "Отмена",
   variant = "default",
+  confirmDisabled = false,
 }: FranchizeConfirmModalProps) {
   const confirmClass =
     variant === "danger"
@@ -41,13 +43,13 @@ export function FranchizeConfirmModal({
       <DialogContent className="border-white/20 bg-zinc-950/95 text-white backdrop-blur-md">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription className="text-zinc-300">{message}</DialogDescription>
+          <DialogDescription className="whitespace-pre-line text-zinc-300">{message}</DialogDescription>
         </DialogHeader>
         <DialogFooter>
           <Button type="button" variant="outline" onClick={onClose}>
             {cancelText}
           </Button>
-          <Button type="button" className={confirmClass} onClick={onConfirm}>
+          <Button type="button" className={confirmClass} onClick={onConfirm} disabled={confirmDisabled}>
             {confirmText}
           </Button>
         </DialogFooter>

--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -184,6 +184,18 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
   }, [dbUser?.user_id, state.selectedMeetupPoint]);
 
   const selectedMeetup = useMemo(() => state.meetups.find((meetup) => meetup.id === selectedMeetupId) || null, [state.meetups, selectedMeetupId]);
+  const selectedMeetupOwnerLabel = useMemo(() => {
+    if (!selectedMeetup) return null;
+    const fullName = selectedMeetup.users?.full_name?.trim();
+    const username = selectedMeetup.users?.username?.trim();
+    if (fullName) return fullName;
+    if (username) return `@${username}`;
+    return selectedMeetup.created_by_user_id;
+  }, [selectedMeetup]);
+  const isSelectedMeetupOwnedByCurrentUser = useMemo(() => {
+    if (!selectedMeetup || !dbUser?.user_id) return false;
+    return selectedMeetup.created_by_user_id === dbUser.user_id;
+  }, [dbUser?.user_id, selectedMeetup]);
 
   const handleMeetupDelete = useCallback(async () => {
     if (!dbUser?.user_id) {
@@ -539,8 +551,15 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
         onClose={() => setIsConfirmOpen(false)}
         onConfirm={handleConfirmDelete}
         title="Удалить meetup?"
-        message={selectedMeetup ? `Удалить meetup «${selectedMeetup.title}»?` : "Удалить выбранную точку встречи?"}
-        confirmText="Удалить"
+        confirmDisabled={isMeetupDeleting}
+        message={
+          selectedMeetup
+            ? `Удалить meetup «${selectedMeetup.title}»?\n\nВладелец: ${selectedMeetupOwnerLabel || "неизвестно"}${
+                isSelectedMeetupOwnedByCurrentUser ? " (вы)" : ""
+              }.\nУдаление доступно автору, owner экипажа или admin.`
+            : "Удалить выбранную точку встречи?"
+        }
+        confirmText={isMeetupDeleting ? "Удаляем…" : "Удалить"}
         cancelText="Отмена"
         variant="danger"
       />


### PR DESCRIPTION
### Motivation
- Prevent duplicate meetup deletion actions and provide user feedback when a delete is in progress by disabling the confirm button.
- Surface the meetup owner information in the confirmation dialog so users understand who created the meetup and whether they have permission to delete it.
- Preserve message formatting with line breaks in the modal description.

### Description
- Added a `confirmDisabled?: boolean` prop and a default value to `FranchizeConfirmModal` and wired it to the confirm `Button`'s `disabled` prop via `disabled={confirmDisabled}`.
- Made `DialogDescription` respect newlines by adding the `whitespace-pre-line` class.
- In `MapRidersClientRefactored`, introduced `selectedMeetupOwnerLabel` and `isSelectedMeetupOwnedByCurrentUser` helpers to compute owner display and ownership status.
- Updated the meetup delete confirmation usage to pass `confirmDisabled={isMeetupDeleting}`, include owner info and permission note in the `message`, and show a dynamic `confirmText` that becomes `"Удаляем…"` while deleting.

### Testing
- Ran TypeScript type-check and a local development build (`next build`/`tsc`) which succeeded.
- Ran project linters which reported no new issues.
- No new unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8834899ec83249e185dbf8054b5de)
supaplan_task: 6e7c4e2c-25fe-4d3c-ae87-3e5497a4b1e2