### PR TITLE
fix: label franchize select controls supaplan_task:dc8f8c2b-2234-4c0a-6789-ccc000ccf789

### DIFF
--- a/app/franchize/[slug]/configurator/ConfiguratorClient.tsx
+++ b/app/franchize/[slug]/configurator/ConfiguratorClient.tsx
@@ -444,7 +444,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
                     return (
                       <label key={motor.value} className={['cfg-option flex items-center justify-between rounded-xl border p-4', active ? 'cfg-option-active' : 'border-[#27272a]'].join(' ')}>
                         <span className="flex items-center gap-3">
-                          <input type="radio" name="motor" className="cfg-radio-dot" value={motor.value} checked={active} onChange={() => setMotorPower(motor.value)} />
+                          <input type="radio" name="motor" className="cfg-radio-dot" value={motor.value} checked={active} onChange={() => setMotorPower(motor.value)} aria-label={`Мощность мотора ${motor.value}W`} />
                           <span><span className="block text-sm font-semibold">{motor.value}W</span><span className="block text-[11px] text-[#71717a]">{motor.extra === 0 ? 'Базовая комплектация' : `+${formatPrice(motor.extra)}`}</span></span>
                         </span>
                         {motor.extra > 0 && <span className="cfg-mono text-xs font-medium text-[#a1a1aa]">+{formatPrice(motor.extra)}</span>}
@@ -464,6 +464,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
                   <div className="mb-4 inline-flex rounded-xl border border-[#27272a] bg-[#09090b] p-1">
                     {(['regular', 'lithium'] as const).map((mode) => (
                       <button key={mode} onClick={() => { setBatteryMode(mode); setBatteryCapacity((mode === 'regular' ? regularBatteries[0] : lithiumBatteries[0])?.capacity ?? '') }}
+                        aria-label={`Тип аккумулятора ${mode === 'regular' ? 'Regular' : 'Lithium'}`}
                         className={['rounded-lg px-4 py-2 text-xs font-semibold transition-all', batteryMode === mode ? 'bg-[#00ffea] text-black shadow-md' : 'text-[#71717a] hover:text-white'].join(' ')}>
                         {mode === 'regular' ? 'Regular' : 'Lithium'}
                       </button>
@@ -475,7 +476,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
                       return (
                         <label key={`${batteryMode}-${battery.capacity}`} className={['cfg-option flex items-center justify-between rounded-xl border p-4', active ? 'cfg-option-active' : 'border-[#27272a]'].join(' ')}>
                           <span className="flex items-center gap-3">
-                            <input type="radio" name="battery" className="cfg-radio-dot" value={battery.capacity} checked={active} onChange={() => setBatteryCapacity(battery.capacity)} />
+                            <input type="radio" name="battery" className="cfg-radio-dot" value={battery.capacity} checked={active} onChange={() => setBatteryCapacity(battery.capacity)} aria-label={`Аккумулятор ${battery.capacity}`} />
                             <span><span className="block text-sm font-semibold">{battery.capacity}</span><span className="block text-[11px] text-[#71717a]">Запас хода: {battery.range_km} км</span></span>
                           </span>
                           <span className="cfg-mono text-xs font-medium text-[#a1a1aa]">{battery.battery_price === 0 ? 'Вкл.' : `+${formatPrice(battery.battery_price)}`}</span>
@@ -499,6 +500,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
                         key={color.id}
                         type="button"
                         onClick={() => setSelectedColorId(color.id)}
+                        aria-label={`Цвет рамы ${color.label}`}
                         className={[
                           'cfg-option flex items-center justify-between rounded-xl border p-4 text-left',
                           active ? 'cfg-option-active' : 'border-[#27272a]',
@@ -542,7 +544,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
                         return (
                           <label key={part.id} className={['cfg-option flex items-start justify-between gap-3 rounded-xl border p-4', checked ? 'cfg-option-active' : 'border-[#27272a]'].join(' ')}>
                             <span className="flex items-start gap-3">
-                              <input type="checkbox" className="cfg-check mt-0.5" checked={checked} onChange={() => setSelectedAccessories((prev) => prev.includes(part.id) ? prev.filter((id) => id !== part.id) : [...prev, part.id])} />
+                              <input type="checkbox" className="cfg-check mt-0.5" checked={checked} onChange={() => setSelectedAccessories((prev) => prev.includes(part.id) ? prev.filter((id) => id !== part.id) : [...prev, part.id])} aria-label={`Аксессуар ${part.model}`} />
                               <span><span className="block text-sm font-semibold">{part.model}</span><span className="mt-0.5 block text-[11px] leading-relaxed text-[#71717a]">{part.description}</span></span>
                             </span>
                             <span className="cfg-mono whitespace-nowrap text-xs font-medium text-[#a1a1aa]">+{formatPrice(part.daily_price)}</span>

--- a/app/franchize/[slug]/configurator/ConfiguratorClient.tsx
+++ b/app/franchize/[slug]/configurator/ConfiguratorClient.tsx
@@ -463,7 +463,7 @@ export function ConfiguratorClient({ crew, slug }: Props) {
                   </div>
                   <div className="mb-4 inline-flex rounded-xl border border-[#27272a] bg-[#09090b] p-1">
                     {(['regular', 'lithium'] as const).map((mode) => (
-                      <button key={mode} onClick={() => { setBatteryMode(mode); setBatteryCapacity((mode === 'regular' ? regularBatteries[0] : lithiumBatteries[0])?.capacity ?? '') }}
+                      <button key={mode} type="button" onClick={() => { setBatteryMode(mode); setBatteryCapacity((mode === 'regular' ? regularBatteries[0] : lithiumBatteries[0])?.capacity ?? '') }}
                         aria-label={`Тип аккумулятора ${mode === 'regular' ? 'Regular' : 'Lithium'}`}
                         className={['rounded-lg px-4 py-2 text-xs font-semibold transition-all', batteryMode === mode ? 'bg-[#00ffea] text-black shadow-md' : 'text-[#71717a] hover:text-white'].join(' ')}>
                         {mode === 'regular' ? 'Regular' : 'Lithium'}

--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { VibeContentRenderer } from "@/components/VibeContentRenderer";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAppContext } from "@/contexts/AppContext";
@@ -401,23 +402,28 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
               </Button>
             ) : null}
             <div className="space-y-2 rounded-xl border border-white/10 bg-black/20 p-3">
+              <Label htmlFor="map-riders-ride-name" className="sr-only">Название заезда</Label>
               <Input
+                id="map-riders-ride-name"
                 value={state.rideName}
                 onChange={(event) => dispatch({ type: "ui/set-ride-name", payload: event.target.value })}
                 placeholder="Название заезда"
                 className="h-9"
               />
+              <Label htmlFor="map-riders-vehicle-label" className="sr-only">Мотоцикл</Label>
               <Input
+                id="map-riders-vehicle-label"
                 value={state.vehicleLabel}
                 onChange={(event) => dispatch({ type: "ui/set-vehicle-label", payload: event.target.value })}
                 placeholder="Мотоцикл"
                 className="h-9"
               />
+              <Label htmlFor="map-riders-ride-mode" className="sr-only">Режим поездки</Label>
               <Select
                 value={state.rideMode}
                 onValueChange={(value: "rental" | "personal") => dispatch({ type: "ui/set-ride-mode", payload: value })}
               >
-                <SelectTrigger className="h-9">
+                <SelectTrigger id="map-riders-ride-mode" aria-label="Режим поездки" className="h-9">
                   <SelectValue placeholder="Режим поездки" />
                 </SelectTrigger>
                 <SelectContent>
@@ -426,26 +432,32 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
                 </SelectContent>
               </Select>
               <div className="grid grid-cols-2 gap-2">
-                <Select value={state.visibilityMode} onValueChange={(value: "crew" | "public") => dispatch({ type: "privacy/set-visibility", payload: value })}>
-                  <SelectTrigger className="h-9">
-                    <SelectValue placeholder="Видимость" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="crew">Только экипаж</SelectItem>
-                    <SelectItem value="public">Все авторизованные</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Select value={String(state.autoExpireMinutes)} onValueChange={(value: "1" | "5" | "15" | "60") => dispatch({ type: "privacy/set-auto-expire", payload: Number(value) as 1 | 5 | 15 | 60 })}>
-                  <SelectTrigger className="h-9">
-                    <SelectValue placeholder="Авто-стоп" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="1">1 мин</SelectItem>
-                    <SelectItem value="5">5 мин</SelectItem>
-                    <SelectItem value="15">15 мин</SelectItem>
-                    <SelectItem value="60">60 мин</SelectItem>
-                  </SelectContent>
-                </Select>
+                <div className="space-y-1">
+                  <Label htmlFor="map-riders-visibility" className="sr-only">Кто видит мою позицию</Label>
+                  <Select value={state.visibilityMode} onValueChange={(value: "crew" | "public") => dispatch({ type: "privacy/set-visibility", payload: value })}>
+                    <SelectTrigger id="map-riders-visibility" aria-label="Кто видит мою позицию" className="h-9">
+                      <SelectValue placeholder="Видимость" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="crew">Только экипаж</SelectItem>
+                      <SelectItem value="public">Все авторизованные</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="map-riders-auto-expire" className="sr-only">Автоматически остановить геошеринг</Label>
+                  <Select value={String(state.autoExpireMinutes)} onValueChange={(value: "1" | "5" | "15" | "60") => dispatch({ type: "privacy/set-auto-expire", payload: Number(value) as 1 | 5 | 15 | 60 })}>
+                    <SelectTrigger id="map-riders-auto-expire" aria-label="Автоматически остановить геошеринг" className="h-9">
+                      <SelectValue placeholder="Авто-стоп" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="1">1 мин</SelectItem>
+                      <SelectItem value="5">5 мин</SelectItem>
+                      <SelectItem value="15">15 мин</SelectItem>
+                      <SelectItem value="60">60 мин</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
               <Button type="button" variant="outline" size="sm" className="w-full" onClick={() => dispatch({ type: "privacy/toggle-home-blur" })}>
                 {state.homeBlurEnabled ? "Дом размыт: ВКЛ" : "Дом размыт: ВЫКЛ"}

--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -402,7 +402,9 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
               </Button>
             ) : null}
             <div className="space-y-2 rounded-xl border border-white/10 bg-black/20 p-3">
-              <Label htmlFor="map-riders-ride-name" className="sr-only">Название заезда</Label>
+              <Label htmlFor="map-riders-ride-name" className="sr-only">
+                Название заезда
+              </Label>
               <Input
                 id="map-riders-ride-name"
                 value={state.rideName}
@@ -410,7 +412,9 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
                 placeholder="Название заезда"
                 className="h-9"
               />
-              <Label htmlFor="map-riders-vehicle-label" className="sr-only">Мотоцикл</Label>
+              <Label htmlFor="map-riders-vehicle-label" className="sr-only">
+                Мотоцикл
+              </Label>
               <Input
                 id="map-riders-vehicle-label"
                 value={state.vehicleLabel}
@@ -418,12 +422,11 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
                 placeholder="Мотоцикл"
                 className="h-9"
               />
-              <Label htmlFor="map-riders-ride-mode" className="sr-only">Режим поездки</Label>
               <Select
                 value={state.rideMode}
                 onValueChange={(value: "rental" | "personal") => dispatch({ type: "ui/set-ride-mode", payload: value })}
               >
-                <SelectTrigger id="map-riders-ride-mode" aria-label="Режим поездки" className="h-9">
+                <SelectTrigger aria-label="Режим поездки" className="h-9">
                   <SelectValue placeholder="Режим поездки" />
                 </SelectTrigger>
                 <SelectContent>
@@ -433,9 +436,8 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
               </Select>
               <div className="grid grid-cols-2 gap-2">
                 <div className="space-y-1">
-                  <Label htmlFor="map-riders-visibility" className="sr-only">Кто видит мою позицию</Label>
                   <Select value={state.visibilityMode} onValueChange={(value: "crew" | "public") => dispatch({ type: "privacy/set-visibility", payload: value })}>
-                    <SelectTrigger id="map-riders-visibility" aria-label="Кто видит мою позицию" className="h-9">
+                    <SelectTrigger aria-label="Кто видит мою позицию" className="h-9">
                       <SelectValue placeholder="Видимость" />
                     </SelectTrigger>
                     <SelectContent>
@@ -445,9 +447,8 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
                   </Select>
                 </div>
                 <div className="space-y-1">
-                  <Label htmlFor="map-riders-auto-expire" className="sr-only">Автоматически остановить геошеринг</Label>
                   <Select value={String(state.autoExpireMinutes)} onValueChange={(value: "1" | "5" | "15" | "60") => dispatch({ type: "privacy/set-auto-expire", payload: Number(value) as 1 | 5 | 15 | 60 })}>
-                    <SelectTrigger id="map-riders-auto-expire" aria-label="Автоматически остановить геошеринг" className="h-9">
+                    <SelectTrigger aria-label="Автоматически остановить геошеринг" className="h-9">
                       <SelectValue placeholder="Авто-стоп" />
                     </SelectTrigger>
                     <SelectContent>

--- a/components/map-riders/RidersDrawer.tsx
+++ b/components/map-riders/RidersDrawer.tsx
@@ -161,10 +161,10 @@ export function RidersDrawer() {
               <div className="space-y-3">
                 {state.selectedMeetupPoint && (
                   <div className="rounded-xl border border-amber-300/30 bg-amber-500/10 p-3">
-                    <Label className="text-xs text-amber-200">Название</Label>
-                    <Input value={meetupTitle} onChange={(e) => setMeetupTitle(e.target.value)} className="mt-1 bg-transparent text-white" />
-                    <Label className="mt-2 text-xs text-amber-200">Комментарий</Label>
-                    <Input value={meetupComment} onChange={(e) => setMeetupComment(e.target.value)} placeholder="Ориентир" className="mt-1 bg-transparent text-white" />
+                    <Label htmlFor="map-riders-meetup-title" className="text-xs text-amber-200">Название</Label>
+                    <Input id="map-riders-meetup-title" value={meetupTitle} onChange={(e) => setMeetupTitle(e.target.value)} className="mt-1 bg-transparent text-white" />
+                    <Label htmlFor="map-riders-meetup-comment" className="mt-2 text-xs text-amber-200">Комментарий</Label>
+                    <Input id="map-riders-meetup-comment" value={meetupComment} onChange={(e) => setMeetupComment(e.target.value)} placeholder="Ориентир" className="mt-1 bg-transparent text-white" />
                     <Button type="button" size="sm" className="mt-2 w-full" disabled={isSubmitting} onClick={handleCreateMeetup}>
                       {isSubmitting ? "Сохраняем meetup..." : "Сохранить meetup"}
                     </Button>
@@ -319,7 +319,10 @@ function ReplayFullscreen({
             <div className="h-2 w-full overflow-hidden rounded bg-white/10">
               <div className="h-full rounded bg-emerald-400 transition-all" style={{ width: `${progress}%` }} />
             </div>
+            <Label htmlFor="map-riders-replay-position" className="sr-only">Позиция воспроизведения маршрута</Label>
             <input
+              id="map-riders-replay-position"
+              aria-label="Позиция воспроизведения маршрута"
               type="range"
               min={0}
               max={Math.max(total - 1, 0)}

--- a/components/map-riders/RidersDrawer.tsx
+++ b/components/map-riders/RidersDrawer.tsx
@@ -161,10 +161,25 @@ export function RidersDrawer() {
               <div className="space-y-3">
                 {state.selectedMeetupPoint && (
                   <div className="rounded-xl border border-amber-300/30 bg-amber-500/10 p-3">
-                    <Label htmlFor="map-riders-meetup-title" className="text-xs text-amber-200">Название</Label>
-                    <Input id="map-riders-meetup-title" value={meetupTitle} onChange={(e) => setMeetupTitle(e.target.value)} className="mt-1 bg-transparent text-white" />
-                    <Label htmlFor="map-riders-meetup-comment" className="mt-2 text-xs text-amber-200">Комментарий</Label>
-                    <Input id="map-riders-meetup-comment" value={meetupComment} onChange={(e) => setMeetupComment(e.target.value)} placeholder="Ориентир" className="mt-1 bg-transparent text-white" />
+                    <Label htmlFor="map-riders-meetup-title" className="text-xs text-amber-200">
+                      Название
+                    </Label>
+                    <Input
+                      id="map-riders-meetup-title"
+                      value={meetupTitle}
+                      onChange={(e) => setMeetupTitle(e.target.value)}
+                      className="mt-1 bg-transparent text-white"
+                    />
+                    <Label htmlFor="map-riders-meetup-comment" className="mt-2 text-xs text-amber-200">
+                      Комментарий
+                    </Label>
+                    <Input
+                      id="map-riders-meetup-comment"
+                      value={meetupComment}
+                      onChange={(e) => setMeetupComment(e.target.value)}
+                      placeholder="Ориентир"
+                      className="mt-1 bg-transparent text-white"
+                    />
                     <Button type="button" size="sm" className="mt-2 w-full" disabled={isSubmitting} onClick={handleCreateMeetup}>
                       {isSubmitting ? "Сохраняем meetup..." : "Сохранить meetup"}
                     </Button>
@@ -319,10 +334,11 @@ function ReplayFullscreen({
             <div className="h-2 w-full overflow-hidden rounded bg-white/10">
               <div className="h-full rounded bg-emerald-400 transition-all" style={{ width: `${progress}%` }} />
             </div>
-            <Label htmlFor="map-riders-replay-position" className="sr-only">Позиция воспроизведения маршрута</Label>
+            <Label htmlFor="map-riders-replay-position" className="sr-only">
+              Позиция воспроизведения маршрута
+            </Label>
             <input
               id="map-riders-replay-position"
-              aria-label="Позиция воспроизведения маршрута"
               type="range"
               min={0}
               max={Math.max(total - 1, 0)}

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -67,6 +67,16 @@ This root file stays intentionally compact so operators and agents can load it q
 - 2026-05-06 — Final polish iteration: implemented `StepsProgress` for the newbie flow and reworded `/app/vipbikerental/todo.md` so completed scope is clearly closed while remaining quick-action/technical items are future backlog, not an automatic trigger.
 ## 3) Active implementation slices
 
+
+### 2026-05-06 — Franchize accessibility labels for MapRiders/configurator
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-06T22:25:00Z
+- `owner`: codex
+- `notes`: Added screen-reader labels/aria names for MapRiders ride controls, privacy dropdowns, meetup drawer inputs, replay scrubber, and configurator option controls. SupaPlan task `dc8f8c2b-2234-4c0a-6789-ccc000ccf789`.
+- `next_step`: Verify `vip-bike` configurator and `/franchize/vip-bike/map-riders` with a browser accessibility audit when a local runtime is available.
+- `risks`: Visual layout should be unchanged because labels are hidden where needed; runtime audit still depends on app boot and route data.
+
 ### 2026-05-06 — Sale buy page VS + test-drive reservation
 
 - `status`: done
@@ -84,3 +94,5 @@ This root file stays intentionally compact so operators and agents can load it q
 - `notes`: Aligned sale reservation CTA copy with the same 100-500 XTR formula used by backend invoices, centralized VS spec aliases, and split reservation/cart CTA state so secondary cart actions do not display invoice success.
 - `next_step`: Verify production `vip-bike` sale bike with real catalog specs and Telegram WebApp invoice delivery.
 - `risks`: Visual/live invoice verification still depends on reachable Supabase and Telegram bot credentials.
+
+- 2026-05-06 — Claimed SupaPlan franchize accessibility task `dc8f8c2b-2234-4c0a-6789-ccc000ccf789`; labeled MapRiders dropdown/input controls and configurator option controls for screen readers. Next step: PR review + runtime accessibility smoke on `vip-bike`.


### PR DESCRIPTION
### Motivation
- Improve accessibility on franchize surfaces by adding screen-reader-visible labels and ARIA names to Selects, inputs, radio/checkbox controls and the replay scrubber in MapRiders and the Configurator to satisfy the SupaPlan accessibility acceptance criteria.

### Description
- Added `Label` imports and hidden labels (`sr-only` / `htmlFor`) and `id` attributes to MapRiders ride inputs and meetup drawer inputs, and to the replay range scrubber in `components/map-riders/RidersDrawer.tsx` and `components/map-riders/MapRidersClientRefactored.tsx`.
- Added `aria-label` / accessible names for `SelectTrigger` elements and for configurator option controls (motor, battery type/capacity, color buttons, accessory checkboxes) in `app/franchize/[slug]/configurator/ConfiguratorClient.tsx`.
- Updated `docs/THE_FRANCHEEZEPLAN.md` with a ready_for_pr diary entry for this accessibility slice and logged a SupaPlan event; committed changes on branch `work`.

supaplan_task: dc8f8c2b-2234-4c0a-6789-ccc000ccf789

### Testing
- Ran `npx eslint --max-warnings=0 'app/franchize/[slug]/configurator/ConfiguratorClient.tsx' components/map-riders/MapRidersClientRefactored.tsx components/map-riders/RidersDrawer.tsx` and it passed.
- Verified repository hygiene with `git diff --check` and created a commit containing the changes.
- Updated SupaPlan status and verified `node scripts/supaplan-skill.mjs task-status --taskId dc8f8c2b-2234-4c0a-6789-ccc000ccf789` shows `ready_for_pr` and confirmed a `supaplan_claims` row exists via the SupaPlan REST query.
- Type-check (`npx tsc --noEmit`) failed due to unrelated pre-existing syntax errors in other files, which do not block this scoped accessibility change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbbf8d1ba883249965af2ba37855c4)
supaplan_task: dc8f8c2b-2234-4c0a-6789-ccc000ccf789