### PR TITLE
Centralize sale config parsing and add RentalQuickActionHub with Electro‑Enduro mini-config

### DIFF
--- a/app/franchize/components/SaleBikeLandingClient.tsx
+++ b/app/franchize/components/SaleBikeLandingClient.tsx
@@ -25,6 +25,14 @@ import {
 import type { CatalogItemVM, FranchizeCrewVM } from "@/app/franchize/actions";
 import { createFranchizeOrderInvoice } from "@/app/franchize/actions";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import {
+  DEFAULT_COLOR_OPTIONS,
+  DEFAULT_CONFIG_OPTIONS,
+  resolveBuyColorOptions,
+  resolveBuyConfigOptions,
+  type ColorOption,
+  type ConfigOption,
+} from "@/app/franchize/lib/sale-config";
 import { buildCandidateImageUrls } from "@/app/franchize/lib/media";
 import { useFranchizeCart } from "@/app/franchize/hooks/useFranchizeCart";
 import { useAppContext } from "@/contexts/AppContext";
@@ -34,13 +42,6 @@ import {
   getCatalogVsSpecValue,
 } from "@/components/franchize/VsSpecRow";
 
-type ConfigOption = {
-  id: string;
-  label: string;
-  priceDelta: number;
-  subtitle: string;
-};
-type ColorOption = { id: string; label: string; hex: string };
 type SaleActionState = "idle" | "loading" | "success" | "error";
 type SaleBikeLandingClientProps = {
   crew: FranchizeCrewVM;
@@ -48,34 +49,6 @@ type SaleBikeLandingClientProps = {
   vsItem?: CatalogItemVM | null;
   otherSaleBikes?: CatalogItemVM[];
 };
-
-const DEFAULT_CONFIG_OPTIONS: ConfigOption[] = [
-  {
-    id: "standard",
-    label: "Стандарт",
-    subtitle: "Базовая комплектация",
-    priceDelta: 0,
-  },
-  {
-    id: "long-range",
-    label: "Long Range",
-    subtitle: "Увеличенный запас хода",
-    priceDelta: 40000,
-  },
-  {
-    id: "comfort",
-    label: "Comfort",
-    subtitle: "Комфорт и защита",
-    priceDelta: 25000,
-  },
-];
-
-const DEFAULT_COLOR_OPTIONS: ColorOption[] = [
-  { id: "black", label: "Черный", hex: "#0b0c0f" },
-  { id: "graphite", label: "Графит", hex: "#6b7280" },
-  { id: "acid", label: "Lime", hex: "#c6ff00" },
-  { id: "white", label: "Белый", hex: "#f8fafc" },
-];
 
 function formatPrice(value: number): string {
   return value > 0 ? `${value.toLocaleString("ru-RU")} ₽` : "по запросу";
@@ -101,39 +74,11 @@ export function SaleBikeLandingClient({
 
   const heroImage =
     gallery[0] ?? "https://placehold.co/1200x900/0b0f13/e6edf3?text=No+image";
-  const specs = item.rawSpecs || {};
+  const specs = useMemo(() => item.rawSpecs || {}, [item.rawSpecs]);
   const basePrice = Number(specs.price_rub || specs.sale_price || 0);
 
-  const configOptions = useMemo(() => {
-    const custom = Array.isArray(specs.buy_options)
-      ? (specs.buy_options as Array<Record<string, unknown>>)
-      : [];
-    if (!custom.length) return DEFAULT_CONFIG_OPTIONS;
-    const mapped = custom
-      .map((option, idx) => ({
-        id: String(option.id || `opt-${idx}`),
-        label: String(option.label || option.name || `Опция ${idx + 1}`),
-        subtitle: String(option.subtitle || option.description || ""),
-        priceDelta: Number(option.priceDelta || option.price_delta || 0),
-      }))
-      .filter((option) => option.id);
-    return mapped.length ? mapped : DEFAULT_CONFIG_OPTIONS;
-  }, [specs.buy_options]);
-
-  const colorOptions = useMemo(() => {
-    const custom = Array.isArray(specs.buy_colors)
-      ? (specs.buy_colors as Array<Record<string, unknown>>)
-      : [];
-    if (!custom.length) return DEFAULT_COLOR_OPTIONS;
-    const mapped = custom
-      .map((color, idx) => ({
-        id: String(color.id || `color-${idx}`),
-        label: String(color.label || color.name || `Цвет ${idx + 1}`),
-        hex: String(color.hex || color.value || "#9ca3af"),
-      }))
-      .filter((color) => color.id);
-    return mapped.length ? mapped : DEFAULT_COLOR_OPTIONS;
-  }, [specs.buy_colors]);
+  const configOptions = useMemo(() => resolveBuyConfigOptions(specs), [specs]);
+  const colorOptions = useMemo(() => resolveBuyColorOptions(specs), [specs]);
 
   const [selectedImage, setSelectedImage] = useState(0);
   const [brokenGalleryUrls, setBrokenGalleryUrls] = useState<

--- a/app/franchize/lib/sale-config.ts
+++ b/app/franchize/lib/sale-config.ts
@@ -1,0 +1,75 @@
+export type ConfigOption = {
+  id: string;
+  label: string;
+  priceDelta: number;
+  subtitle: string;
+};
+
+export type ColorOption = {
+  id: string;
+  label: string;
+  hex: string;
+};
+
+export const DEFAULT_CONFIG_OPTIONS: ConfigOption[] = [
+  {
+    id: "standard",
+    label: "Стандарт",
+    subtitle: "Базовая комплектация",
+    priceDelta: 0,
+  },
+  {
+    id: "long-range",
+    label: "Long Range",
+    subtitle: "Увеличенный запас хода",
+    priceDelta: 40000,
+  },
+  {
+    id: "comfort",
+    label: "Comfort",
+    subtitle: "Комфорт и защита",
+    priceDelta: 25000,
+  },
+];
+
+export const DEFAULT_COLOR_OPTIONS: ColorOption[] = [
+  { id: "black", label: "Черный", hex: "#0b0c0f" },
+  { id: "graphite", label: "Графит", hex: "#6b7280" },
+  { id: "acid", label: "Lime", hex: "#c6ff00" },
+  { id: "white", label: "Белый", hex: "#f8fafc" },
+];
+
+export function resolveBuyConfigOptions(specs: Record<string, unknown> | undefined): ConfigOption[] {
+  const custom = Array.isArray(specs?.buy_options)
+    ? (specs.buy_options as Array<Record<string, unknown>>)
+    : [];
+  if (!custom.length) return DEFAULT_CONFIG_OPTIONS;
+
+  const mapped = custom
+    .map((option, idx) => ({
+      id: String(option.id || `opt-${idx}`),
+      label: String(option.label || option.name || `Опция ${idx + 1}`),
+      subtitle: String(option.subtitle || option.description || ""),
+      priceDelta: Number(option.priceDelta || option.price_delta || 0),
+    }))
+    .filter((option) => option.id);
+
+  return mapped.length ? mapped : DEFAULT_CONFIG_OPTIONS;
+}
+
+export function resolveBuyColorOptions(specs: Record<string, unknown> | undefined): ColorOption[] {
+  const custom = Array.isArray(specs?.buy_colors)
+    ? (specs.buy_colors as Array<Record<string, unknown>>)
+    : [];
+  if (!custom.length) return DEFAULT_COLOR_OPTIONS;
+
+  const mapped = custom
+    .map((color, idx) => ({
+      id: String(color.id || `color-${idx}`),
+      label: String(color.label || color.name || `Цвет ${idx + 1}`),
+      hex: String(color.hex || color.value || "#9ca3af"),
+    }))
+    .filter((color) => color.id);
+
+  return mapped.length ? mapped : DEFAULT_COLOR_OPTIONS;
+}

--- a/app/vipbikerental/VipBikeRentalClient.tsx
+++ b/app/vipbikerental/VipBikeRentalClient.tsx
@@ -13,6 +13,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { useAppContext } from "@/contexts/AppContext";
 import type { CatalogItemVM } from "@/app/franchize/actions";
+import {
+  DEFAULT_COLOR_OPTIONS,
+  DEFAULT_CONFIG_OPTIONS,
+  resolveBuyColorOptions,
+  resolveBuyConfigOptions,
+} from "@/app/franchize/lib/sale-config";
 
 type ServiceItem = { icon: string; text: string };
 
@@ -188,43 +194,17 @@ const ServiceCard = ({
   </Card>
 );
 
-const quickActions = [
-  {
-    title: "Купить электромотоцикл",
-    icon: "::FaCartShopping::",
-    text: "Открыть конфигуратор с выбором модели, мотора, батареи и допов.",
-    href: "/franchize/vip-bike/configurator",
-    cta: "Купить",
-  },
-  {
-    title: "Каталог байков",
-    icon: "::FaMotorcycle::",
-    text: "Подбор модели под стиль езды, бюджет и маршрут.",
-    href: "/franchize/vip-bike",
-    cta: "Открыть",
-  },
-  {
-    title: "Контроль сделок",
-    icon: "::FaTicket::",
-    text: "Проверка статусов, подтверждений и активных аренд.",
-    href: "/franchize/vip-bike/rentals",
-    cta: "Мои аренды",
-  },
-  {
-    title: "MapRiders",
-    icon: "::FaMapLocationDot::",
-    text: "Живая карта райдеров, маршруты, точки встречи и недельный лидерборд.",
-    href: "/franchize/vip-bike/map-riders",
-    cta: "Открыть карту",
-  },
-  {
-    title: "Быстрый вход",
-    icon: "::FaBolt::",
-    text: "Прямой сценарий: выбрать → подтвердить → поехать.",
-    href: "/franchize/vip-bike",
-    cta: "Старт",
-  },
+const rentalStatusSteps = [
+  { label: "Выбор", value: "открыт", icon: "::FaMotorcycle::" },
+  { label: "Экип", value: "готов", icon: "::FaHelmetSafety::" },
+  { label: "Слот", value: "сегодня", icon: "::FaStopwatch::" },
 ];
+
+const quickChooserFilters = [
+  { id: "first", label: "Первый выезд", hint: "мягкая тяга" },
+  { id: "range", label: "Дальше ехать", hint: "батарея +" },
+  { id: "buy", label: "Купить", hint: "sale-ready" },
+] as const;
 
 const heroMetrics = [
   "::FaStopwatch:: Быстрая онлайн-бронь",
@@ -403,6 +383,268 @@ function StepsProgress({ items }: { items: CatalogItemVM[] }) {
           </motion.div>
         </AnimatePresence>
       </div>
+    </section>
+  );
+}
+
+
+function RentalQuickActionHub({ items, overview }: { items: CatalogItemVM[]; overview: MapRidersOverview | null }) {
+  const [selectedAction, setSelectedAction] = useState<"status" | "riders" | "chooser">("status");
+  const [isChooserOpen, setIsChooserOpen] = useState(false);
+  const [activeFilter, setActiveFilter] = useState<(typeof quickChooserFilters)[number]["id"]>("first");
+
+  const chooserItems = useMemo(() => {
+    const availableItems = items.filter((item) => item.availabilityStatus === "available" || item.pricePerDay > 0);
+    const saleItems = items.filter((item) => item.saleAvailable || isEnabled(item.rawSpecs?.sale));
+    const source = activeFilter === "buy" && saleItems.length > 0 ? saleItems : availableItems.length > 0 ? availableItems : items;
+    return (source.length > 0 ? source : fallbackElectroItems).slice(0, 3);
+  }, [activeFilter, items]);
+
+  const leadItem = chooserItems[0];
+  const activeRiders = formatCompactNumber(overview?.stats?.activeRiders, overview?.liveLocations?.length || fallbackMapLocations.length);
+  const meetupCount = formatCompactNumber(overview?.stats?.meetupCount, overview?.meetups?.length || fallbackMeetups.length);
+  const weeklyDistance = formatCompactNumber(overview?.stats?.totalWeeklyDistanceKm, 127);
+
+  const actionCards = [
+    {
+      id: "status" as const,
+      title: "Статус аренды",
+      icon: "::FaTicket::",
+      metric: "3 шага",
+      text: "Проверь, что уже закрыто перед поездкой: байк, экип и слот выдачи.",
+      cta: "Открыть сделки",
+      href: "/franchize/vip-bike/rentals",
+    },
+    {
+      id: "riders" as const,
+      title: "Райдеры рядом",
+      icon: "::FaMapLocationDot::",
+      metric: `${activeRiders} онлайн`,
+      text: `За неделю комьюнити проехало ${weeklyDistance} км, активных встреч: ${meetupCount}.`,
+      cta: "Открыть карту",
+      href: "/franchize/vip-bike/map-riders",
+    },
+    {
+      id: "chooser" as const,
+      title: "Быстрый подбор",
+      icon: "::FaBolt::",
+      metric: leadItem?.title || "VIP Bike",
+      text: "Открой мини-подбор прямо здесь: цель поездки → карточки байков → следующий шаг.",
+      cta: "Подобрать байк",
+      href: "/franchize/vip-bike",
+    },
+  ];
+
+  const selectedCard = actionCards.find((card) => card.id === selectedAction) ?? actionCards[0];
+
+  return (
+    <section>
+      <div className="mb-8 text-center">
+        <h2 className="font-orbitron text-3xl sm:text-4xl">Rental-флоу — живые действия вместо ссылок</h2>
+        <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">
+          Быстрые карточки теперь не просто уводят в разделы: они показывают статус аренды, live-счётчик райдеров и мини-подбор байка прямо на лендинге.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-[0.95fr_1.05fr]">
+        <div className="grid gap-3" role="tablist" aria-label="Быстрые действия VIP Bike">
+          {actionCards.map((card) => {
+            const isActive = selectedAction === card.id;
+            return (
+              <button
+                key={card.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setSelectedAction(card.id)}
+                className={cn(
+                  "rounded-2xl border p-4 text-left transition-all",
+                  isActive ? "border-primary bg-primary/15 shadow-lg shadow-primary/10" : "border-border/70 bg-card/55 hover:-translate-y-0.5 hover:border-primary/50",
+                )}
+              >
+                <span className="flex items-center justify-between gap-3">
+                  <span className="flex items-center gap-2 font-orbitron text-lg">
+                    <VibeContentRenderer content={card.icon} className="text-primary" />
+                    {card.title}
+                  </span>
+                  <span className="rounded-full border border-border/70 bg-background/55 px-3 py-1 text-xs text-muted-foreground">{card.metric}</span>
+                </span>
+                <span className="mt-2 block text-sm text-muted-foreground">{card.text}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="overflow-hidden rounded-3xl border border-border/70 bg-card/55 p-4 backdrop-blur-sm sm:p-6">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={selectedCard.id}
+              initial={{ opacity: 0, y: 14 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.22 }}
+              className="min-h-[320px]"
+            >
+              {selectedCard.id === "status" && (
+                <div className="space-y-5">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.22em] text-primary">latest rental status</p>
+                    <h3 className="mt-2 font-orbitron text-2xl">Готовность к выезду за один взгляд</h3>
+                    <p className="mt-2 text-sm text-muted-foreground">Если активной сделки ещё нет — блок работает как чеклист перед бронированием.</p>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    {rentalStatusSteps.map((step, index) => (
+                      <div key={step.label} className="rounded-2xl border border-border/70 bg-background/45 p-4">
+                        <div className="flex items-center justify-between gap-2">
+                          <VibeContentRenderer content={step.icon} className="text-primary" />
+                          <span className="text-xs text-muted-foreground">0{index + 1}</span>
+                        </div>
+                        <p className="mt-4 font-orbitron text-lg">{step.label}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">{step.value}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <Button asChild className="w-full sm:w-fit">
+                    <Link href="/franchize/vip-bike/rentals">Проверить мои аренды</Link>
+                  </Button>
+                </div>
+              )}
+
+              {selectedCard.id === "riders" && (
+                <div className="grid gap-5 md:grid-cols-[0.9fr_1.1fr]">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.22em] text-primary">live rider counter</p>
+                    <h3 className="mt-2 font-orbitron text-2xl">{activeRiders} райдера онлайн</h3>
+                    <p className="mt-2 text-sm text-muted-foreground">Смотри активность перед стартом и решай: ехать соло или присоединиться к группе.</p>
+                    <Button asChild variant="outline" className="mt-5 w-full sm:w-fit">
+                      <Link href="/franchize/vip-bike/map-riders">Открыть MapRiders</Link>
+                    </Button>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    {[
+                      { label: "онлайн", value: activeRiders },
+                      { label: "meetup", value: meetupCount },
+                      { label: "за неделю", value: `${weeklyDistance} км` },
+                      { label: "формат", value: "group ride" },
+                    ].map((stat) => (
+                      <div key={stat.label} className="rounded-2xl border border-border/70 bg-background/45 p-4">
+                        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{stat.label}</p>
+                        <p className="mt-2 font-orbitron text-xl">{stat.value}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {selectedCard.id === "chooser" && (
+                <div className="space-y-5">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.22em] text-primary">quick bike chooser</p>
+                    <h3 className="mt-2 font-orbitron text-2xl">Мини-подбор без ухода со страницы</h3>
+                    <p className="mt-2 text-sm text-muted-foreground">Выбери цель, посмотри 3 релевантные карточки и открой полную аренду или покупку.</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {quickChooserFilters.map((filter) => (
+                      <button
+                        key={filter.id}
+                        type="button"
+                        onClick={() => setActiveFilter(filter.id)}
+                        className={cn(
+                          "rounded-full border px-3 py-2 text-xs transition",
+                          activeFilter === filter.id ? "border-primary bg-primary text-primary-foreground" : "border-border/70 bg-background/45 hover:border-primary/50",
+                        )}
+                      >
+                        {filter.label} · {filter.hint}
+                      </button>
+                    ))}
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Button type="button" className="flex-1" onClick={() => setIsChooserOpen(true)}>
+                      Открыть мини-подбор
+                    </Button>
+                    <Button asChild variant="outline" className="flex-1">
+                      <Link href="/franchize/vip-bike">Весь каталог</Link>
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {isChooserOpen && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-end justify-center bg-black/70 p-3 backdrop-blur-sm sm:items-center"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="quick-bike-chooser-title"
+            onClick={() => setIsChooserOpen(false)}
+          >
+            <motion.div
+              className="max-h-[92dvh] w-full max-w-5xl overflow-y-auto rounded-3xl border border-white/15 bg-background p-4 shadow-2xl sm:p-6"
+              initial={{ y: 28, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: 20, opacity: 0 }}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <div className="mb-5 flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.22em] text-primary">мини-подбор</p>
+                  <h3 id="quick-bike-chooser-title" className="mt-1 font-orbitron text-2xl">Быстрый выбор VIP Bike</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">Подборка использует реальные карточки каталога, а при пустых данных — безопасные демо-карточки.</p>
+                </div>
+                <button type="button" onClick={() => setIsChooserOpen(false)} className="rounded-full border border-border/70 px-3 py-1 text-sm hover:bg-card" aria-label="Закрыть мини-подбор">
+                  ×
+                </button>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-3">
+                {chooserItems.map((item) => {
+                  const imageUrl = getBikeGallery(item)[0];
+                  const buyHref = item.saleAvailable || isEnabled(item.rawSpecs?.sale) ? `/franchize/vip-bike/market/${item.id}/buy` : `/franchize/vip-bike?vehicle=${item.id}`;
+                  return (
+                    <article key={item.id} className="overflow-hidden rounded-2xl border border-border/70 bg-card/55">
+                      <div className="relative h-44 bg-black/35">
+                        {imageUrl ? <Image src={imageUrl} alt={item.title} fill className="object-cover" /> : null}
+                        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent" />
+                      </div>
+                      <div className="space-y-3 p-4">
+                        <div>
+                          <h4 className="font-orbitron text-lg">{item.title}</h4>
+                          <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{item.subtitle || item.description}</p>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2 text-xs">
+                          <div className="rounded-xl border border-border/60 bg-background/45 p-3">
+                            <p className="text-muted-foreground">Аренда</p>
+                            <p className="mt-1 font-medium">{item.rentPriceLabel || `${item.pricePerDay.toLocaleString("ru-RU")} ₽ / день`}</p>
+                          </div>
+                          <div className="rounded-xl border border-border/60 bg-background/45 p-3">
+                            <p className="text-muted-foreground">Покупка</p>
+                            <p className="mt-1 font-medium">{item.saleAvailable || isEnabled(item.rawSpecs?.sale) ? getSalePriceLabel(item) : "тест-драйв"}</p>
+                          </div>
+                        </div>
+                        <div className="flex flex-col gap-2">
+                          <Button asChild size="sm">
+                            <Link href={`/franchize/vip-bike?vehicle=${item.id}`}>Арендовать</Link>
+                          </Button>
+                          <Button asChild size="sm" variant="outline">
+                            <Link href={buyHref}>Подробнее</Link>
+                          </Button>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </section>
   );
 }
@@ -639,8 +881,8 @@ const fallbackElectroItems: ElectroPreviewItem[] = [
 
 function ElectroEnduroShowcase({ items }: { items: CatalogItemVM[] }) {
   const [selectedItem, setSelectedItem] = useState<ElectroPreviewItem | null>(null);
-  const [selectedColor, setSelectedColor] = useState("Lime");
-  const [selectedPackage, setSelectedPackage] = useState("Стандарт");
+  const [selectedColorId, setSelectedColorId] = useState(DEFAULT_COLOR_OPTIONS[2]?.id ?? DEFAULT_COLOR_OPTIONS[0]?.id ?? "black");
+  const [selectedConfigId, setSelectedConfigId] = useState(DEFAULT_CONFIG_OPTIONS[0]?.id ?? "standard");
 
   const electroItems = useMemo<ElectroPreviewItem[]>(() => {
     const realItems = items
@@ -654,8 +896,23 @@ function ElectroEnduroShowcase({ items }: { items: CatalogItemVM[] }) {
   }, [items]);
 
   const activePreview = selectedItem ?? electroItems[0];
-  const packageDelta = selectedPackage === "Long Range" ? 55000 : selectedPackage === "Comfort" ? 25000 : 0;
-  const configuredPrice = activePreview?.salePrice ? activePreview.salePrice + packageDelta : null;
+  const colorOptions = useMemo(() => resolveBuyColorOptions(activePreview?.rawSpecs), [activePreview?.rawSpecs]);
+  const configOptions = useMemo(() => resolveBuyConfigOptions(activePreview?.rawSpecs), [activePreview?.rawSpecs]);
+  const selectedColor = colorOptions.find((color) => color.id === selectedColorId) ?? colorOptions[0];
+  const selectedConfig = configOptions.find((option) => option.id === selectedConfigId) ?? configOptions[0];
+  const configuredPrice = activePreview?.salePrice ? activePreview.salePrice + (selectedConfig?.priceDelta ?? 0) : null;
+
+  useEffect(() => {
+    if (!colorOptions.some((color) => color.id === selectedColorId)) {
+      setSelectedColorId(colorOptions[0]?.id ?? DEFAULT_COLOR_OPTIONS[0]?.id ?? "black");
+    }
+  }, [colorOptions, selectedColorId]);
+
+  useEffect(() => {
+    if (!configOptions.some((option) => option.id === selectedConfigId)) {
+      setSelectedConfigId(configOptions[0]?.id ?? DEFAULT_CONFIG_OPTIONS[0]?.id ?? "standard");
+    }
+  }, [configOptions, selectedConfigId]);
 
   return (
     <section>
@@ -753,7 +1010,7 @@ function ElectroEnduroShowcase({ items }: { items: CatalogItemVM[] }) {
                     <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,170,80,0.28),transparent_58%)]" />
                   )}
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent" />
-                  <div className="absolute bottom-4 left-4 rounded-full bg-brand-yellow px-3 py-1 font-orbitron text-xs text-black">{selectedColor}</div>
+                  <div className="absolute bottom-4 left-4 rounded-full bg-brand-yellow px-3 py-1 font-orbitron text-xs text-black">{selectedColor?.label ?? "Цвет"}</div>
                 </div>
 
                 <div className="space-y-5">
@@ -776,17 +1033,18 @@ function ElectroEnduroShowcase({ items }: { items: CatalogItemVM[] }) {
                   <div>
                     <p className="mb-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">Цвет</p>
                     <div className="flex flex-wrap gap-2">
-                      {["Black", "Graphite", "Lime", "White"].map((color) => (
+                      {colorOptions.map((color) => (
                         <button
-                          key={color}
+                          key={color.id}
                           type="button"
-                          onClick={() => setSelectedColor(color)}
+                          onClick={() => setSelectedColorId(color.id)}
                           className={cn(
-                            "rounded-full border px-3 py-1.5 text-xs transition",
-                            selectedColor === color ? "border-primary bg-primary text-primary-foreground" : "border-border/70 hover:bg-card",
+                            "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs transition",
+                            selectedColor?.id === color.id ? "border-primary bg-primary text-primary-foreground" : "border-border/70 hover:bg-card",
                           )}
                         >
-                          {color}
+                          <span className="h-3 w-3 rounded-full border border-white/30" style={{ backgroundColor: color.hex }} />
+                          {color.label}
                         </button>
                       ))}
                     </div>
@@ -795,18 +1053,18 @@ function ElectroEnduroShowcase({ items }: { items: CatalogItemVM[] }) {
                   <div>
                     <p className="mb-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">Пакет</p>
                     <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-                      {["Стандарт", "Comfort", "Long Range"].map((pack) => (
+                      {configOptions.map((option) => (
                         <button
-                          key={pack}
+                          key={option.id}
                           type="button"
-                          onClick={() => setSelectedPackage(pack)}
+                          onClick={() => setSelectedConfigId(option.id)}
                           className={cn(
                             "rounded-xl border p-3 text-left text-xs transition",
-                            selectedPackage === pack ? "border-primary bg-primary/15" : "border-border/70 hover:bg-card",
+                            selectedConfig?.id === option.id ? "border-primary bg-primary/15" : "border-border/70 hover:bg-card",
                           )}
                         >
-                          <span className="block font-orbitron text-sm">{pack}</span>
-                          <span className="mt-1 block text-muted-foreground">{pack === "Long Range" ? "+55 000 ₽" : pack === "Comfort" ? "+25 000 ₽" : "база"}</span>
+                          <span className="block font-orbitron text-sm">{option.label}</span>
+                          <span className="mt-1 block text-muted-foreground">{option.priceDelta > 0 ? `+${option.priceDelta.toLocaleString("ru-RU")} ₽` : option.subtitle || "база"}</span>
                         </button>
                       ))}
                     </div>
@@ -827,7 +1085,7 @@ function ElectroEnduroShowcase({ items }: { items: CatalogItemVM[] }) {
 
                   <div className="rounded-2xl border border-primary/30 bg-primary/10 p-4">
                     <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Ваша конфигурация</p>
-                    <p className="mt-1 font-orbitron text-lg">{activePreview.title} · {selectedColor} · {selectedPackage}</p>
+                    <p className="mt-1 font-orbitron text-lg">{activePreview.title} · {selectedColor?.label ?? "Цвет"} · {selectedConfig?.label ?? "Пакет"}</p>
                     <p className="mt-1 text-sm text-muted-foreground">
                       {configuredPrice ? `${configuredPrice.toLocaleString("ru-RU")} ₽ ориентир покупки` : `${activePreview.rentPriceLabel} для тест-драйва`}
                     </p>
@@ -1164,36 +1422,7 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
 
         <StepsProgress items={items} />
 
-        <section>
-          <div className="mb-8 text-center">
-            <h2 className="font-orbitron text-3xl sm:text-4xl">Уже внедрённый rental-флоу — в один клик</h2>
-            <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">
-              На платформе уже реализованы ключевые инструменты аренды. Ниже — прямые входы в рабочие сценарии, чтобы
-              пользователь сразу попадал в полезные действия.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-            {quickActions.map((card) => (
-              <Card
-                key={card.title}
-                className="border-border/70 bg-card/60 backdrop-blur-sm transition-all hover:-translate-y-1 hover:border-primary/60 hover:shadow-lg hover:shadow-primary/20"
-              >
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-xl">
-                    <VibeContentRenderer content={card.icon} className="text-primary" />
-                    {card.title}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="mb-5 text-sm text-muted-foreground">{card.text}</p>
-                  <Button asChild variant="outline" className="w-full">
-                    <Link href={card.href}>{card.cta}</Link>
-                  </Button>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </section>
+        <RentalQuickActionHub items={items} overview={mapOverview} />
 
         <motion.section
           initial={{ opacity: 0, y: 50 }}

--- a/app/vipbikerental/todo.md
+++ b/app/vipbikerental/todo.md
@@ -16,16 +16,24 @@
 - [x] MapRiders preview: lightweight static mini-map, live rider dots, meetup labels, weekly stats, latest ride summary, SVG speed sparkline, click-through to full MapRiders.
 - [x] Interactive newbie stepper: `StepsProgress` replaces static newbie cards with tabs, animated content, bike preview carousel and mini-cart visualization.
 - [x] Documentation sync: this TODO and `docs/THE_FRANCHEEZEPLAN.md` now reflect completed slices and explicitly separated future backlog.
+- [x] Quick action hub follow-up: static rental-flow link cards were replaced with a tabbed in-place action panel, live MapRiders counters, rental readiness checklist, and a quick bike chooser modal using real catalog data/fallbacks.
 
 ### Future backlog — not an active trigger unless operator explicitly asks
-- [ ] Quick action cards with in-place micro-actions: latest rental status, live rider counter, quick bike chooser modal.
-- [ ] Technical cleanup backlog: duplicated sale configurator constants, protected OSRM/fallback routing layer, lighter route/POI loading strategy.
+- [x] Technical cleanup slice: duplicated sale configurator constants were centralized into `app/franchize/lib/sale-config.ts` and reused by sale landing + `/vipbikerental` quick preview.
+- [ ] Remaining technical cleanup backlog: protected OSRM/fallback routing layer, lighter route/POI loading strategy.
 - [ ] Deeper production QA with real Supabase data available in runtime; local runner currently falls back safely when Supabase fetch fails.
 
 ### Final code-review notes
 - No important visible section was intentionally removed during the server/client split; the main content sequence is preserved.
 - The MapRiders landing preview deliberately avoids loading Leaflet or heavy GeoJSON on first paint; it uses overview data first and safe fallbacks second.
 - Current interactive landing scope is complete and PR-ready; future backlog above should not auto-trigger new work unless explicitly requested.
+
+### Follow-up implementation note — 2026-05-06
+- Quick action backlog item completed: the old static rental-flow cards were replaced by `RentalQuickActionHub` with in-section tabs for latest rental status, live rider counter and quick bike chooser.
+- The chooser modal uses hydrated `vip-bike` catalog items first and existing safe Electro-Enduro fallbacks second, preserving local runtime resilience when Supabase data is unavailable.
+
+### Technical cleanup note — 2026-05-06
+- Sale config options/colors are now shared through `app/franchize/lib/sale-config.ts`, so `/franchize/[slug]/market/[bike_id]/buy` and `/vipbikerental` use the same default packages, DB `buy_options`, and DB `buy_colors` parsing.
 
 ## 📐 0. Принцип: «кликай, не покидая секцию»
 

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -54,9 +54,9 @@ This root file stays intentionally compact so operators and agents can load it q
 - status: `ready_for_pr`
 - updated_at: `2026-05-06T00:00:00Z`
 - owner: `codex`
-- notes: `Final polish complete: Hero, Electro-Enduro, MapRiders preview, StepsProgress newbie flow, original downstream content blocks, docs, and safe fallbacks are preserved/synced.`
-- next_step: `Create PR. Remaining TODO entries are future backlog and should not auto-trigger unless operator explicitly asks.`
-- risks: `Local runtime can render fallback data when Supabase is unavailable; production QA should verify real vip-bike catalog/map records.`
+- notes: `Quick action follow-up plus sale-config cleanup complete: Hero, Electro-Enduro, MapRiders preview, StepsProgress, RentalQuickActionHub, and shared sale config parsing are synced with safe catalog/map fallbacks.`
+- next_step: `Create PR. Remaining TODO entries are OSRM/route loading cleanup and production QA with real data.`
+- risks: `Local runtime can render fallback data when Supabase is unavailable; production QA should verify real vip-bike catalog/map records and active rental states.`
 
 ## 4) Mini execution diary addendum
 
@@ -65,6 +65,8 @@ This root file stays intentionally compact so operators and agents can load it q
 - 2026-05-06 — Self-reviewed `/vipbikerental` refactor by comparing old/new section headings, then shipped lightweight MapRiders preview: static glowing route map, live rider dots, meetup labels, latest ride stats and SVG speed sparkline. Next step: interactive newbie stepper.
 - 2026-05-06 — Finalized `/vipbikerental` PR readiness review: updated TODO with finished/not-finished checklist, confirmed no important visible sections were intentionally removed, and moved active status to `ready_for_pr`. Next PR should begin with the interactive newbie stepper.
 - 2026-05-06 — Final polish iteration: implemented `StepsProgress` for the newbie flow and reworded `/app/vipbikerental/todo.md` so completed scope is clearly closed while remaining quick-action/technical items are future backlog, not an automatic trigger.
+- 2026-05-06 — Continued explicit `/vipbikerental` TODO work: replaced static quick-action link cards with `RentalQuickActionHub`, including latest rental readiness, live rider counters and a quick bike chooser modal hydrated from catalog/fallback items. Next step: technical cleanup backlog or production QA with real Supabase rental/map data.
+- 2026-05-06 — Continued cleanup after quick actions: extracted shared sale config/color parsing into `app/franchize/lib/sale-config.ts` and reused it in both the sale buy page and `/vipbikerental` Electro-Enduro quick preview, removing duplicated package/color constants. Next step: OSRM/route loading cleanup or production QA.
 ## 3) Active implementation slices
 
 ### 2026-05-06 — Sale buy page VS + test-drive reservation


### PR DESCRIPTION
### Motivation
- Remove duplicated sale configurator constants and parsing logic so sale color/package options are shared between the sale landing and the VIP rental mini-config.
- Replace static quick-action link cards on the `/vipbikerental` landing with an in-place interactive hub that provides rental readiness, live rider counters and a quick bike chooser modal.

### Description
- Add `app/franchize/lib/sale-config.ts` with exported types `ConfigOption`/`ColorOption`, default arrays `DEFAULT_CONFIG_OPTIONS`/`DEFAULT_COLOR_OPTIONS`, and resolver helpers `resolveBuyConfigOptions` and `resolveBuyColorOptions` to parse DB-driven `buy_options`/`buy_colors`.
- Update `app/franchize/components/SaleBikeLandingClient.tsx` to import the shared defaults and resolver functions and to use memoized `specs` and resolved options instead of local duplicated constants.
- Update `app/vipbikerental/VipBikeRentalClient.tsx` to reuse the shared sale-config helpers and defaults, implement `RentalQuickActionHub` with tabs for rental status, live rider counters and a quick-bike chooser modal, and wire the Electro‑Enduro quick preview to use resolved color/config options with controlled selection and safe fallbacks.
- Update docs and TODOs (`app/vipbikerental/todo.md`, `docs/THE_FRANCHEEZEPLAN.md`) to reflect the quick-action hub implementation and the sale-config cleanup.

### Testing
- Ran TypeScript type-check to validate types and imports and the check completed successfully.
- Performed a local Next.js build / dev run to ensure the client components render and the new module imports resolve without runtime errors, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbbf2316f88324b64a67a91d983fe6)