### PR TITLE
Add factory color selection to configurator and include in DOCX/notifications

### DIFF
--- a/app/franchize/[slug]/configurator/ConfiguratorClient.tsx
+++ b/app/franchize/[slug]/configurator/ConfiguratorClient.tsx
@@ -22,6 +22,7 @@ import {
   fallbackParts,
   lithiumBatteries,
 } from './fallback-catalog'
+import { DEFAULT_FACTORY_COLOR, FACTORY_COLORS, getFactoryColorById } from './factory-colors'
 import {
   type ConfiguratorBike,
   type ConfiguratorPart,
@@ -29,7 +30,6 @@ import {
   formatPrice,
   TIER_META,
   CATEGORY_LABELS,
-  PART_CATEGORY_ICONS,
   STEPS,
   type ConfigStep,
 } from './configurator-types'
@@ -142,6 +142,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
   const [batteryMode, setBatteryMode] = useState<'regular' | 'lithium'>('regular')
   const [batteryCapacity, setBatteryCapacity] = useState('')
   const [selectedAccessories, setSelectedAccessories] = useState<string[]>([])
+  const [selectedColorId, setSelectedColorId] = useState(DEFAULT_FACTORY_COLOR?.id ?? '')
   const [deliveryApplied, setDeliveryApplied] = useState(false)
 
   useEffect(() => {
@@ -217,6 +218,8 @@ export function ConfiguratorClient({ crew, slug }: Props) {
     [batteryCapacity, batteryMode, regularBatteries],
   )
 
+  const selectedColor = useMemo(() => getFactoryColorById(selectedColorId) ?? DEFAULT_FACTORY_COLOR, [selectedColorId])
+
   const filteredBikes = useMemo(() => bikes.filter((b) => b.daily_price >= priceRange[0] && b.daily_price <= priceRange[1]), [bikes, priceRange])
   const accessoriesTotal = useMemo(() => selectedAccessories.reduce((sum, id) => sum + (parts.find((p) => p.id === id)?.daily_price ?? 0), 0), [selectedAccessories, parts])
 
@@ -240,6 +243,8 @@ export function ConfiguratorClient({ crew, slug }: Props) {
         bikeLabel: `${selectedBike.make} ${selectedBike.model}`,
         motorLabel: selectedMotor?.label ?? '—',
         batteryLabel: activeBattery ? `${activeBattery.capacity} (${batteryMode})` : 'без батареи',
+        selectedColorId: selectedColor?.id ?? DEFAULT_FACTORY_COLOR?.id ?? 'unknown',
+        selectedColorFactoryId: selectedColor?.factoryId ?? DEFAULT_FACTORY_COLOR?.factoryId ?? 'UNKNOWN-FACTORY-COLOR',
         selectedAccessories: selectedAccessories.map((id) => {
           const part = parts.find((p) => p.id === id)
           return { name: part?.model ?? id, price: part?.daily_price ?? 0 }
@@ -481,6 +486,38 @@ export function ConfiguratorClient({ crew, slug }: Props) {
                 </div>
               )}
 
+              <div className="rounded-2xl border border-[#27272a] bg-[#111113] p-5 sm:p-6">
+                <div className="mb-4 flex items-center gap-2">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#00ffea]/10"><Sparkles className="h-4 w-4 text-[#00ffea]" /></div>
+                  <div><h3 className="text-sm font-bold">Цвет</h3><p className="text-[11px] text-[#71717a]">Цвет попадёт в заказ и DOCX с factory ID</p></div>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {FACTORY_COLORS.map((color) => {
+                    const active = selectedColorId === color.id
+                    return (
+                      <button
+                        key={color.id}
+                        type="button"
+                        onClick={() => setSelectedColorId(color.id)}
+                        className={[
+                          'cfg-option flex items-center justify-between rounded-xl border p-4 text-left',
+                          active ? 'cfg-option-active' : 'border-[#27272a]',
+                        ].join(' ')}
+                      >
+                        <span className="flex items-center gap-3">
+                          <span className="h-5 w-5 rounded-full border border-white/20" style={{ backgroundColor: color.hex ?? '#6b7280' }} />
+                          <span>
+                            <span className="block text-sm font-semibold">{color.label}</span>
+                            <span className="block text-[11px] text-[#71717a]">Factory ID: {color.factoryId}</span>
+                          </span>
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+
+
               <div className="flex gap-3">
                 <Button variant="ghost" onClick={() => setTab('model')} className="text-[#71717a] hover:text-white">← Назад</Button>
                 <Button onClick={() => setTab('addons')} className="cfg-glow-btn flex-1 bg-[#00ffea] font-bold text-black hover:bg-[#33ffed] sm:flex-none">Дальше: опции<ChevronRight className="ml-1 h-4 w-4" /></Button>
@@ -543,6 +580,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
                       { icon: Zap, label: 'Мотор', value: `${selectedMotor?.value ?? '3000'}W` },
                       { icon: Battery, label: 'Батарея', value: activeBattery ? activeBattery.capacity : '—' },
                       { icon: Gauge, label: 'Скорость', value: `${selectedBike.specs.max_speed_kmh} км/ч` },
+                      { icon: Sparkles, label: 'Цвет', value: selectedColor?.label ?? '—' },
                       { icon: Shield, label: 'Запас хода', value: activeBattery ? `${activeBattery.range_km} км` : '—' },
                     ].map(({ icon: Icon, label, value }) => (
                       <div key={label} className="rounded-xl border border-[#27272a] bg-[#111113] p-3"><Icon className="mb-1.5 h-4 w-4 text-[#71717a]" /><p className="cfg-mono text-lg font-bold">{value}</p><p className="text-[10px] uppercase tracking-widest text-[#71717a]">{label}</p></div>
@@ -568,6 +606,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
                       <h3 className="mb-4 text-sm font-bold uppercase tracking-widest text-[#71717a]">Расчёт стоимости</h3>
                       <div className="space-y-3 text-sm">
                         <div className="flex justify-between"><span className="text-[#a1a1aa]">{selectedBike.make} {selectedBike.model}</span><span className="cfg-mono font-medium">{formatPrice(basePrice)}</span></div>
+                        <div className="flex justify-between"><span className="text-[#a1a1aa]">Цвет (Factory ID)</span><span className="cfg-mono text-xs font-medium">{selectedColor?.factoryId ?? 'UNKNOWN-FACTORY-COLOR'}</span></div>
                         {motorExtra > 0 && <div className="flex justify-between"><span className="text-[#a1a1aa]">Мотор {selectedMotor?.value}W</span><span className="cfg-mono font-medium">+{formatPrice(motorExtra)}</span></div>}
                         {batteryPrice > 0 && <div className="flex justify-between"><span className="text-[#a1a1aa]">Батарея {activeBattery?.capacity}</span><span className="cfg-mono font-medium">+{formatPrice(batteryPrice)}</span></div>}
                         {accessoriesTotal > 0 && <div className="flex justify-between"><span className="text-[#a1a1aa]">Опции ({selectedAccessories.length})</span><span className="cfg-mono font-medium">+{formatPrice(accessoriesTotal)}</span></div>}

--- a/app/franchize/[slug]/configurator/actions_configurator.ts
+++ b/app/franchize/[slug]/configurator/actions_configurator.ts
@@ -17,6 +17,7 @@ import {
   fallbackParts,
   lithiumBatteries,
 } from "./fallback-catalog";
+import { DEFAULT_FACTORY_COLOR, FACTORY_COLORS, getFactoryColorById } from "./factory-colors";
 
 // ─────────────────────────────────────────────
 // Catalog loader
@@ -101,6 +102,8 @@ const CONFIGURATOR_DOC_TEMPLATE = `# ⚡ Конфигурация электро
 | **Модель** | {{bike_make_model}} |
 | **Мощность мотора** | {{motor_power}} |
 | **Тип батареи** | {{battery_type}} |
+| **Цвет** | {{bike_color_label}} |
+| **Factory ID (цвет)** | {{bike_color_factory_id}} |
 | **Ёмкость батареи** | {{battery_capacity}} |
 | **Запас хода** | {{battery_range}} км |
 
@@ -144,6 +147,14 @@ async function buildConfiguratorDocAndNotify(input: ConfiguratorLeadInput) {
 
   const fmt = (n: number) => n.toLocaleString("ru-RU");
 
+  const fallbackColor = DEFAULT_FACTORY_COLOR ?? FACTORY_COLORS[0] ?? { id: 'unknown', factoryId: 'UNKNOWN-FACTORY-COLOR', label: 'Не указан' };
+  const resolvedColor =
+    getFactoryColorById(input.selectedColorId) ??
+    FACTORY_COLORS.find((c) => c.factoryId === input.selectedColorFactoryId) ??
+    fallbackColor;
+  const resolvedColorFactoryId =
+    resolvedColor.factoryId?.trim() || input.selectedColorFactoryId?.trim() || 'UNKNOWN-FACTORY-COLOR';
+
   const accessoriesTable =
     input.selectedAccessories.length > 0
       ? input.selectedAccessories
@@ -172,6 +183,8 @@ async function buildConfiguratorDocAndNotify(input: ConfiguratorLeadInput) {
         ? "Стандартная (Regular)"
         : input.batteryLabel || "—",
     battery_capacity: input.batteryLabel.split(" ")[0] || "—",
+    bike_color_label: resolvedColor.label || 'Не указан',
+    bike_color_factory_id: resolvedColorFactoryId,
     battery_range: "—",
     accessories_table: accessoriesTable,
     accessories_count: String(input.selectedAccessories.length),
@@ -237,6 +250,7 @@ async function buildConfiguratorDocAndNotify(input: ConfiguratorLeadInput) {
         `Модель: ${input.bikeLabel}`,
         `Мотор: ${input.motorLabel}`,
         `Батарея: ${input.batteryLabel}`,
+        `Цвет: ${resolvedColor.label} (${resolvedColorFactoryId})`,
         `Опции: ${input.selectedAccessories.length} шт.`,
         `Итого: ${fmt(input.total)} ₽`,
       ].join("\n")

--- a/app/franchize/[slug]/configurator/configurator-types.ts
+++ b/app/franchize/[slug]/configurator/configurator-types.ts
@@ -63,6 +63,16 @@ export interface ConfiguratorPart {
 
 // ── UI constants ──
 
+
+export interface ConfiguratorColorOption {
+  id: string
+  factoryId: string
+  label: string
+  hex?: string
+  availability?: 'in_stock' | 'made_to_order' | 'out_of_stock'
+  isDefault?: boolean
+}
+
 export const TIER_META: Record<string, { label: string; color: string }> = {
   budget: { label: 'Бюджет', color: '#6ee7b7' },
   standard: { label: 'Стандарт', color: '#60a5fa' },
@@ -99,6 +109,8 @@ export interface ConfiguratorLeadInput {
   bikeLabel: string
   motorLabel: string
   batteryLabel: string
+  selectedColorId: string
+  selectedColorFactoryId: string
   selectedAccessories: Array<{ name: string; price: number }>
   withDelivery: boolean
   deliveryPrice: number

--- a/app/franchize/[slug]/configurator/factory-colors.ts
+++ b/app/franchize/[slug]/configurator/factory-colors.ts
@@ -1,0 +1,49 @@
+import type { ConfiguratorColorOption } from './configurator-types'
+
+/**
+ * Single source of truth for order-document color mapping.
+ * Edit only this file when the factory palette or OEM color codes change.
+ */
+export const FACTORY_COLORS: ConfiguratorColorOption[] = [
+  {
+    id: 'matte-black',
+    factoryId: 'OEM-BLK-MT',
+    label: 'Матовый чёрный',
+    hex: '#1A1A1A',
+    isDefault: true,
+    availability: 'in_stock',
+  },
+  {
+    id: 'snow-white',
+    factoryId: 'OEM-WHT-SN',
+    label: 'Снежно-белый',
+    hex: '#F8F8F8',
+    availability: 'in_stock',
+  },
+  {
+    id: 'graphite-gray',
+    factoryId: 'OEM-GRY-GR',
+    label: 'Графитовый',
+    hex: '#4B5563',
+    availability: 'made_to_order',
+  },
+  {
+    id: 'neon-cyan',
+    factoryId: 'OEM-CYN-NE',
+    label: 'Неон-циан',
+    hex: '#22D3EE',
+    availability: 'made_to_order',
+  },
+]
+
+export const FACTORY_COLOR_BY_ID = Object.fromEntries(
+  FACTORY_COLORS.map((color) => [color.id, color]),
+) as Record<string, ConfiguratorColorOption>
+
+export const getFactoryColorById = (id?: string | null): ConfiguratorColorOption | null => {
+  if (!id) return null
+  return FACTORY_COLOR_BY_ID[id] ?? null
+}
+
+export const DEFAULT_FACTORY_COLOR =
+  FACTORY_COLORS.find((color) => color.isDefault) ?? FACTORY_COLORS[0] ?? null


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for OEM factory paint options and allow users to choose a factory color in the configurator so the choice is recorded in orders and DOCX documents.
- Ensure the chosen color (label and factory ID) is included in the lead payload, order document, and admin notifications.

### Description
- Added a new `factory-colors.ts` file with `FACTORY_COLORS`, `getFactoryColorById`, and `DEFAULT_FACTORY_COLOR` as the canonical palette and lookup helpers.
- Extended types in `configurator-types.ts` with a `ConfiguratorColorOption` interface and added `selectedColorId` and `selectedColorFactoryId` to `ConfiguratorLeadInput`.
- Updated the UI in `ConfiguratorClient.tsx` to track `selectedColorId`, render a color selection block, show the chosen color in the summary, and include color fields in the payload sent to `sendConfiguratorLead` via `submitLead`.
- Updated server-side logic in `actions_configurator.ts` to resolve the color from `selectedColorId`/`selectedColorFactoryId` using `getFactoryColorById` and `FACTORY_COLORS`, inject `bike_color_label` and `bike_color_factory_id` into the generated DOCX variables, and include the color in the admin notification text.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88e03e96083248b50ebf166d0d609)