### PR TITLE
Add onboarding content and dual rent/sale flows for Electro-Enduro, Configurator and VIP pages

### DIFF
--- a/app/franchize/[slug]/configurator/page.tsx
+++ b/app/franchize/[slug]/configurator/page.tsx
@@ -3,6 +3,7 @@ import { CrewFooter } from '../../components/CrewFooter'
 import { CrewHeader } from '../../components/CrewHeader'
 import { crewPaletteForSurface } from '../../lib/theme'
 import { ConfiguratorClient } from './ConfiguratorClient'
+import Link from 'next/link'
 
 interface ConfiguratorPageProps {
   params: Promise<{ slug: string }>
@@ -16,8 +17,40 @@ export default async function ConfiguratorPage({ params }: ConfiguratorPageProps
   return (
     <main className="min-h-screen" style={surface.page}>
       <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/configurator`} groupLinks={items.map((item) => item.category)} />
+      <section className="mx-auto w-full max-w-7xl px-4 pt-6 2xl:max-w-[1600px]">
+        <div className="rounded-3xl border border-white/15 bg-black/30 p-5 backdrop-blur-sm sm:p-8">
+          <p className="text-xs uppercase tracking-[0.18em] text-white/60">Configurator onboarding</p>
+          <h1 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">Как оформить заказ электромотоцикла без ошибок</h1>
+          <p className="mt-3 max-w-3xl text-sm text-white/75 sm:text-base">
+            Сначала прочитай вводную по сценариям, затем собери конфиг и только потом переходи к корзине и оформлению.
+            Для тест-драйва лучше начать с аренды, для покупки — продолжать здесь в режиме продажи.
+          </p>
+          <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-3">
+            <div className="rounded-2xl border border-white/15 bg-white/5 p-4 text-sm text-white/80">
+              <p className="text-white">1) Вводная</p>
+              <p className="mt-1">Сравни аренду и покупку, чтобы выбрать подходящий сценарий.</p>
+            </div>
+            <div className="rounded-2xl border border-white/15 bg-white/5 p-4 text-sm text-white/80">
+              <p className="text-white">2) Конфигурация</p>
+              <p className="mt-1">Выбери модель, батарею, мощность, подвеску, допы и экип.</p>
+            </div>
+            <div className="rounded-2xl border border-white/15 bg-white/5 p-4 text-sm text-white/80">
+              <p className="text-white">3) Корзина и заказ</p>
+              <p className="mt-1">Проверь состав, стоимость и отправь заказ на подтверждение.</p>
+            </div>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Link className="inline-flex rounded-xl border border-white/30 px-3 py-2 text-sm text-white hover:bg-white hover:text-black" href={`/franchize/${crew.slug || slug}/electro-enduro`}>
+              Открыть Electro-Enduro раздел
+            </Link>
+            <Link className="inline-flex rounded-xl border border-white/30 px-3 py-2 text-sm text-white hover:bg-white hover:text-black" href={`/franchize/${crew.slug || slug}`}>
+              Перейти в аренду (тест-драйв)
+            </Link>
+          </div>
+        </div>
+      </section>
       <ConfiguratorClient crew={crew} slug={slug} />
-      {/* <CrewFooter crew={crew} />*/}
+      <CrewFooter crew={crew} />
     </main>
   )
 }

--- a/app/franchize/[slug]/electro-enduro/page.tsx
+++ b/app/franchize/[slug]/electro-enduro/page.tsx
@@ -3,22 +3,136 @@ import { CrewHeader } from "../../components/CrewHeader";
 import { CatalogClient } from "../../components/CatalogClient";
 import { getFranchizeBySlug } from "../../actions";
 import { crewPaletteForSurface } from "../../lib/theme";
+import Link from "next/link";
 
 interface ElectroEnduroPageProps {
   params: Promise<{ slug: string }>;
 }
 
 const isSaleEnabled = (value: unknown) => value === 1 || value === true || String(value).toLowerCase() === "1" || String(value).toLowerCase() === "true";
+const isRentEnabled = (value: unknown) => value === 1 || value === true || String(value).toLowerCase() === "1" || String(value).toLowerCase() === "true";
+const SALE_ID_OVERRIDES = new Set(["sequence-zero", "falcon-gt-2025", "500gt"]);
+const RENT_ID_OVERRIDES = new Set(["sequence-zero", "falcon-gt-2025", "500gt"]);
+const ACCESSORY_KEYWORDS = ["шлем", "перчат", "ботин", "джерси", "защит", "черепах", "колен", "helmet", "glove", "boots", "jersey", "armor", "knee"];
 
 export default async function ElectroEnduroPage({ params }: ElectroEnduroPageProps) {
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
-  const saleItems = items.filter((item) => item.saleAvailable || isSaleEnabled(item.rawSpecs?.sale));
+  const saleItems = items.filter((item) => {
+    const id = item.id.toLowerCase();
+    return item.saleAvailable || isSaleEnabled(item.rawSpecs?.sale) || SALE_ID_OVERRIDES.has(id);
+  });
+  const rentItems = items.filter((item) => {
+    const id = item.id.toLowerCase();
+    return item.availabilityStatus === "available" || isRentEnabled(item.rawSpecs?.rent) || RENT_ID_OVERRIDES.has(id);
+  });
+  const featuredRentItems = rentItems.filter((item) => item.id.toLowerCase().includes("sequence-zero")).slice(0, 3);
+  const featuredSaleItems = saleItems.filter((item) => item.id.toLowerCase().includes("falcon-gt-2025")).slice(0, 3);
+  const rentPreview = featuredRentItems.length > 0 ? featuredRentItems : rentItems.slice(0, 3);
+  const salePreview = featuredSaleItems.length > 0 ? featuredSaleItems : saleItems.slice(0, 3);
+  const accessoryHighlights = Array.from(
+    new Set(
+      items
+        .flatMap((item) => [
+          ...item.specs.map((spec) => `${spec.label}: ${spec.value}`),
+          ...(Array.isArray(item.rawSpecs?.accessories) ? (item.rawSpecs?.accessories as unknown[]).map(String) : []),
+        ])
+        .filter((entry) => ACCESSORY_KEYWORDS.some((keyword) => entry.toLowerCase().includes(keyword))),
+    ),
+  ).slice(0, 8);
 
   return (
     <main className="min-h-screen" style={surface.page}>
       <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/electro-enduro`} groupLinks={saleItems.map((item) => item.category)} />
+      <section className="mx-auto w-full max-w-7xl px-4 pt-6 2xl:max-w-[1600px]">
+        <div className="rounded-3xl border border-white/15 bg-black/30 p-5 backdrop-blur-sm sm:p-8">
+          <p className="text-xs uppercase tracking-[0.18em] text-white/60">Electro-Enduro flow</p>
+          <h1 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">Electro-enduro: два сценария в одном каталоге</h1>
+          <p className="mt-3 max-w-3xl text-sm text-white/75 sm:text-base">
+            Для быстрого старта удобно взять байк в аренду и оценить поведение на маршруте. Для заказа в собственность
+            используйте конфигуратор: параметры, комплектация и оформление идут отдельным потоком.
+          </p>
+          <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2">
+            <article className="rounded-2xl border border-emerald-300/30 bg-emerald-500/10 p-4 text-white">
+              <h2 className="text-lg font-medium">Аренда / тест-драйв</h2>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-white/80">
+                <li>Быстрый старт для знакомства с техникой.</li>
+                <li>Подходит для сравнения нескольких моделей перед покупкой.</li>
+                <li>Маршрутный формат и базовый инструктаж перед выездом.</li>
+              </ul>
+              <Link className="mt-4 inline-flex rounded-xl border border-white/30 px-3 py-2 text-sm hover:bg-white hover:text-black" href={`/franchize/${crew.slug || slug}`}>
+                Открыть каталог аренды
+              </Link>
+            </article>
+            <article className="rounded-2xl border border-amber-300/30 bg-amber-500/10 p-4 text-white">
+              <h2 className="text-lg font-medium">Продажа / кастомная сборка</h2>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-white/80">
+                <li>Выбор батареи, мощности, подвески и дополнительных опций.</li>
+                <li>Отдельный flow: конфигурация → корзина → заказ.</li>
+                <li>Лучше для тех, кто ищет байк в постоянное владение.</li>
+              </ul>
+              <Link className="mt-4 inline-flex rounded-xl border border-white/30 px-3 py-2 text-sm hover:bg-white hover:text-black" href={`/franchize/${crew.slug || slug}/configurator`}>
+                Перейти в конфигуратор
+              </Link>
+            </article>
+          </div>
+        </div>
+      </section>
+      <section className="mx-auto w-full max-w-7xl px-4 pt-6 2xl:max-w-[1600px]">
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+          <article className="rounded-3xl border border-emerald-300/30 bg-emerald-500/10 p-5 text-white">
+            <h3 className="text-xl font-semibold">Группа аренды (test-ride friendly)</h3>
+            <p className="mt-2 text-sm text-white/75">Включает модели для первого знакомства и коротких прокатных сессий.</p>
+            <div className="mt-4 space-y-2">
+              {rentPreview.map((item) => (
+                <Link
+                  key={item.id}
+                  href={`/franchize/${crew.slug || slug}/electro-enduro?vehicle=${item.id}`}
+                  className="flex items-center justify-between rounded-xl border border-white/20 px-3 py-2 text-sm hover:bg-white hover:text-black"
+                >
+                  <span>{item.title}</span>
+                  <span className="text-xs opacity-80">{item.pricePerDay} ₽/день</span>
+                </Link>
+              ))}
+            </div>
+          </article>
+          <article className="rounded-3xl border border-amber-300/30 bg-amber-500/10 p-5 text-white">
+            <h3 className="text-xl font-semibold">Группа продажи (build-to-order)</h3>
+            <p className="mt-2 text-sm text-white/75">Фокус на кастомизации и заказе модели в конфигураторе.</p>
+            <div className="mt-4 space-y-2">
+              {salePreview.map((item) => (
+                <Link
+                  key={item.id}
+                  href={`/franchize/${crew.slug || slug}/configurator?vehicle=${item.id}`}
+                  className="flex items-center justify-between rounded-xl border border-white/20 px-3 py-2 text-sm hover:bg-white hover:text-black"
+                >
+                  <span>{item.title}</span>
+                  <span className="text-xs opacity-80">{item.pricePerDay} ₽/день</span>
+                </Link>
+              ))}
+            </div>
+          </article>
+        </div>
+      </section>
+      {accessoryHighlights.length > 0 && (
+        <section className="mx-auto w-full max-w-7xl px-4 pt-6 2xl:max-w-[1600px]">
+          <div className="rounded-3xl border border-white/15 bg-white/5 p-5 text-white">
+            <h3 className="text-xl font-semibold">Экип и аксессуары из текущих спецификаций</h3>
+            <p className="mt-2 text-sm text-white/75">
+              Ниже карточки, которые уже встречаются в спецификациях моделей. Это помогает быстро проверить, что входит
+              в комплект и что стоит добавить к заказу.
+            </p>
+            <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              {accessoryHighlights.map((entry) => (
+                <div key={entry} className="rounded-xl border border-white/20 px-3 py-2 text-sm text-white/85">
+                  {entry}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
       <CatalogClient crew={crew} slug={slug} items={saleItems} mode="electro" />
       <CrewFooter crew={crew} />
     </main>

--- a/app/vipbikerental/page.tsx
+++ b/app/vipbikerental/page.tsx
@@ -94,7 +94,7 @@ const quickActions = [
     title: "Контроль сделок",
     icon: "::FaTicket::",
     text: "Проверка статусов, подтверждений и активных аренд.",
-    href: "/rentals",
+    href: "/franchize/vip-bike/rentals",
     cta: "Мои аренды",
   },
   {
@@ -128,7 +128,7 @@ const partnerLinks = [
     note: "Подбор электроэндуро по уровню, трассе и формату аренды.",
   },
   {
-    name: "Конфигуратор и заказ",
+    name: "Конфигуратор электричек и заказ",
     href: "/franchize/vip-bike/configurator",
     note: "Актуальная конфигурация: модель → батарея → допы → корзина.",
   },
@@ -139,7 +139,7 @@ const partnerLinks = [
   },
   {
     name: "Личный раздел аренды",
-    href: "/rentals",
+    href: "/franchize/vip-bike/rentals",
     note: "Активные заказы, подтверждения, управление поездками.",
   },
 ];
@@ -156,14 +156,14 @@ const newbieFlow = [
     step: "Шаг 2",
     title: "Выбор байка и конфигурации",
     description: "Перейди в конфигуратор: выбери модель, батарею, режим мощности и нужные допы.",
-    href: "/franchize/vip-bike/configurator",
+    href: "/franchize/vip-bike/electro-enduro",
     cta: "Подобрать конфиг",
   },
   {
     step: "Шаг 3",
     title: "Корзина и оформление",
     description: "Проверь заказ в корзине, добавь экип, подтверди данные и отправь заявку менеджеру.",
-    href: "/rentals",
+    href: "/franchize/vip-bike/profile",
     cta: "Проверить оформление",
   },
 ];

--- a/app/vipbikerental/page.tsx
+++ b/app/vipbikerental/page.tsx
@@ -120,6 +120,69 @@ const heroMetrics = [
   "::FaHeadset:: Поддержка на маршруте",
 ];
 
+
+const partnerLinks = [
+  {
+    name: "Каталог аренды VIP Bike",
+    href: "/franchize/vip-bike",
+    note: "Подбор электроэндуро по уровню, трассе и формату аренды.",
+  },
+  {
+    name: "Конфигуратор и заказ",
+    href: "/franchize/vip-bike/configurator",
+    note: "Актуальная конфигурация: модель → батарея → допы → корзина.",
+  },
+  {
+    name: "MapRiders",
+    href: "/franchize/vip-bike/map-riders",
+    note: "Карта райдеров, маршруты и точки встречи.",
+  },
+  {
+    name: "Личный раздел аренды",
+    href: "/rentals",
+    note: "Активные заказы, подтверждения, управление поездками.",
+  },
+];
+
+const newbieFlow = [
+  {
+    step: "Шаг 1",
+    title: "Старт с раздела и вводного гида",
+    description: "Открой страницу заказа, прочитай вводный блок про локацию, маршруты и правила безопасности.",
+    href: "/vipbikerental",
+    cta: "Открыть вводный блок",
+  },
+  {
+    step: "Шаг 2",
+    title: "Выбор байка и конфигурации",
+    description: "Перейди в конфигуратор: выбери модель, батарею, режим мощности и нужные допы.",
+    href: "/franchize/vip-bike/configurator",
+    cta: "Подобрать конфиг",
+  },
+  {
+    step: "Шаг 3",
+    title: "Корзина и оформление",
+    description: "Проверь заказ в корзине, добавь экип, подтверди данные и отправь заявку менеджеру.",
+    href: "/rentals",
+    cta: "Проверить оформление",
+  },
+];
+
+const mapRidersJourney = [
+  {
+    title: "Шаг 1: Найди точку старта",
+    text: "Открой карту и выбери ближайшую точку сбора по времени и уровню сложности.",
+  },
+  {
+    title: "Шаг 2: Проверь экип и маршрут",
+    text: "Перед выездом отметь экип и дистанцию — так проще выбрать комфортную сессию.",
+  },
+  {
+    title: "Шаг 3: Поехали с группой",
+    text: "Присоединяйся к активной группе, отслеживай прогресс и отмечай пройденные участки.",
+  },
+];
+
 export default function HomePage() {
   const { dbUser } = useAppContext();
   const { scrollYProgress } = useScroll();
@@ -242,6 +305,199 @@ export default function HomePage() {
       </motion.section>
 
       <div className="container mx-auto max-w-7xl space-y-20 px-4 py-16 sm:space-y-24 sm:py-24">
+        <section className="rounded-2xl border border-border/60 bg-card/40 p-5 sm:p-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="font-orbitron text-2xl sm:text-3xl">Актуальность контента / партнёрских ссылок</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Раздел обновлён под новый franchize-поток: Electro-Enduro + Configurator + MapRiders.
+                Последний аудит контента: <span className="font-medium text-foreground">04 мая 2026</span>.
+              </p>
+            </div>
+            <Button asChild variant="outline">
+              <Link href="/franchize/vip-bike/configurator">Начать с конфигуратора</Link>
+            </Button>
+          </div>
+          <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2">
+            {partnerLinks.map((item) => (
+              <Card key={item.name} className="border-border/70 bg-background/40">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{item.name}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="mb-3 text-sm text-muted-foreground">{item.note}</p>
+                  <Button asChild size="sm" variant="outline" className="w-full">
+                    <Link href={item.href}>Открыть раздел</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <div className="mb-8 text-center">
+            <h2 className="font-orbitron text-3xl sm:text-4xl">Electro-Enduro: аренда + продажа в одном потоке</h2>
+            <p className="mx-auto mt-3 max-w-3xl text-muted-foreground">
+              Мы развиваем отдельное направление по электроэндуро в зоне от метро Моста до Ленинского затона вдоль
+              реки: новичок получает понятный старт, райдер — быстрый доступ к маршрутам, а клиент на покупку —
+              прозрачный путь до кастомного байка.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+            <Card className="border-primary/40 bg-card/60 backdrop-blur-sm">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-2xl">
+                  <VibeContentRenderer content="::FaBolt::" className="text-primary" />
+                  Аренда электроэндуро
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <p>
+                  Идеально для теста перед покупкой: берёшь байк на слот, едешь по подготовленным маршрутам вдоль
+                  набережной и получаешь поддержку команды на всём пути.
+                </p>
+                <div className="space-y-2 rounded-xl border border-border/60 bg-background/40 p-4">
+                  <VibeContentRenderer content="::FaRoute:: Маршруты: Мост — Ленинский затон — речные точки" />
+                  <VibeContentRenderer content="::FaClock:: Формат: часовые и дневные слоты" />
+                  <VibeContentRenderer content="::FaHeadset:: Сопровождение: брифинг + онлайн поддержка" />
+                </div>
+                <Button asChild className="w-full">
+                  <Link href="/franchize/vip-bike">Выбрать байк для аренды</Link>
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card className="border-secondary/40 bg-card/60 backdrop-blur-sm">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-2xl">
+                  <VibeContentRenderer content="::FaCartShopping::" className="text-secondary" />
+                  Продажа электричек
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <p>
+                  Для тех, кто готов брать свой электромотоцикл: сравниваешь модели, собираешь конфиг под бюджет,
+                  дальше переходишь в корзину и оформляешь заказ без лишних шагов.
+                </p>
+                <div className="space-y-2 rounded-xl border border-border/60 bg-background/40 p-4">
+                  <VibeContentRenderer content="::FaSliders:: Конфигуратор: мотор, батарея, подвеска, допы" />
+                  <VibeContentRenderer content="::FaWallet:: Актуализация прайса: гибкий апдейт по позициям" />
+                  <VibeContentRenderer content="::FaBoxesPacking:: Финал: корзина + оформление + подтверждение" />
+                </div>
+                <Button asChild variant="outline" className="w-full">
+                  <Link href="/franchize/vip-bike/configurator">Открыть продажу и конфигурацию</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section>
+          <div className="mb-8 text-center">
+            <h2 className="font-orbitron text-3xl sm:text-4xl">MapRiders — карта, которой реально хочется пользоваться</h2>
+            <p className="mx-auto mt-3 max-w-3xl text-muted-foreground">
+              Здесь не просто метки. Это рабочий инструмент: где кататься сегодня, где встретиться, где безопасно
+              стартовать новичку и где проходят активные сессии комьюнити.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <Card className="border-border/70 bg-card/60">
+              <CardHeader>
+                <CardTitle className="text-lg"><VibeContentRenderer content="::FaMapLocationDot:: Живые точки" /></CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">
+                Карта показывает точки старта, сервисные зоны и места встреч с райдерами в реальном контексте дня.
+              </CardContent>
+            </Card>
+            <Card className="border-border/70 bg-card/60">
+              <CardHeader>
+                <CardTitle className="text-lg"><VibeContentRenderer content="::FaUserGroup:: Новичкам просто" /></CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">
+                Для первого выезда: выбери маршрут по сложности, отметь экип и поехали с комфортной группой.
+              </CardContent>
+            </Card>
+            <Card className="border-border/70 bg-card/60">
+              <CardHeader>
+                <CardTitle className="text-lg"><VibeContentRenderer content="::FaTrophy:: Геймификация" /></CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">
+                Лидерборд недели, пройденные участки и прогресс по маршрутам — всё в одном месте без лишних экранов.
+              </CardContent>
+            </Card>
+          </div>
+          <div className="mt-4 flex justify-center">
+            <Button asChild size="lg" variant="outline">
+              <Link href="/franchize/vip-bike/map-riders">Перейти в MapRiders</Link>
+            </Button>
+          </div>
+          <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-3">
+            {mapRidersJourney.map((item) => (
+              <Card key={item.title} className="border-border/70 bg-card/60">
+                <CardHeader>
+                  <CardTitle className="text-base">{item.title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">{item.text}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <div className="mb-8 text-center">
+            <h2 className="font-orbitron text-3xl sm:text-4xl">Экип и безопасность — отдельный блок перед стартом</h2>
+            <p className="mx-auto mt-3 max-w-3xl text-muted-foreground">
+              Перед арендой или покупкой сразу закрываем вопрос защиты: подбираем комплект под стиль катания и сезон.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            {[
+              "::FaHelmetSafety:: Шлемы",
+              "::FaHands:: Перчатки",
+              "::FaShirt:: Джерси",
+              "::FaShoePrints:: Ботинки",
+              "::FaShield:: Черепахи",
+              "::FaPersonRunning:: Колени",
+              "::FaRoadBarrier:: Локти и защита корпуса",
+              "::FaKitMedical:: Аптечка и расходники",
+            ].map((item) => (
+              <div key={item} className="rounded-xl border border-border/70 bg-card/60 px-3 py-3 text-sm">
+                <VibeContentRenderer content={item} />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <div className="mb-8 text-center">
+            <h2 className="font-orbitron text-3xl sm:text-4xl">Пошагово для новичка: от информации к заказу</h2>
+            <p className="mx-auto mt-3 max-w-3xl text-muted-foreground">
+              Логика страницы: сначала понятный вводный блок по разделу, дальше выбор мотоциклов и конфигурации,
+              затем корзина и оформление. Никакого хаоса — только последовательный путь.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            {newbieFlow.map((item) => (
+              <Card key={item.title} className="border-border/70 bg-card/60">
+                <CardHeader>
+                  <p className="text-xs uppercase tracking-wide text-primary">{item.step}</p>
+                  <CardTitle className="text-lg">{item.title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="mb-4 text-sm text-muted-foreground">{item.description}</p>
+                  <Button asChild className="w-full" variant="outline">
+                    <Link href={item.href}>{item.cta}</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
         <section>
           <div className="mb-8 text-center">
             <h2 className="font-orbitron text-3xl sm:text-4xl">Уже внедрённый rental-флоу — в один клик</h2>


### PR DESCRIPTION
### Motivation
- Provide clear onboarding and step-by-step guidance for configurator and electro-enduro flows to reduce ordering mistakes and improve conversion. 
- Expose both rental (test-ride) and sale (custom build) scenarios in the Electro-Enduro catalog so users can easily switch between quick rentals and build-to-order flows. 
- Surface accessory highlights and partner/navigation links on the VIP landing page to guide new users through the end-to-end journey. 

### Description
- Added an onboarding/info panel to `app/franchize/[slug]/configurator/page.tsx` with guidance, quick links and re-enabled the `CrewFooter`. 
- Enhanced `app/franchize/[slug]/electro-enduro/page.tsx` to distinguish sale vs rent items using `isSaleEnabled`/`isRentEnabled`, ID overrides (`SALE_ID_OVERRIDES` / `RENT_ID_OVERRIDES`), and built previews (`salePreview`, `rentPreview`). 
- Implemented accessory extraction (`ACCESSORY_KEYWORDS`) to surface accessory highlights from specs and `rawSpecs.accessories`. 
- Added multiple UI sections and navigation `Link`s for rental vs sale flows, previews of items, and an accessories grid; imported `next/link` where needed. 
- Extended `app/vipbikerental/page.tsx` with partner links, a newbie flow, MapRiders journey, equipment blocks and additional promotional/guide cards linking into the new franchize flows.

### Testing
- Ran type checking and full site production build with `next build` and the build completed successfully. 
- Ran linting with `pnpm lint` and no new lint errors remained. 
- Executed the test suite via `pnpm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8fb7a2f9c83249bf0c0dbc76a026c)
supaplan_task:b72956f5-e59c-4a8f-b4a2-f1384bfd139c