### PR TITLE
fix: guard useTelegram unmount updates supaplan_task:d9c5f5f8-9234-4c9e-3456-99990009f456

### DIFF
--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -84,3 +84,13 @@ This root file stays intentionally compact so operators and agents can load it q
 - `notes`: Aligned sale reservation CTA copy with the same 100-500 XTR formula used by backend invoices, centralized VS spec aliases, and split reservation/cart CTA state so secondary cart actions do not display invoice success.
 - `next_step`: Verify production `vip-bike` sale bike with real catalog specs and Telegram WebApp invoice delivery.
 - `risks`: Visual/live invoice verification still depends on reachable Supabase and Telegram bot credentials.
+
+### 2026-05-06 — Telegram auth unmount guard
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-06T22:25:00Z
+- `owner`: codex
+- `notes`: Claimed SupaPlan `CQ-TELEGRAM-GUARD` and moved `useTelegram` async initialization from a local boolean to a lifecycle ref guard so delayed auth results do not update state after unmount.
+- `next_step`: Merge PR, then verify Telegram WebApp auth/navigation on `vip-bike` under slow network throttling.
+- `risks`: Runtime Telegram validation still depends on configured bot/API env and a real WebApp launch context.
+

--- a/hooks/useTelegram.ts
+++ b/hooks/useTelegram.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { debugLogger } from "@/lib/debugLogger"; 
 import { logger as globalLogger } from "@/lib/logger"; 
 import { 
@@ -121,6 +121,7 @@ export function useTelegram() {
   const [error, setError] = useState<Error | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false); 
   const[startParam, setStartParam] = useState<string | null>(null);
+  const isMountedRef = useRef(false);
 
   const handleAuthentication = useCallback(
     async (userToAuth: WebAppUser): Promise<AuthResult> => {
@@ -208,9 +209,10 @@ export function useTelegram() {
   );
 
   useEffect(() => {
-    let isMounted = true;
+    isMountedRef.current = true;
+    const canUpdateState = () => isMountedRef.current;
     let detachVisibilityRecovery: (() => void) | undefined;
-    globalLogger.info("[HOOK_TELEGRAM EFFECT_MAIN_INIT] START. isMounted:", isMounted);
+    globalLogger.info("[HOOK_TELEGRAM EFFECT_MAIN_INIT] START. isMountedRef.current:", canUpdateState());
     
     setIsLoading(true);
     setIsAuthenticating(true);
@@ -223,10 +225,10 @@ export function useTelegram() {
     globalLogger.log("[HOOK_TELEGRAM EFFECT_MAIN_INIT] STEP 1: All relevant states reset to initial values.");
 
     const initialize = async () => {
-      globalLogger.log("[HOOK_TELEGRAM initialize ASYNC_FN_START] STEP 2: Starting async initialization. isMounted:", isMounted);
-      if (!isMounted) {
+      globalLogger.log("[HOOK_TELEGRAM initialize ASYNC_FN_START] STEP 2: Starting async initialization. isMountedRef.current:", canUpdateState());
+      if (!canUpdateState()) {
           globalLogger.warn("[HOOK_TELEGRAM initialize ASYNC_FN_ABORT] Aborted: component unmounted before async logic could run fully.");
-          if (isMounted) {
+          if (canUpdateState()) {
             setIsAuthenticating(false); 
             setIsLoading(false);
           }
@@ -243,23 +245,26 @@ export function useTelegram() {
         if (typeof window !== "undefined" && (window as any).Telegram?.WebApp) {
           const telegram = (window as any).Telegram.WebApp;
           tempTgWebApp = telegram; 
-          if(isMounted) {
+          if (canUpdateState()) {
             setTgWebApp(telegram);
             globalLogger.log("[HOOK_TELEGRAM initialize] STEP 3.1: Telegram WebApp object FOUND and set to state (tgWebApp).");
           }
           
           inTgContextReal = !!telegram.initData && telegram.initData.length > 0; 
           rawStartParam = telegram.initDataUnsafe?.start_param || null;
-          if (isMounted && rawStartParam) {
+          if (canUpdateState() && rawStartParam) {
             setStartParam(rawStartParam);
             globalLogger.info(`[HOOK_TELEGRAM initialize] STEP 3.1.1: start_param found: "${rawStartParam}" and set to state.`);
           }
           
-          if (isMounted) {
+          if (canUpdateState()) {
             safeReady(telegram);
             globalLogger.log("[HOOK_TELEGRAM initialize] STEP 3.3: Called telegram.ready()");
             if (inTgContextReal && telegram.expand) {
               const expanded = await safeExpand(telegram, { attempts: 3, delayMs: 120 });
+              if (!canUpdateState()) {
+                return;
+              }
               if (expanded) {
                 globalLogger.info("[HOOK_TELEGRAM initialize] STEP 3.3.1: Called telegram.expand() to maximize Web App.");
               } else {
@@ -277,7 +282,7 @@ export function useTelegram() {
                   globalLogger.info(`[HOOK_TELEGRAM initialize] STEP 4A.1: REAL Telegram auth validated successfully via API. Auth Candidate User ID: ${authCandidate.id}`);
               } else {
                   globalLogger.warn("[HOOK_TELEGRAM initialize] STEP 4A.2: REAL Telegram initData validation FAILED via API or returned no user. Error will be set.");
-                   if (isMounted) { 
+                   if (canUpdateState()) { 
                      const validationError = new Error("Telegram data validation failed via API. User data might be compromised or API issue.");
                      setError((prev) => prev ?? validationError);
                    }
@@ -297,7 +302,7 @@ export function useTelegram() {
             inTgContextReal = false; 
         }
         
-        if (isMounted) { 
+        if (canUpdateState()) { 
           const finalInTgContext = inTgContextReal && !!authCandidate && authCandidate !== MOCK_USER;
           setIsInTelegramContext(finalInTgContext);
         }
@@ -306,7 +311,7 @@ export function useTelegram() {
           globalLogger.log(`[HOOK_TELEGRAM initialize] STEP 7: Auth Candidate found (ID: ${authCandidate.id}). Proceeding to handleAuthentication.`);
           try { 
             const authData = await handleAuthentication(authCandidate); 
-            if (isMounted) {
+            if (canUpdateState()) {
               setTgUser(authData.tgUserToSet);
               setDbUser(authData.dbUserToSet); 
               setIsAuthenticated(authData.isAuthenticatedToSet);
@@ -314,7 +319,7 @@ export function useTelegram() {
             }
           } catch (authProcessError: any) { 
             globalLogger.error(`[HOOK_TELEGRAM initialize] STEP 7.3 (ERROR): Error DURING handleAuthentication:`, authProcessError.message);
-            if (isMounted) {
+            if (canUpdateState()) {
               setError((prev) => prev ?? authProcessError); 
               setTgUser(authCandidate); 
               setDbUser(null);          
@@ -323,7 +328,7 @@ export function useTelegram() {
           }
         } else { 
            globalLogger.warn(`[HOOK_TELEGRAM initialize] STEP 7 (NO_CANDIDATE): No authCandidate available.`);
-           if (isMounted) {
+           if (canUpdateState()) {
              const noAuthCandidateError = new Error("No user data available for authentication.");
              setError((prev) => prev ?? noAuthCandidateError);
             setTgUser(null);
@@ -333,11 +338,11 @@ export function useTelegram() {
         }
       } catch (outerError: any) { 
         globalLogger.error("[HOOK_TELEGRAM initialize] STEP ERROR (OUTER_CATCH): CRITICAL OUTER ERROR:", outerError.message);
-        if (isMounted) { 
+        if (canUpdateState()) { 
           setError((prev) => prev ?? outerError);
         }
       } finally { 
-        if (isMounted) {
+        if (canUpdateState()) {
           setIsAuthenticating(false); 
         }
       }
@@ -347,7 +352,7 @@ export function useTelegram() {
 
     return () => {
       globalLogger.info("[HOOK_TELEGRAM EFFECT_MAIN_INIT_CLEANUP] Cleanup. Setting isMounted=false.");
-      isMounted = false;
+      isMountedRef.current = false;
       detachVisibilityRecovery?.();
     };
   }, [handleAuthentication]); 


### PR DESCRIPTION
### Motivation
- Fix a franchize code-quality issue where `useTelegram` could call `setState` after the component had unmounted, causing React warnings and potential memory leaks. 
- This addresses SupaPlan task `CQ-TELEGRAM-GUARD` under capability `franchize.code-quality` and makes Telegram WebApp auth/init more robust during slow networks.

### Description
- Replaced the ad-hoc local `isMounted` boolean in `hooks/useTelegram.ts` with a `useRef`-backed lifecycle guard (`isMountedRef`) and added a `canUpdateState()` helper for safe post-await updates. 
- Added guard checks around Telegram WebApp initialization, `safeExpand` early-return when unmounted, validation error/state updates, and auth-result state writes to prevent updates after unmount. 
- Updated `docs/THE_FRANCHEEZEPLAN.md` with a new diary entry recording the claimed task and next verification steps. 
- SupaPlan task reference: `supaplan_task: d9c5f5f8-9234-4c9e-3456-99990009f456`.

### Testing
- Ran the SupaPlan claim flow with `node scripts/supaplan-skill.mjs pick-task` and claimed the task, then moved it to `running` and `ready_for_pr`, and verified `node scripts/supaplan-skill.mjs task-status` returned `ready_for_pr`. (passed)
- Targeted lint for the changed file via `npx eslint hooks/useTelegram.ts` passed. (passed)
- Ran repository lint `npm run lint` which surfaced existing repo-wide warnings/errors unrelated to this change; these pre-existing issues prevented a clean, repo-wide green lint run. (repo-wide lint: warnings/errors unrelated)
- Type-check with `npx tsc --noEmit` failed due to unrelated syntax errors in other files (`data/questions.ts`, `supabase/functions/arbitrage-scan-instance/index.ts`) and not because of the changes in `hooks/useTelegram.ts`. (typecheck: failed due to unrelated files)
- Verified SupaPlan claim row via REST check and inserted progress events with `node scripts/supaplan-skill.mjs log-event`; status notifications were skipped because `SUPAPLAN_NOTIFY_STATUS_UPDATES` is not enabled in this environment. (verification: passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbbf4a264c8324a91e637e31d7bf89)