### PR TITLE
franchize: normalize category IDs, harden start-param router, and add Vitest coverage for helpers

### DIFF
--- a/app/franchize/__tests__/todo.md
+++ b/app/franchize/__tests__/todo.md
@@ -1,0 +1,15 @@
+# Franchize test coverage foundation
+
+Status: `ready_for_pr`
+Task: `RENT-P3.2: Test coverage foundation for key server actions`
+
+## Implemented in this slice
+
+- Added Vitest coverage for `app/franchize/lib/navigation.ts` helper behavior, including trimmed category anchors.
+- Added Vitest coverage for `app/franchize/lib/theme.ts` palette-to-style helpers and variant cycling.
+
+## Next slices
+
+- Add mocked Supabase tests for server action input validation.
+- Add promo-code validation tests after `RENT-P1.2` replaces the UI stub with real logic.
+- Add CI enforcement once coverage thresholds are stable across the existing suite.

--- a/app/franchize/lib/navigation.ts
+++ b/app/franchize/lib/navigation.ts
@@ -1,3 +1,3 @@
-export const toCategoryId = (category: string) => `category-${category.toLowerCase().replace(/\s+/g, "-")}`;
+export const toCategoryId = (category: string) => `category-${category.trim().toLowerCase().replace(/\s+/g, "-")}`;
 
 export const isExternalHref = (href: string) => /^https?:\/\//.test(href);

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -58,6 +58,16 @@ This root file stays intentionally compact so operators and agents can load it q
 - next_step: `Create PR. Remaining TODO entries are future backlog and should not auto-trigger unless operator explicitly asks.`
 - risks: `Local runtime can render fallback data when Supabase is unavailable; production QA should verify real vip-bike catalog/map records.`
 
+
+### 2026-05-06 — SupaPlan franchize maintenance pair
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-06T22:30:00Z
+- `owner`: codex-frz-couple-01
+- `notes`: Implemented `FIX-STARTPARAM` stale-ref reset for repeated Telegram deep links and started `RENT-P3.2` with Vitest coverage for franchize navigation/theme helpers; self-review tightened duplicate-processing/stale-result guards and category anchor normalization.
+- `next_step`: Add mocked Supabase coverage for server action validators after this PR lands.
+- `risks`: Server-action integration tests remain future work because this slice intentionally focused on low-conflict pure helper coverage.
+
 ## 4) Mini execution diary addendum
 
 - 2026-05-06 — Started `/vipbikerental` interactive enhancement stream from `app/vipbikerental/todo.md`; shipped the first Hero tabs slice with animated mode preview and MapRiders overview metrics. Next step: replace fallback rent/buy preview cards with real catalog item data.
@@ -84,3 +94,6 @@ This root file stays intentionally compact so operators and agents can load it q
 - `notes`: Aligned sale reservation CTA copy with the same 100-500 XTR formula used by backend invoices, centralized VS spec aliases, and split reservation/cart CTA state so secondary cart actions do not display invoice success.
 - `next_step`: Verify production `vip-bike` sale bike with real catalog specs and Telegram WebApp invoice delivery.
 - `risks`: Visual/live invoice verification still depends on reachable Supabase and Telegram bot credentials.
+- 2026-05-06 — SupaPlan franchize maintenance pair: fixed repeated `startapp` handling in `useStartParamRouter` and added a test-coverage foundation for franchize helper libraries. Next step: mocked Supabase action validation tests.
+- 2026-05-06 — Self-reviewed SupaPlan franchize maintenance pair: replaced the boolean start-param guard with active/last-handled param refs to prevent duplicate processing during pathname/clear races, removed dead sale metadata, and normalized category anchors before tests codify the behavior.
+- 2026-05-06 — Final code review polish for SupaPlan franchize maintenance: added a run-id freshness guard so slow async start-param resolutions cannot navigate after a newer deep link wins.

--- a/hooks/useStartParamRouter.ts
+++ b/hooks/useStartParamRouter.ts
@@ -61,8 +61,19 @@ export function useStartParamRouter() {
   } = useAppContext();
   const { success: showToast } = useAppToast();
 
-  const handledRef = useRef(false);
+  const activeStartParamRef = useRef<string | null>(null);
+  const lastHandledStartParamRef = useRef<string | null>(null);
+  const startParamRunIdRef = useRef(0);
+  const mountedRef = useRef(false);
   const consumedTempCartRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const handleBio30Referral = useCallback(
     async (referrerId: string, referrerCode: string) => {
@@ -118,7 +129,6 @@ export function useStartParamRouter() {
         const slug = (data.slug || "vip-bike").trim() || "vip-bike";
         const resolvedVehicle = (data.vehicleId || vehicleId).trim().toLowerCase();
         const resolvedFlow = data.flow === "buy" ? "buy" : "rent";
-        const saleAvailable = Boolean((data as { saleAvailable?: boolean }).saleAvailable);
         if (resolvedFlow === "buy") {
           return `/franchize/${slug}/market/${encodeURIComponent(resolvedVehicle)}/buy`;
         }
@@ -139,100 +149,137 @@ export function useStartParamRouter() {
       const rawStartParam = startParamPayload || searchParams.get("tgWebAppStartParam");
       const paramToProcess = normalizeStartParamPath(rawStartParam);
 
-      if (isAppLoading || isAuthenticating || !paramToProcess || handledRef.current) {
+      if (!paramToProcess) {
+        activeStartParamRef.current = null;
+        lastHandledStartParamRef.current = null;
         return;
       }
 
-      handledRef.current = true;
+      if (isAppLoading || isAuthenticating) {
+        return;
+      }
+
+      if (
+        activeStartParamRef.current === paramToProcess ||
+        lastHandledStartParamRef.current === paramToProcess
+      ) {
+        return;
+      }
+
+      activeStartParamRef.current = paramToProcess;
+      const runId = startParamRunIdRef.current + 1;
+      startParamRunIdRef.current = runId;
+      const isLatestRun = () => (
+        mountedRef.current &&
+        startParamRunIdRef.current === runId &&
+        activeStartParamRef.current === paramToProcess
+      );
       let targetPath: string | undefined;
 
-      logger.info(`[ClientLayout] Processing Start Param: ${paramToProcess}`);
+      try {
+        logger.info(`[ClientLayout] Processing Start Param: ${paramToProcess}`);
 
-      if (paramToProcess === "wb_dashboard") {
-        targetPath = userCrewInfo?.slug ? `/wb/${userCrewInfo.slug}` : "/wblanding";
-      } else if (paramToProcess.startsWith("cart_id_")) {
-        const mockEnabled = isMockUserModeEnabled();
-        const cartId = paramToProcess.slice("cart_id_".length).trim();
-        if (!mockEnabled && dbUser?.user_id && cartId && consumedTempCartRef.current !== cartId) {
-          consumedTempCartRef.current = cartId;
-          const consumed = await consumeTempFranchizeCartAction({ cartId, userId: dbUser.user_id });
-          if (consumed.ok && consumed.cartBySlug && typeof window !== "undefined") {
-            for (const [slug, cartState] of Object.entries(consumed.cartBySlug)) {
-              window.localStorage.setItem(`franchize-cart:${slug}`, JSON.stringify({ updatedAt: Date.now(), cart: cartState }));
+        if (paramToProcess === "wb_dashboard") {
+          targetPath = userCrewInfo?.slug ? `/wb/${userCrewInfo.slug}` : "/wblanding";
+        } else if (paramToProcess.startsWith("cart_id_")) {
+          const mockEnabled = isMockUserModeEnabled();
+          const cartId = paramToProcess.slice("cart_id_".length).trim();
+          if (!mockEnabled && dbUser?.user_id && cartId && consumedTempCartRef.current !== cartId) {
+            consumedTempCartRef.current = cartId;
+            const consumed = await consumeTempFranchizeCartAction({ cartId, userId: dbUser.user_id });
+            if (consumed.ok && consumed.cartBySlug && typeof window !== "undefined") {
+              for (const [slug, cartState] of Object.entries(consumed.cartBySlug)) {
+                window.localStorage.setItem(`franchize-cart:${slug}`, JSON.stringify({ updatedAt: Date.now(), cart: cartState }));
+              }
+              window.dispatchEvent(new CustomEvent("franchize-cart-sync", { detail: { storageKey: "*" } }));
             }
-            window.dispatchEvent(new CustomEvent("franchize-cart-sync", { detail: { storageKey: "*" } }));
           }
-        }
-        targetPath = pathname;
-      } else if (paramToProcess.startsWith("buy_")) {
-        targetPath = await resolveFranchizeVehicleLink(paramToProcess, "buy") ?? undefined;
-      } else if (paramToProcess.startsWith("rent_")) {
-        targetPath = await resolveFranchizeVehicleLink(paramToProcess, "rent") ?? undefined;
-      } else if (START_PARAM_PAGE_MAP[paramToProcess]) {
-        targetPath = START_PARAM_PAGE_MAP[paramToProcess];
-      } else if (paramToProcess.startsWith("crew_")) {
-      const content = paramToProcess.substring(5);
-      if (content.endsWith("_join_crew")) {
-        const slug = content.substring(0, content.length - 10);
-        targetPath = `/wb/${slug}?join_crew=true`;
-      } else {
-        targetPath = `/wb/${content}`;
-      }
-    } else if (paramToProcess.startsWith("viz_")) {
-      const simId = paramToProcess.substring(4);
-      targetPath = `/god-mode-sandbox?simId=${simId}`;
-    } else if (paramToProcess.startsWith("bio30_")) {
-      const parts = paramToProcess.split("_");
-      const productId = parts.length > 1 && parts[1] !== "ref" ? parts[1] : undefined;
-      const refIndex = parts.indexOf("ref");
-      const referrerId = refIndex !== -1 && refIndex + 1 < parts.length ? parts[refIndex + 1] : undefined;
+          targetPath = pathname;
+        } else if (paramToProcess.startsWith("buy_")) {
+          targetPath = await resolveFranchizeVehicleLink(paramToProcess, "buy") ?? undefined;
+        } else if (paramToProcess.startsWith("rent_")) {
+          targetPath = await resolveFranchizeVehicleLink(paramToProcess, "rent") ?? undefined;
+        } else if (START_PARAM_PAGE_MAP[paramToProcess]) {
+          targetPath = START_PARAM_PAGE_MAP[paramToProcess];
+        } else if (paramToProcess.startsWith("crew_")) {
+          const content = paramToProcess.substring(5);
+          if (content.endsWith("_join_crew")) {
+            const slug = content.substring(0, content.length - 10);
+            targetPath = `/wb/${slug}?join_crew=true`;
+          } else {
+            targetPath = `/wb/${content}`;
+          }
+        } else if (paramToProcess.startsWith("viz_")) {
+          const simId = paramToProcess.substring(4);
+          targetPath = `/god-mode-sandbox?simId=${simId}`;
+        } else if (paramToProcess.startsWith("bio30_")) {
+          const parts = paramToProcess.split("_");
+          const productId = parts.length > 1 && parts[1] !== "ref" ? parts[1] : undefined;
+          const refIndex = parts.indexOf("ref");
+          const referrerId = refIndex !== -1 && refIndex + 1 < parts.length ? parts[refIndex + 1] : undefined;
 
-      if (referrerId) {
-        void handleBio30Referral(referrerId, paramToProcess);
-      }
-      targetPath = productId && BIO30_PRODUCT_PATHS[productId] ? BIO30_PRODUCT_PATHS[productId] : "/bio30";
-    } else if (paramToProcess.startsWith("lobby_")) {
-      const lobbyId = paramToProcess.substring(6);
-      if (lobbyId) {
-        targetPath = `/strikeball/lobbies/${lobbyId}`;
-      }
-    } else if (paramToProcess.startsWith("rental-") || paramToProcess.startsWith("rentals-") || paramToProcess.startsWith("sale-")) {
-      const rentalId = paramToProcess.split("-").at(-1);
-      const franchizeSlug = searchParams.get("slug") || "vip-bike";
-      if (rentalId) {
-        targetPath = `/franchize/${franchizeSlug}/rental/${rentalId}`;
-      }
-    } else if (paramToProcess.startsWith("mapriders_") || paramToProcess.startsWith("mapriders-")) {
-      const separator = paramToProcess.includes("_") ? "_" : "-";
-      const slug = paramToProcess.split(separator).slice(1).join(separator) || searchParams.get("slug") || userCrewInfo?.slug || "vip-bike";
-      targetPath = `/franchize/${slug}/map-riders`;
-    } else if (paramToProcess.startsWith("rental_") || paramToProcess.startsWith("rentals_")) {
-      const parts = paramToProcess.split("_");
-      const rentalId = parts.at(-1);
-      const maybeSlug = parts.length > 2 ? parts[1] : searchParams.get("slug") || "vip-bike";
-      if (rentalId) {
-        if (parts.length > 2 || searchParams.get("slug")) {
-          targetPath = `/franchize/${maybeSlug}/rental/${rentalId}`;
+          if (referrerId) {
+            void handleBio30Referral(referrerId, paramToProcess);
+          }
+          targetPath = productId && BIO30_PRODUCT_PATHS[productId] ? BIO30_PRODUCT_PATHS[productId] : "/bio30";
+        } else if (paramToProcess.startsWith("lobby_")) {
+          const lobbyId = paramToProcess.substring(6);
+          if (lobbyId) {
+            targetPath = `/strikeball/lobbies/${lobbyId}`;
+          }
+        } else if (paramToProcess.startsWith("rental-") || paramToProcess.startsWith("rentals-") || paramToProcess.startsWith("sale-")) {
+          const rentalId = paramToProcess.split("-").at(-1);
+          const franchizeSlug = searchParams.get("slug") || "vip-bike";
+          if (rentalId) {
+            targetPath = `/franchize/${franchizeSlug}/rental/${rentalId}`;
+          }
+        } else if (paramToProcess.startsWith("mapriders_") || paramToProcess.startsWith("mapriders-")) {
+          const separator = paramToProcess.includes("_") ? "_" : "-";
+          const slug = paramToProcess.split(separator).slice(1).join(separator) || searchParams.get("slug") || userCrewInfo?.slug || "vip-bike";
+          targetPath = `/franchize/${slug}/map-riders`;
+        } else if (paramToProcess.startsWith("rental_") || paramToProcess.startsWith("rentals_")) {
+          const parts = paramToProcess.split("_");
+          const rentalId = parts.at(-1);
+          const maybeSlug = parts.length > 2 ? parts[1] : searchParams.get("slug") || "vip-bike";
+          if (rentalId) {
+            if (parts.length > 2 || searchParams.get("slug")) {
+              targetPath = `/franchize/${maybeSlug}/rental/${rentalId}`;
+            } else {
+              targetPath = `/rentals/${rentalId}`;
+            }
+          }
+        } else if (paramToProcess.startsWith("ref_")) {
+          const refCode = paramToProcess.substring(4);
+          void handleSyndicateReferral(refCode);
+          targetPath = pathname === "/" ? "/wblanding" : pathname;
+        } else if (paramToProcess.includes("/")) {
+          targetPath = `/${paramToProcess}`;
         } else {
-          targetPath = `/rentals/${rentalId}`;
+          targetPath = `/${paramToProcess}`;
+        }
+
+        if (!isLatestRun()) {
+          logger.info(`[ClientLayout] Skipping stale Start Param result: ${paramToProcess}`);
+          return;
+        }
+
+        lastHandledStartParamRef.current = paramToProcess;
+
+        if (targetPath && targetPath !== pathname) {
+          logger.info(`[ClientLayout] Redirecting to ${targetPath}`);
+          router.replace(targetPath);
+        }
+
+        if (!isLatestRun()) {
+          return;
+        }
+
+        clearStartParam?.();
+      } finally {
+        if (activeStartParamRef.current === paramToProcess) {
+          activeStartParamRef.current = null;
         }
       }
-      } else if (paramToProcess.startsWith("ref_")) {
-      const refCode = paramToProcess.substring(4);
-      void handleSyndicateReferral(refCode);
-      targetPath = pathname === "/" ? "/wblanding" : pathname;
-      } else if (paramToProcess.includes("/")) {
-      targetPath = `/${paramToProcess}`;
-      } else {
-      targetPath = `/${paramToProcess}`;
-      }
-
-      if (targetPath && targetPath !== pathname) {
-        logger.info(`[ClientLayout] Redirecting to ${targetPath}`);
-        router.replace(targetPath);
-      }
-
-      clearStartParam?.();
     };
 
     void processStartParam();

--- a/tests/franchize/lib.spec.ts
+++ b/tests/franchize/lib.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { catalogCardVariantStyles, crewPaletteForSurface, floatingCartOverlayBackground } from '@/app/franchize/lib/theme';
+import { isExternalHref, toCategoryId } from '@/app/franchize/lib/navigation';
+import type { FranchizeTheme } from '@/app/franchize/actions';
+
+const theme: FranchizeTheme = {
+  mode: 'dark',
+  radius: 'xl',
+  palette: {
+    bgBase: '#101113',
+    bgCard: '#20242a',
+    textPrimary: '#f8fafc',
+    textSecondary: '#a1a1aa',
+    borderSoft: '#3f3f46',
+    accentMain: '#f97316',
+    accentSecondary: '#fed7aa',
+  },
+};
+
+describe('franchize navigation helpers', () => {
+  it('normalizes catalog category names into stable DOM ids', () => {
+    expect(toCategoryId('Big Adventure Bikes')).toBe('category-big-adventure-bikes');
+    expect(toCategoryId('  City   Rental  ')).toBe('category-city-rental');
+  });
+
+  it('detects only HTTP(S) links as external navigation targets', () => {
+    expect(isExternalHref('https://example.com')).toBe(true);
+    expect(isExternalHref('http://example.com')).toBe(true);
+    expect(isExternalHref('/franchize/vip-bike')).toBe(false);
+    expect(isExternalHref('tg://resolve?domain=oneBikePlsBot')).toBe(false);
+  });
+});
+
+describe('franchize theme helpers', () => {
+  it('maps crew palette tokens to surface style objects', () => {
+    expect(crewPaletteForSurface(theme)).toMatchObject({
+      page: {
+        backgroundColor: '#101113',
+        color: '#f8fafc',
+      },
+      accentPill: {
+        borderColor: '#f97316',
+        color: '#f97316',
+        backgroundColor: 'rgba(249, 115, 22, 0.12)',
+      },
+    });
+  });
+
+  it('cycles catalog card variants predictably', () => {
+    expect(catalogCardVariantStyles(theme, 0)).toMatchObject({
+      borderColor: 'rgba(63, 63, 70, 0.3)',
+      backgroundColor: '#20242a',
+    });
+    expect(catalogCardVariantStyles(theme, 3)).toEqual(catalogCardVariantStyles(theme, 0));
+    expect(catalogCardVariantStyles(theme, -1)).toEqual(catalogCardVariantStyles(theme, 1));
+  });
+
+  it('uses stronger cart overlay opacity in dark mode', () => {
+    expect(floatingCartOverlayBackground(theme)).toBe('rgba(32, 36, 42, 0.94)');
+    expect(floatingCartOverlayBackground({ ...theme, mode: 'light' })).toBe('rgba(32, 36, 42, 0.9)');
+  });
+});


### PR DESCRIPTION
### Motivation

- Normalize category anchor generation to avoid unstable DOM ids produced by leading/trailing whitespace. 
- Prevent duplicate or stale deep-link processing in the start-param router when multiple Telegram deep links or async resolutions race. 
- Add a small, low-conflict test foundation for franchize helper libraries to codify expected navigation and theme behaviors. 

### Description

- Trimmed category input in `toCategoryId` by changing it to `category.trim().toLowerCase().replace(/\s+/g, "-")` in `app/franchize/lib/navigation.ts`. 
- Reworked `useStartParamRouter` in `hooks/useStartParamRouter.ts` to replace a single boolean guard with `activeStartParamRef`, `lastHandledStartParamRef`, `startParamRunIdRef`, and `mountedRef`, added a run-id freshness guard and cleanup to prevent stale navigation and duplicate processing. 
- Ensured consumed temp cart handling writes `franchize-cart:{slug}` to `localStorage` and dispatches a `CustomEvent` for sync only when appropriate. 
- Added Vitest unit tests in `tests/franchize/lib.spec.ts` covering `toCategoryId`, `isExternalHref`, and theme helpers `crewPaletteForSurface`, `catalogCardVariantStyles`, and `floatingCartOverlayBackground`. 
- Added test TODO and planning notes in `app/franchize/__tests__/todo.md` and updated `docs/THE_FRANCHEEZEPLAN.md` with maintenance diary entries. 

### Testing

- Ran the new Vitest suite targeting the franchize helper tests using `vitest` and the tests in `tests/franchize/lib.spec.ts` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbbfc95d28832485603f99c2f8c9f0)
supaplan_task: d5e1b1b4-5234-4e5a-f012-55550005ef12, 1d97a634-66c9-4ea1-9c8f-b0e39aea2bf6