### PR TITLE
Surface contract verifier details on rental card and add reconciliation action

### DIFF
--- a/app/franchize/[slug]/rental/[id]/page.tsx
+++ b/app/franchize/[slug]/rental/[id]/page.tsx
@@ -78,6 +78,11 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
                 record: {rental.docVerifierRecordId.slice(0, 8)}…
               </span>
             ) : null}
+            {rental.contractSourceScope ? (
+              <span className="text-[11px]" style={{ color: crew.theme.palette.textSecondary }}>
+                source: {rental.contractSourceScope}
+              </span>
+            ) : null}
           </div>
           <div className="grid gap-3 text-sm sm:grid-cols-2">
             <p><span style={{ color: crew.theme.palette.textSecondary }}>Rental ID:</span> {rental.rentalId}</p>
@@ -85,6 +90,11 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
             <p><span style={{ color: crew.theme.palette.textSecondary }}>Оплата:</span> {rental.paymentStatus}</p>
             <p><span style={{ color: crew.theme.palette.textSecondary }}>Итого:</span> {rental.totalCost.toLocaleString("ru-RU")} ₽</p>
             <p className="sm:col-span-2"><span style={{ color: crew.theme.palette.textSecondary }}>Транспорт:</span> {rental.vehicleTitle}</p>
+            {rental.contractOriginalSha256 ? (
+              <p className="sm:col-span-2 break-all">
+                <span style={{ color: crew.theme.palette.textSecondary }}>Contract SHA256:</span> {rental.contractOriginalSha256}
+              </p>
+            ) : null}
           </div>
 
           <div className="mt-5 grid gap-2 sm:grid-cols-2">

--- a/app/franchize/[slug]/rental/[id]/todo.md
+++ b/app/franchize/[slug]/rental/[id]/todo.md
@@ -1,0 +1,45 @@
+# RENT-P0.2 — Rental contract E2E wiring (DOCX → doc-verifier → rental record attachment)
+
+- **Task UUID:** `0642f801-4e7e-4620-90fa-ca4ecab9f206`
+- **Capability:** `franchize.backend.supabase`
+- **Scope:** `app/franchize/[slug]/rental/[id]/*`
+- **Status:** `completed` ✅
+- **Completed at:** `2026-05-04`
+
+## Delivered
+
+- [x] Investigated and documented integration points for:
+  - DOCX generation capability (`buildFranchizeDocxFromTemplate`)
+  - `doc-verifier` registration/verification storage path
+  - buy/rent order flow contract attachment step
+  - configurator flow verifier registration
+- [x] Added guardrail logging in rental attachment path (`buildFranchizeOrderDocAndNotify`) for:
+  - rental lookup errors,
+  - rental-not-found by `metadata.orderId`,
+  - rental metadata update failures.
+- [x] Normalized rental-card verifier status parsing (`verified|ok|valid` => verified; explicit `expired` respected).
+- [x] Surfaced verifier diagnostics on rental card:
+  - `sourceScope`
+  - `originalSha256`
+- [x] Added reconciliation server action:
+  - `reconcileRentalContractVerifierAttachment({ rentalId, orderId?, flowType?, slug? })`
+  - backfills `rentals.metadata.contract_verifier` using `doc_verifier_records` lookup by `(integration_scope, document_key)`.
+
+## Final contract shape (runtime)
+
+`rentals.metadata.contract_verifier` expected fields:
+
+- `scope: string` — canonical rental scope (`rental:<rental_id>`)
+- `sourceScope: string` — source order scope (`<flowType>:<slug>:<orderId>`)
+- `documentKey: string` — deterministic key (`rental-<slug>-<orderId>` or `sale-...`)
+- `docVerifierRecordId: string | null`
+- `originalSha256: string`
+- `status: "verified" | "not_verified" | "expired"`
+- `verifiedAt: ISO timestamp`
+- `expiresAt: ISO timestamp | null`
+
+## Notes
+
+- Configurator flow intentionally registers DOCX in verifier without rental attachment, since it is pre-order lead flow.
+- Reconciliation action is idempotent for same record pair and can be used by operator tooling/cron to repair partial failures.
+- This `todo.md` is kept intentionally as a scoped execution artifact for RENT-P0.2 traceability; do not delete unless task-tracking policy changes.

--- a/app/franchize/actions.ts
+++ b/app/franchize/actions.ts
@@ -1530,7 +1530,7 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
     });
 
     if (flowType === "rental") {
-      const { data: rentalRow } = await supabaseAdmin
+      const { data: rentalRow, error: rentalLookupError } = await supabaseAdmin
         .from("rentals")
         .select("rental_id, metadata")
         .eq("metadata->>orderId", payload.orderId)
@@ -1538,11 +1538,24 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
         .limit(1)
         .maybeSingle();
 
-      if (rentalRow?.rental_id) {
+      if (rentalLookupError) {
+        logger.warn("[franchize] rental lookup for contract attachment failed", {
+          orderId: payload.orderId,
+          slug: payload.slug,
+          error: rentalLookupError.message,
+        });
+      } else if (!rentalRow?.rental_id) {
+        logger.warn("[franchize] rental not found for contract attachment", {
+          orderId: payload.orderId,
+          slug: payload.slug,
+          verifierScope,
+          documentKey: variables.document_key,
+        });
+      } else {
         const existingMetadata =
           rentalRow.metadata && typeof rentalRow.metadata === "object" ? (rentalRow.metadata as Record<string, unknown>) : {};
         const rentalScope = `rental:${rentalRow.rental_id}`;
-        await supabaseAdmin
+        const { error: rentalUpdateError } = await supabaseAdmin
           .from("rentals")
           .update({
             metadata: {
@@ -1560,6 +1573,14 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
             },
           })
           .eq("rental_id", rentalRow.rental_id);
+
+        if (rentalUpdateError) {
+          logger.warn("[franchize] rental contract verifier attachment failed", {
+            rentalId: rentalRow.rental_id,
+            orderId: payload.orderId,
+            error: rentalUpdateError.message,
+          });
+        }
       }
     }
 
@@ -1573,6 +1594,87 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
 
     throw error;
   }
+}
+
+export async function reconcileRentalContractVerifierAttachment(input: {
+  rentalId: string;
+  orderId?: string;
+  flowType?: "rental" | "sale" | "mixed";
+  slug?: string;
+}): Promise<{ success: boolean; error?: string; attached?: boolean; recordId?: string }> {
+  const rentalId = input.rentalId.trim();
+  if (!rentalId) return { success: false, error: "rentalId is required" };
+
+  const { data: rental, error: rentalError } = await supabaseAdmin
+    .from("rentals")
+    .select("rental_id, metadata")
+    .eq("rental_id", rentalId)
+    .maybeSingle();
+
+  if (rentalError || !rental) {
+    return { success: false, error: rentalError?.message || "rental not found" };
+  }
+
+  const metadata = rental.metadata && typeof rental.metadata === "object" ? (rental.metadata as Record<string, unknown>) : {};
+  const verifier = metadata.contract_verifier && typeof metadata.contract_verifier === "object"
+    ? (metadata.contract_verifier as Record<string, unknown>)
+    : null;
+
+  const flowType = input.flowType ?? "rental";
+  const slug = (input.slug || String(metadata.slug || "")).trim();
+  const orderId = (input.orderId || String(metadata.orderId || "")).trim();
+
+  const sourceScope = typeof verifier?.sourceScope === "string" && verifier.sourceScope.trim()
+    ? verifier.sourceScope.trim()
+    : slug && orderId
+      ? `${flowType}:${slug}:${orderId}`
+      : "";
+  const keyPrefix = flowType === "sale" || flowType === "mixed" ? "sale" : "rental";
+  const documentKey = typeof verifier?.documentKey === "string" && verifier.documentKey.trim()
+    ? verifier.documentKey.trim()
+    : slug && orderId
+      ? `${keyPrefix}-${slug}-${orderId}`
+      : "";
+
+  if (!sourceScope || !documentKey) {
+    return { success: false, error: "Cannot derive sourceScope/documentKey for reconciliation" };
+  }
+
+  const { data: record, error: recordError } = await supabaseAdmin
+    .from("doc_verifier_records")
+    .select("id, integration_scope, document_key, original_sha256")
+    .eq("integration_scope", sourceScope)
+    .eq("document_key", documentKey)
+    .maybeSingle();
+
+  if (recordError || !record) {
+    return { success: false, error: recordError?.message || "doc_verifier record not found" };
+  }
+
+  const contractVerifierPatch = {
+    ...(verifier ?? {}),
+    scope: `rental:${rentalId}`,
+    sourceScope: sourceScope,
+    documentKey: documentKey,
+    docVerifierRecordId: record.id,
+    originalSha256: record.original_sha256,
+    status: "verified",
+    verifiedAt: new Date().toISOString(),
+    expiresAt: typeof verifier?.expiresAt === "string" ? verifier.expiresAt : null,
+  };
+
+  const { error: updateError } = await supabaseAdmin
+    .from("rentals")
+    .update({
+      metadata: {
+        ...metadata,
+        contract_verifier: contractVerifierPatch,
+      },
+    })
+    .eq("rental_id", rentalId);
+
+  if (updateError) return { success: false, error: updateError.message };
+  return { success: true, attached: true, recordId: record.id };
 }
 
 
@@ -1933,6 +2035,8 @@ export async function getFranchizeRentalCard(slug: string, rentalId: string): Pr
   contractVerifierScope: string;
   contractDocumentKey: string;
   docVerifierRecordId: string;
+  contractSourceScope: string;
+  contractOriginalSha256: string;
   telegramDeepLink: string;
 }> {
   const safeSlug = slug.trim();
@@ -1953,6 +2057,8 @@ export async function getFranchizeRentalCard(slug: string, rentalId: string): Pr
       contractVerifierScope: "",
       contractDocumentKey: "",
       docVerifierRecordId: "",
+      contractSourceScope: "",
+      contractOriginalSha256: "",
       telegramDeepLink: `https://t.me/oneBikePlsBot/app?startapp=rental-${safeRentalId}`,
     };
   }
@@ -1979,6 +2085,8 @@ export async function getFranchizeRentalCard(slug: string, rentalId: string): Pr
       contractVerifierScope: "",
       contractDocumentKey: "",
       docVerifierRecordId: "",
+      contractSourceScope: "",
+      contractOriginalSha256: "",
       telegramDeepLink: `https://t.me/oneBikePlsBot/app?startapp=rental-${safeRentalId}`,
     };
   }
@@ -1987,12 +2095,15 @@ export async function getFranchizeRentalCard(slug: string, rentalId: string): Pr
 
   const metadata = (data.metadata as Record<string, unknown> | null) ?? null;
   const verifier = metadata && typeof metadata.contract_verifier === "object" ? (metadata.contract_verifier as Record<string, unknown>) : null;
+  const rawStatus = typeof verifier?.status === "string" ? verifier.status.trim().toLowerCase() : "";
   const expiresAtValue = typeof verifier?.expiresAt === "string" ? verifier.expiresAt : "";
   const hasExpired = Boolean(expiresAtValue) && new Date(expiresAtValue).getTime() < Date.now();
   const contractVerificationStatus = hasExpired
     ? "expired"
-    : typeof verifier?.status === "string" && verifier.status.toLowerCase() === "verified"
+    : rawStatus === "verified" || rawStatus === "ok" || rawStatus === "valid"
       ? "verified"
+      : rawStatus === "expired"
+        ? "expired"
       : "not_verified";
 
   return {
@@ -2010,6 +2121,8 @@ export async function getFranchizeRentalCard(slug: string, rentalId: string): Pr
     contractVerifierScope: typeof verifier?.scope === "string" ? verifier.scope : "",
     contractDocumentKey: typeof verifier?.documentKey === "string" ? verifier.documentKey : "",
     docVerifierRecordId: typeof verifier?.docVerifierRecordId === "string" ? verifier.docVerifierRecordId : "",
+    contractSourceScope: typeof verifier?.sourceScope === "string" ? verifier.sourceScope : "",
+    contractOriginalSha256: typeof verifier?.originalSha256 === "string" ? verifier.originalSha256 : "",
     telegramDeepLink: `https://t.me/oneBikePlsBot/app?startapp=rental-${data.rental_id}`,
   };
 }


### PR DESCRIPTION
### Motivation

- Expose doc-verifier diagnostics on the rental detail UI to help operators see verifier `sourceScope` and document `originalSha256` for troubleshooting. 
- Harden the DOCX→doc-verifier→rental attachment flow with additional guardrail logging and error handling to make partial failures observable. 
- Provide an idempotent reconciliation action to backfill missing `rentals.metadata.contract_verifier` entries from `doc_verifier_records`.

### Description

- Updated the rental page `app/franchize/[slug]/rental/[id]/page.tsx` to display `contractSourceScope` and `contractOriginalSha256` when present. 
- Added `todo.md` (`app/franchize/[slug]/rental/[id]/todo.md`) documenting the RENT-P0.2 delivery, final contract shape, and notes for the DOCX→doc-verifier→rental wiring. 
- Enhanced `buildFranchizeOrderDocAndNotify` in `app/franchize/actions.ts` with rental lookup error warnings, missing-rental warnings, and rental metadata update error logging when attaching verifier info. 
- Added `reconcileRentalContractVerifierAttachment` server action in `app/franchize/actions.ts` that looks up `doc_verifier_records` by `(integration_scope, document_key)` and backfills `rentals.metadata.contract_verifier` (idempotent). 
- Extended `getFranchizeRentalCard` to return `contractSourceScope` and `contractOriginalSha256` and normalized verifier status parsing to treat `verified|ok|valid` as verified while respecting `expired`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f882db67d88324a62902e3727ec601)
supaplan_task: 0642f801-4e7e-4620-90fa-ca4ecab9f206