### PR TITLE
feat(seed): add HORWIN SK3 Plus seed entry and hosted gallery URLs

### DIFF
--- a/docs/sql/electrobikes_and_parts_seed.sql
+++ b/docs/sql/electrobikes_and_parts_seed.sql
@@ -562,3 +562,30 @@ VALUES (
 )
 ON CONFLICT (id) DO NOTHING;
 
+
+-- Horwin SK3 Plus (official website data)
+INSERT INTO public.cars (id, make, model, description, daily_price, image_url, rent_link, is_test_result, specs, type, quantity)
+VALUES (
+    'horwin-sk3-plus',
+    'HORWIN',
+    'SK3 Plus',
+    'Электромотоцикл HORWIN SK3 Plus: городская спортивная платформа с пиковой мощностью 8.64 кВт, максимальной скоростью до 100 км/ч и dual-battery конфигурацией для увеличенного запаса хода.',
+    0,
+    'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/horwin-sk3-plus/image_1.png',
+    '/rent/horwin-sk3-plus',
+    false,
+    '{"type": "Electric", "engine": "Электро", "subtitle": "HORWIN SK3 Plus", "bike_subtype": "Electric Urban Sport", "power_kw": 8.64, "power_continuous_kw": 4.5, "top_speed_kmh": 100, "range_km": "150 (45 км/ч, dual-battery)", "battery": "72V 45Ah x2", "charging_time": "≈5.5h x2 (8A)", "weight_kg": 103, "seat_height_mm": 790, "ground_clearance_mm": 135, "wheelbase_mm": 1310, "features": ["ABS + TCS", "TFT", "GPS + App"], "source": "https://global.horwin.com/SK3-PLUS.html", "gallery": ["https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/horwin-sk3-plus/image_1.png", "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/horwin-sk3-plus/image_2.png", "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/horwin-sk3-plus/image_3.png"], "sale": true}'::jsonb,
+    'bike',
+    1
+)
+ON CONFLICT (id) DO UPDATE SET
+    make = EXCLUDED.make,
+    model = EXCLUDED.model,
+    description = EXCLUDED.description,
+    daily_price = EXCLUDED.daily_price,
+    image_url = EXCLUDED.image_url,
+    rent_link = EXCLUDED.rent_link,
+    is_test_result = EXCLUDED.is_test_result,
+    specs = EXCLUDED.specs,
+    type = EXCLUDED.type,
+    quantity = EXCLUDED.quantity;


### PR DESCRIPTION
### Motivation
- Add HORWIN SK3 Plus to the sale bikes catalog so the product appears in the app and configurator.
- Host official product images in the existing Supabase `carpix` bucket so the seed can reference publicly-accessible gallery URLs.
- Populate specs from the official HORWIN product page to provide accurate searchable/filtered metadata for the bike.

### Description
- Added a new SQL seed INSERT for `horwin-sk3-plus` in `docs/sql/electrobikes_and_parts_seed.sql` with id `horwin-sk3-plus`, rent link `/rent/horwin-sk3-plus`, `type: bike`, `quantity: 1`, and a rich `specs` jsonb payload containing power, speed, range, battery, dimensions, features and `source`.
- Included a `gallery` array in the `specs` that points to Supabase-hosted image URLs under `carpix/horwin-sk3-plus/image_1.png`, `image_2.png`, and `image_3.png` and set `sale: true` for the entry.
- Downloaded three official SK3 Plus images from the HORWIN product page and uploaded them to the Supabase storage bucket under `carpix/horwin-sk3-plus/` so the gallery links are live.

### Testing
- Fetched and parsed the official HORWIN SK3 Plus product page using an automated script (`urllib.request`) to extract candidate asset URLs, and this step completed successfully.
- Downloaded three selected images locally via `urllib.request.urlretrieve` and verified file sizes, and then uploaded them to Supabase storage via authenticated `curl` requests using the environment `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`, with all uploads returning positive object keys/IDs.
- Verified the SQL seed was appended correctly by inspecting `docs/sql/electrobikes_and_parts_seed.sql` and confirming the new `horwin-sk3-plus` INSERT and gallery URLs are present; no automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8897bd638832485b37b432e113436)