### PR TITLE
fix: close franchize a11y and invoice gaps supaplan_task:a58aea2f-b6ff-43f1-ad0e-a946ac359d9a supaplan_task:d1a6f7d0-1234-4a1e-bcde-11110001abcd

### DIFF
--- a/app/franchize/actions.ts
+++ b/app/franchize/actions.ts
@@ -1816,6 +1816,30 @@ function buildFranchizeInvoiceId(payload: FranchizeOrderInvoicePayload) {
   return `franchize_order_${safeSlug}_${safeOrderId}_${safeUserId}`;
 }
 
+async function cleanupPendingFranchizeInvoiceAfterSendFailure(invoiceId: string, rentalId: string) {
+  const { error } = await supabaseAdmin
+    .from("invoices")
+    .delete()
+    .eq("id", invoiceId)
+    .eq("status", "pending")
+    .contains("metadata", { rental_id: rentalId });
+
+  if (error) {
+    logger.error("[franchize] failed to cleanup unsent invoice", {
+      invoiceId,
+      rentalId,
+      error: error.message,
+    });
+    return false;
+  }
+
+  logger.warn("[franchize] cleaned up unsent pending invoice after Telegram XTR send failure", {
+    invoiceId,
+    rentalId,
+  });
+  return true;
+}
+
 async function createFranchizeOrderInvoiceInternal(
   payload: FranchizeOrderInvoicePayload,
   options: { skipNotification?: boolean } = {},
@@ -1907,6 +1931,8 @@ async function createFranchizeOrderInvoiceInternal(
     flowType,
   };
 
+  let createdPendingInvoiceForThisAttempt = false;
+
   try {
     if (!options.skipNotification) {
       await buildFranchizeOrderDocAndNotify({ ...payload, totalAmount: effectiveTotal, subtotal: payload.subtotal, extrasTotal: payload.extrasTotal });
@@ -1916,6 +1942,7 @@ async function createFranchizeOrderInvoiceInternal(
     if (!invoiceRecord.success) {
       return { success: false, error: invoiceRecord.error ?? "Не удалось создать запись счёта." };
     }
+    createdPendingInvoiceForThisAttempt = invoiceRecord.data?.status === "pending";
 
     const invoiceSent = await sendTelegramInvoice(
       payload.telegramUserId,
@@ -1927,11 +1954,17 @@ async function createFranchizeOrderInvoiceInternal(
     );
 
     if (!invoiceSent.success) {
+      if (createdPendingInvoiceForThisAttempt) {
+        await cleanupPendingFranchizeInvoiceAfterSendFailure(invoiceId, rentalId);
+      }
       return { success: false, error: invoiceSent.error ?? "Не удалось отправить XTR-счёт в Telegram." };
     }
 
     return { success: true, invoiceId, amountXtr };
   } catch (error) {
+    if (createdPendingInvoiceForThisAttempt) {
+      await cleanupPendingFranchizeInvoiceAfterSendFailure(invoiceId, rentalId);
+    }
     logger.error("[franchize] createFranchizeOrderInvoice failed", error);
     return {
       success: false,

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -254,11 +254,16 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
           </p>
         )}
 
-        <div id="catalog-search" className="relative mb-5">
+        <div id="catalog-search" className="relative mb-5" role="search" aria-label="Поиск по каталогу байков">
+          <label htmlFor="catalog-search-input" className="sr-only">
+            Поиск по каталогу байков
+          </label>
           <input
             id="catalog-search-input"
             type="text"
             placeholder="Введите название байка"
+            autoComplete="off"
+            aria-describedby="catalog-results-status"
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
             className="w-full rounded-full border py-3 pl-5 pr-36 text-sm outline-none transition focus:border-transparent focus:ring-2"
@@ -275,6 +280,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
           {searchQuery.trim().length > 0 && (
             <button
               type="button"
+              aria-label="Очистить поиск по каталогу"
               onClick={() => setSearchQuery("")}
               className="absolute bottom-2 right-24 top-2 rounded-full px-3 text-xs font-medium transition active:scale-95"
               onFocus={() => setClearFocused(true)}
@@ -291,6 +297,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
           )}
           <button
             type="button"
+            aria-label="Перейти к первому найденному байку"
             onClick={() => {
               const firstResult = document.querySelector("[data-catalog-item='true']") as HTMLElement | null;
               firstResult?.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -317,7 +324,8 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
                   key={module.id}
                   title={module.title}
                   href={module.href}
-                  className="w-[85vw] shrink-0 rounded-2xl border p-3 transition hover:opacity-95 sm:w-auto"
+                  aria-label={`${module.ctaLabel}: ${module.title}`}
+                  className="w-[85vw] shrink-0 rounded-2xl border p-3 transition hover:opacity-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--catalog-accent)] sm:w-auto"
                   style={{
                     borderColor: crew.theme.palette.borderSoft,
                     background: promoGradientByIndex(index),
@@ -342,7 +350,11 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
           </div>
         )}
 
-        <div className="mb-5 flex gap-2 overflow-x-auto pb-1 no-scrollbar [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+        <p id="catalog-results-status" className="sr-only" aria-live="polite">
+          Найдено позиций: {filteredItems.length}
+        </p>
+
+        <div className="mb-5 flex gap-2 overflow-x-auto pb-1 no-scrollbar [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden" role="group" aria-label="Быстрые фильтры каталога">
           {QUICK_FILTERS.map((filter) => {
             const active = quickFilter === filter.key;
             return (
@@ -350,7 +362,8 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
                 key={filter.key}
                 type="button"
                 onClick={() => setQuickFilter(filter.key)}
-                className="shrink-0 rounded-full bg-[var(--quick-pill-bg)] px-3 py-1.5 text-xs font-medium text-[var(--quick-pill-text)]"
+                aria-pressed={active}
+                className="shrink-0 rounded-full bg-[var(--quick-pill-bg)] px-3 py-1.5 text-xs font-medium text-[var(--quick-pill-text)] transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--catalog-accent)]"
                 style={{
                   ["--quick-pill-bg" as string]: active ? crew.theme.palette.accentMain : crew.theme.palette.bgCard,
                   ["--quick-pill-text" as string]: active ? "#000000" : crew.theme.palette.textPrimary,
@@ -367,7 +380,8 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
                 setQuickFilter("all");
                 setSearchQuery("");
               }}
-              className="shrink-0 rounded-full bg-[var(--quick-pill-bg)] px-3 py-1.5 text-xs font-medium text-[var(--quick-pill-text)]"
+              aria-label="Сбросить поиск и все быстрые фильтры"
+              className="shrink-0 rounded-full bg-[var(--quick-pill-bg)] px-3 py-1.5 text-xs font-medium text-[var(--quick-pill-text)] transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--catalog-accent)]"
               style={{ ["--quick-pill-bg" as string]: crew.theme.palette.bgCard, ["--quick-pill-text" as string]: crew.theme.palette.textPrimary }}
             >
               Сбросить всё
@@ -405,6 +419,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
                     >
                       <button
                         type="button"
+                        aria-label={`Открыть карточку ${item.title}: ${item.rentPriceLabel}`}
                         className="block w-full text-left"
                         onClick={() => openItem(item)}
                         onFocus={() => setFocusedItemId(item.id)}

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -299,8 +299,9 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
             type="button"
             aria-label="Перейти к первому найденному байку"
             onClick={() => {
-              const firstResult = document.querySelector("[data-catalog-item='true']") as HTMLElement | null;
+              const firstResult = document.querySelector("[data-catalog-item-button='true']") as HTMLButtonElement | null;
               firstResult?.scrollIntoView({ behavior: "smooth", block: "center" });
+              firstResult?.focus({ preventScroll: true });
             }}
             className="absolute bottom-1 right-1 top-1 rounded-full px-5 text-sm font-semibold transition active:scale-95"
             onFocus={() => setSearchCtaFocused(true)}
@@ -420,6 +421,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
                       <button
                         type="button"
                         aria-label={`Открыть карточку ${item.title}: ${item.rentPriceLabel}`}
+                        data-catalog-item-button="true"
                         className="block w-full text-left"
                         onClick={() => openItem(item)}
                         onFocus={() => setFocusedItemId(item.id)}

--- a/app/franchize/components/CrewFooter.tsx
+++ b/app/franchize/components/CrewFooter.tsx
@@ -54,12 +54,12 @@ export function CrewFooter({ crew }: CrewFooterProps) {
               return (
                 <li key={`${link.href}-${link.label}`} className="border-b border-[var(--footer-border)]">
                   {isExternal ? (
-                    <a href={link.href} className="flex items-center gap-2 py-3" target="_blank" rel="noreferrer">
+                    <a href={link.href} className="flex items-center gap-2 py-3 transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" target="_blank" rel="noreferrer" aria-label={`${link.label} (откроется в новой вкладке)`}>
                       <ChevronRight className="h-4 w-4" />
                       <span>{link.label}</span>
                     </a>
                   ) : (
-                    <Link href={link.href} className="flex items-center gap-2 py-3 hover:opacity-90 transition">
+                    <Link href={link.href} className="flex items-center gap-2 py-3 hover:opacity-90 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
                       <ChevronRight className="h-4 w-4" />
                       <span>{link.label}</span>
                     </Link>
@@ -75,7 +75,7 @@ export function CrewFooter({ crew }: CrewFooterProps) {
           <ul className="mt-5 grid gap-1 text-base md:grid-cols-2">
             {socialLinks.map((item) => (
               <li key={`${item.label}-${item.href}`} className="border-b border-[var(--footer-border)]">
-                <a href={item.href} className="flex items-center gap-2 py-3" target="_blank" rel="noreferrer">
+                <a href={item.href} className="flex items-center gap-2 py-3 transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" target="_blank" rel="noreferrer" aria-label={`${item.label} (откроется в новой вкладке)`}>
                   <Send className="h-4 w-4" />
                   <span>{item.label}</span>
                 </a>

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -166,9 +166,11 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
         >
           <button
             type="button"
-            aria-label="Open menu"
+            aria-label="Открыть меню экипажа"
+            aria-expanded={menuOpen}
+            aria-controls="franchize-header-menu"
             onClick={() => setMenuOpen(true)}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-xl transition"
+            className="inline-flex h-11 w-11 items-center justify-center rounded-xl transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
             style={{
               backgroundColor: `${crew.theme.palette.bgBase}CC`,
               color: crew.theme.palette.textPrimary,
@@ -181,7 +183,8 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
           {/* HEADER LOGO — PURE SPA LINK */}
           <Link
             href={headerLogoHref}
-            className="relative z-10 mx-auto flex flex-col items-center text-center cursor-pointer hover:opacity-90 transition-opacity pointer-events-auto"
+            aria-label={`На главную страницу ${crew.header.brandName}`}
+            className="relative z-10 mx-auto flex flex-col items-center text-center cursor-pointer hover:opacity-90 transition-opacity pointer-events-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
           >
             <div
               className="relative h-16 w-16 overflow-hidden rounded-full border shadow-lg"
@@ -234,7 +237,9 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
                   key={linkLabel}
                   href={href}
                   data-category-pill={linkLabel}
-                  className="shrink-0 snap-start rounded-full bg-[var(--pill-bg)] px-4 py-2 text-xs font-medium tracking-wide text-[var(--pill-text)] transition-colors pointer-events-auto"
+                  aria-current={isActive ? "location" : undefined}
+                  aria-label={`Перейти к разделу ${linkLabel}`}
+                  className="shrink-0 snap-start rounded-full bg-[var(--pill-bg)] px-4 py-2 text-xs font-medium tracking-wide text-[var(--pill-text)] transition-colors pointer-events-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
                   style={{
                     ["--pill-bg" as string]: isActive ? crew.theme.palette.accentMain : crew.theme.palette.bgCard,
                     ["--pill-text" as string]: isActive ? "#000000" : crew.theme.palette.textPrimary,

--- a/app/franchize/components/FloatingCartIconLink.tsx
+++ b/app/franchize/components/FloatingCartIconLink.tsx
@@ -30,9 +30,9 @@ export function FloatingCartIconLink({ href, itemCount, totalPrice, accentColor,
     >
       <button
         type="button"
-        aria-label="Scroll to top"
+        aria-label="Прокрутить страницу вверх"
         onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-        className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-[var(--floating-cart-bg)] text-[var(--floating-cart-text)] shadow-lg transition active:scale-95 cursor-pointer"
+        className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-[var(--floating-cart-bg)] text-[var(--floating-cart-text)] shadow-lg transition active:scale-95 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--floating-cart-accent)]"
       >
         <ArrowUp className="h-5 w-5" />
       </button>
@@ -40,7 +40,8 @@ export function FloatingCartIconLink({ href, itemCount, totalPrice, accentColor,
       {/* RESTORED TO SPA LINK */}
       <Link
         href={href}
-        className="relative inline-flex items-center justify-center gap-2 rounded-full bg-[var(--floating-cart-accent)] px-5 py-3 text-black shadow-xl transition-transform active:scale-95 cursor-pointer no-underline"
+        aria-label={`Открыть корзину: ${itemCount} позиций, ${isCartEmpty ? "0 ₽" : `${totalPrice.toLocaleString("ru-RU")} ₽`}`}
+        className="relative inline-flex items-center justify-center gap-2 rounded-full bg-[var(--floating-cart-accent)] px-5 py-3 text-black shadow-xl transition-transform active:scale-95 cursor-pointer no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--floating-cart-accent)]"
       >
         <ShoppingCart className="h-5 w-5" />
         <span className="text-sm font-bold">{isCartEmpty ? "0 ₽" : `${totalPrice.toLocaleString("ru-RU")} ₽`}</span>

--- a/app/franchize/components/ItemGallery.tsx
+++ b/app/franchize/components/ItemGallery.tsx
@@ -98,8 +98,9 @@ export function ItemGallery({
     return (
       <div
         ref={containerRef}
-        tabIndex={disableKeyboardNav ? -1 : 0}
-        className={`relative w-full outline-none ${getAspectRatioClass()}`}
+        tabIndex={-1}
+        aria-label={`Галерея ${altText}`}
+        className={`relative w-full outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${getAspectRatioClass()}`}
         style={{ backgroundColor: "var(--item-card-bg, #000)" }}
       >
         <Image
@@ -116,7 +117,13 @@ export function ItemGallery({
   }
 
   return (
-    <div ref={containerRef} tabIndex={disableKeyboardNav ? -1 : 0} className={`relative w-full outline-none ${className}`}>
+    <div
+      ref={containerRef}
+      tabIndex={disableKeyboardNav ? -1 : 0}
+      role="region"
+      aria-label={`Галерея ${altText}`}
+      className={`relative w-full outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${className}`}
+    >
       {/* Main Image Container - FIXED: Added explicit aspect ratio class */}
       <div className={`relative w-full bg-black/25 ${getAspectRatioClass()}`}>
         <Image
@@ -154,7 +161,7 @@ export function ItemGallery({
         </button>
 
         {/* Image Counter Badge */}
-        <div className="absolute bottom-3 left-3 rounded-full bg-black/55 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm select-none pointer-events-none">
+        <div className="absolute bottom-3 left-3 rounded-full bg-black/55 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm select-none pointer-events-none" aria-live="polite">
           {activeIndex + 1} / {resolvedImages.length}
         </div>
       </div>
@@ -164,7 +171,7 @@ export function ItemGallery({
         className="border-t px-3 pb-3 pt-3 sm:px-4"
         style={{ borderColor, backgroundColor: bgColor }}
       >
-        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-6">
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-6" role="group" aria-label="Миниатюры фотографий">
           {resolvedImages.map((url, index) => {
             const isActive = index === activeIndex;
             return (
@@ -174,7 +181,7 @@ export function ItemGallery({
                 onClick={() => onSelect(index)}
                 aria-pressed={isActive}
                 aria-label={`Показать фото ${index + 1}`}
-                className={`relative aspect-[5/4] w-full overflow-hidden rounded-2xl border transition-all duration-200 ${
+                className={`relative aspect-[5/4] w-full overflow-hidden rounded-2xl border transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
                   isActive ? "scale-[0.98] opacity-100" : "opacity-85 hover:opacity-100 active:scale-[0.97]"
                 }`}
                 style={{

--- a/app/franchize/modals/HeaderMenu.tsx
+++ b/app/franchize/modals/HeaderMenu.tsx
@@ -14,9 +14,19 @@ interface HeaderMenuProps {
   onOpenChange: (open: boolean) => void;
 }
 
+const focusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
 export function HeaderMenu({ crew, activePath, open, onOpenChange }: HeaderMenuProps) {
   const [mounted, setMounted] = useState(false);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const surface = crewPaletteForSurface(crew.theme);
 
   useEffect(() => {
@@ -26,16 +36,47 @@ export function HeaderMenu({ crew, activePath, open, onOpenChange }: HeaderMenuP
   useEffect(() => {
     if (!open) return;
 
+    const originalOverflow = document.body.style.overflow;
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    document.body.style.overflow = "hidden";
+
+    const focusFirstControl = window.requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
         onOpenChange(false);
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusable = Array.from(menuRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ?? [])
+        .filter((element) => element.offsetParent !== null || element === document.activeElement);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    closeButtonRef.current?.focus();
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      window.cancelAnimationFrame(focusFirstControl);
+      document.body.style.overflow = originalOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+      if (previouslyFocused && document.contains(previouslyFocused)) {
+        previouslyFocused.focus();
+      }
+    };
   }, [onOpenChange, open]);
 
   if (!open || !mounted) return null;
@@ -43,6 +84,7 @@ export function HeaderMenu({ crew, activePath, open, onOpenChange }: HeaderMenuP
   return createPortal(
     <div className="fixed inset-0 z-[70] flex items-start justify-center bg-black/75 p-4" onClick={() => onOpenChange(false)}>
       <div
+        ref={menuRef}
         id="franchize-header-menu"
         role="dialog"
         aria-modal="true"

--- a/app/franchize/modals/HeaderMenu.tsx
+++ b/app/franchize/modals/HeaderMenu.tsx
@@ -2,7 +2,7 @@
 
 import { X } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { FranchizeCrewVM } from "../actions";
 import { crewPaletteForSurface } from "../lib/theme";
@@ -16,17 +16,37 @@ interface HeaderMenuProps {
 
 export function HeaderMenu({ crew, activePath, open, onOpenChange }: HeaderMenuProps) {
   const [mounted, setMounted] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const surface = crewPaletteForSurface(crew.theme);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onOpenChange(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    closeButtonRef.current?.focus();
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onOpenChange, open]);
+
   if (!open || !mounted) return null;
 
   return createPortal(
     <div className="fixed inset-0 z-[70] flex items-start justify-center bg-black/75 p-4" onClick={() => onOpenChange(false)}>
       <div
+        id="franchize-header-menu"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="franchize-header-menu-title"
         className="mt-[calc(max(env(safe-area-inset-top),0.5rem)+0.5rem)] max-h-[calc(100dvh-max(env(safe-area-inset-top),0.5rem)-1rem)] w-full max-w-sm overflow-y-auto rounded-2xl border border-[var(--header-menu-border)] bg-[var(--header-menu-bg)] p-4 text-[var(--header-menu-text)] shadow-2xl"
         style={{
           ["--header-menu-bg" as string]: crew.theme.palette.bgCard,
@@ -37,12 +57,13 @@ export function HeaderMenu({ crew, activePath, open, onOpenChange }: HeaderMenuP
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">
-          <p className="text-sm font-semibold uppercase tracking-[0.16em]">Menu</p>
+          <p id="franchize-header-menu-title" className="text-sm font-semibold uppercase tracking-[0.16em]">Меню экипажа</p>
           <button
+            ref={closeButtonRef}
             type="button"
-            aria-label="Close menu"
+            aria-label="Закрыть меню"
             onClick={() => onOpenChange(false)}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--header-menu-border)]"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--header-menu-border)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--header-menu-accent)]"
           >
             <X className="h-4 w-4" />
           </button>
@@ -58,7 +79,8 @@ export function HeaderMenu({ crew, activePath, open, onOpenChange }: HeaderMenuP
                 key={`${link.href}-${link.label}`}
                 href={link.href}
                 onClick={() => onOpenChange(false)}
-                className={`w-full text-left block rounded-xl border px-4 py-3 text-sm transition cursor-pointer ${
+                aria-current={isActive ? "page" : undefined}
+                className={`w-full text-left block rounded-xl border px-4 py-3 text-sm transition cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--header-menu-accent)] ${
                   isActive
                     ? "border-[var(--header-menu-accent)] text-[var(--header-menu-accent)]"
                     : "border-[var(--header-menu-border)] text-[var(--header-menu-text)]"

--- a/app/franchize/modals/Item.tsx
+++ b/app/franchize/modals/Item.tsx
@@ -61,13 +61,14 @@ function OptionChips({
       <p className="mb-2 text-xs font-medium uppercase tracking-[0.12em] text-[var(--item-muted-text)]">
         {title}
       </p>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-2" role="group" aria-label={title}>
         {options.map((option) => {
           const isActive = option === selected;
           return (
             <button
               key={option}
               type="button"
+              aria-pressed={isActive}
               onClick={() => onSelect(option)}
               className={`rounded-full border px-3 py-1.5 text-xs transition hover:opacity-90 active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--item-accent)] ${
                 isActive
@@ -219,6 +220,7 @@ export function ItemModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby={`item-modal-title-${item.id}`}
+      aria-describedby={`item-modal-description-${item.id}`}
       tabIndex={-1}
       style={themeVars}
     >
@@ -269,6 +271,7 @@ export function ItemModal({
                 </p>
               )}
               <p
+                id={`item-modal-description-${item.id}`}
                 className={`mt-2 text-sm leading-6 ${descriptionExpanded ? "" : "line-clamp-4"}`}
                 style={surface.mutedText}
               >
@@ -278,6 +281,8 @@ export function ItemModal({
                 <button
                   type="button"
                   className="mt-1 text-sm font-medium text-[var(--item-accent)] transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--item-accent)]"
+                  aria-expanded={descriptionExpanded}
+                  aria-controls={`item-modal-description-${item.id}`}
                   onClick={() => setDescriptionExpanded((prev) => !prev)}
                 >
                   {descriptionExpanded ? "Скрыть" : "Показать ещё..."}
@@ -315,7 +320,8 @@ export function ItemModal({
             {item.saleAvailable && (
               <Link
                 href={`/franchize/${slug}/market/${item.id}/buy`}
-                className="inline-flex w-full items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium transition hover:opacity-90"
+                className="inline-flex w-full items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--item-accent)]"
+                aria-label={`Открыть страницу покупки ${item.title}`}
                 style={surface.subtleCard}
               >
                 Открыть страницу покупки
@@ -361,7 +367,8 @@ export function ItemModal({
                       key={bike.id}
                       type="button"
                       onClick={() => setVsBike(bike)}
-                      className="rounded-xl border p-2 text-left text-xs transition hover:bg-white/5"
+                      aria-pressed={vsBike?.id === bike.id}
+                      className="rounded-xl border p-2 text-left text-xs transition hover:bg-white/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--item-accent)]"
                       style={surface.subtleCard}
                     >
                       <span className="flex items-center justify-between gap-2">
@@ -413,6 +420,7 @@ export function ItemModal({
             <button
               type="button"
               onClick={onClose}
+              aria-label="Закрыть карточку товара"
               className="rounded-xl border px-3 py-2 text-sm font-medium transition hover:opacity-90 active:scale-[0.99] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--item-accent)]"
               style={surface.subtleCard}
             >
@@ -422,6 +430,7 @@ export function ItemModal({
               type="button"
               onClick={handleAddToCart}
               disabled={isAdding}
+              aria-busy={isAdding}
               className="rounded-xl bg-[var(--item-accent)] px-3 py-2 text-sm font-semibold text-[var(--item-accent-contrast)] transition hover:brightness-105 active:scale-[0.99] disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--item-accent)]"
             >
               {isAdding

--- a/app/franchize/modals/Item.tsx
+++ b/app/franchize/modals/Item.tsx
@@ -35,6 +35,14 @@ interface ItemModalProps {
 const packageOptions = ["Базовый", "Комфорт", "Максимум"];
 const durationOptions = ["1 день", "3 дня", "7 дней"];
 const perkOptions = ["Стандарт", "Шлем + GoPro", "Полный комплект"];
+const modalFocusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
 
 const getModalThemeVars = (theme: FranchizeTheme) =>
   ({
@@ -141,16 +149,40 @@ export function ItemModal({
         e.preventDefault();
         e.stopPropagation();
         onClose();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+
+      const focusable = Array.from(modalRef.current?.querySelectorAll<HTMLElement>(modalFocusableSelector) ?? [])
+        .filter((element) => element.offsetParent !== null || element === document.activeElement);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        modalRef.current?.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    modalRef.current?.focus();
+    const focusDialog = window.requestAnimationFrame(() => modalRef.current?.focus());
 
     return () => {
+      window.cancelAnimationFrame(focusDialog);
       document.body.style.overflow = originalOverflow;
       document.removeEventListener("keydown", handleKeyDown);
-      previouslyFocused?.focus();
+      if (previouslyFocused && document.contains(previouslyFocused)) {
+        previouslyFocused.focus();
+      }
     };
   }, [item, onClose]);
 

--- a/app/franchize/todo.md
+++ b/app/franchize/todo.md
@@ -13,3 +13,8 @@ Tasks
 
 Notes
 - Do not move files out of /app — keep plugin in place, formalize with manifest.
+
+## SupaPlan execution — 2026-05-06
+
+- [x] `RENT-P3.1` (`a58aea2f-b6ff-43f1-ad0e-a946ac359d9a`): storefront a11y pass added explicit search labels/live result status, pressed/current states, focus-visible affordances, dialog/menu semantics, and clearer cart/gallery/modal labels.
+- [x] `FIX-ORPHAN-INVOICE` (`d1a6f7d0-1234-4a1e-bcde-11110001abcd`): `createFranchizeOrderInvoiceInternal` now deletes the just-created pending invoice when Telegram XTR invoice sending fails, guarded by invoice id/status/rental metadata.

--- a/app/franchize/todo.md
+++ b/app/franchize/todo.md
@@ -16,5 +16,5 @@ Notes
 
 ## SupaPlan execution — 2026-05-06
 
-- [x] `RENT-P3.1` (`a58aea2f-b6ff-43f1-ad0e-a946ac359d9a`): storefront a11y pass added explicit search labels/live result status, pressed/current states, focus-visible affordances, dialog/menu semantics, and clearer cart/gallery/modal labels.
+- [x] `RENT-P3.1` (`a58aea2f-b6ff-43f1-ad0e-a946ac359d9a`): storefront a11y pass added explicit search labels/live result status, pressed/current states, focus-visible affordances, dialog/menu semantics, focus containment/return for overlays, and clearer cart/gallery/modal labels.
 - [x] `FIX-ORPHAN-INVOICE` (`d1a6f7d0-1234-4a1e-bcde-11110001abcd`): `createFranchizeOrderInvoiceInternal` now deletes the just-created pending invoice when Telegram XTR invoice sending fails, guarded by invoice id/status/rental metadata.

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -135,6 +135,6 @@ This root file stays intentionally compact so operators and agents can load it q
 - `status`: ready_for_pr
 - `updated_at`: 2026-05-06T23:20:00Z
 - `owner`: codex
-- `notes`: Completed SupaPlan `RENT-P3.1` and `FIX-ORPHAN-INVOICE`: public storefront controls now expose stronger labels/current/pressed states and failed Telegram XTR sends clean up newly-created pending franchize invoices.
+- `notes`: Completed SupaPlan `RENT-P3.1` and `FIX-ORPHAN-INVOICE`: public storefront controls now expose stronger labels/current/pressed states, overlay focus containment/return was tightened in self-review, and failed Telegram XTR sends clean up newly-created pending franchize invoices.
 - `next_step`: Merge PR, then run browser accessibility smoke on `/franchize/vip-bike` and a Telegram invoice failure-path smoke with test credentials.
 - `risks`: Visual a11y smoke depends on a bootable local/prod runtime; invoice delivery/failure verification depends on Telegram bot credentials.

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -129,3 +129,12 @@ This root file stays intentionally compact so operators and agents can load it q
 - `notes`: Added a compact `/nexus` KPI scoreboard for the VIP Bike franchise funnel with pilot conversion/SLA/partner signals and lead-to-paid-booking stages. SupaPlan task `913e8a73-46f6-4c22-8278-c1b5aabe661e`.
 - `next_step`: Wire the same KPI cards to real order/lead events after event analytics storage is finalized.
 - `risks`: Current numbers are explicitly pilot targets, not live production analytics.
+
+### 2026-05-06 — Storefront a11y + XTR orphan invoice cleanup
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-06T23:20:00Z
+- `owner`: codex
+- `notes`: Completed SupaPlan `RENT-P3.1` and `FIX-ORPHAN-INVOICE`: public storefront controls now expose stronger labels/current/pressed states and failed Telegram XTR sends clean up newly-created pending franchize invoices.
+- `next_step`: Merge PR, then run browser accessibility smoke on `/franchize/vip-bike` and a Telegram invoice failure-path smoke with test credentials.
+- `risks`: Visual a11y smoke depends on a bootable local/prod runtime; invoice delivery/failure verification depends on Telegram bot credentials.

--- a/tests/franchize/doc-flow.spec.ts
+++ b/tests/franchize/doc-flow.spec.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   getUserSensitiveData: vi.fn(),
   getCrewSensitiveData: vi.fn(),
   from: vi.fn(),
+  invoiceDeleteContains: vi.fn(),
 }));
 
 vi.mock('@/lib/supabase-server', () => ({
@@ -118,6 +119,27 @@ function buildSupabaseFromMock() {
             maybeSingle: async () => ({ data: null, error: null }),
           }),
         }),
+        delete: () => ({
+          eq: () => ({
+            eq: () => ({
+              contains: mocks.invoiceDeleteContains,
+            }),
+          }),
+        }),
+      };
+    }
+
+    if (table === 'rentals') {
+      return {
+        select: () => ({
+          eq: () => ({
+            order: () => ({
+              limit: () => ({
+                maybeSingle: async () => ({ data: null, error: null }),
+              }),
+            }),
+          }),
+        }),
       };
     }
 
@@ -134,7 +156,8 @@ describe('franchize checkout doc-flow', () => {
     mocks.sendTelegramDocument.mockResolvedValue({ success: true });
     mocks.notifyAdmin.mockResolvedValue({ success: true });
     mocks.sendTelegramInvoice.mockResolvedValue({ success: true });
-    mocks.createInvoice.mockResolvedValue({ success: true });
+    mocks.createInvoice.mockResolvedValue({ success: true, data: { status: 'pending' } });
+    mocks.invoiceDeleteContains.mockResolvedValue({ error: null });
     mocks.buildDocx.mockResolvedValue({ bytes: new Uint8Array([1, 2, 3]), renderedMarkdown: 'ok' });
     vi.stubEnv('ADMIN_CHAT_ID', '417553377');
   });
@@ -156,6 +179,19 @@ describe('franchize checkout doc-flow', () => {
     expect(result.success).toBe(true);
     expect(mocks.createInvoice).toHaveBeenCalledTimes(1);
     expect(mocks.sendTelegramInvoice).toHaveBeenCalledTimes(1);
+    expect(mocks.invoiceDeleteContains).not.toHaveBeenCalled();
     expect(mocks.sendTelegramDocument).toHaveBeenCalled();
+  });
+
+  it('cleans up the pending invoice when Telegram XTR send fails', async () => {
+    mocks.sendTelegramInvoice.mockResolvedValueOnce({ success: false, error: 'telegram send failed' });
+
+    const result = await createFranchizeOrderCheckout(buildPayload('telegram_xtr', 'order-cleanup'));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('telegram send failed');
+    expect(mocks.createInvoice).toHaveBeenCalledTimes(1);
+    expect(mocks.invoiceDeleteContains).toHaveBeenCalledTimes(1);
+    expect(mocks.invoiceDeleteContains).toHaveBeenCalledWith('metadata', expect.objectContaining({ rental_id: expect.any(String) }));
   });
 });


### PR DESCRIPTION
### Motivation
- Deliver the `RENT-P3.1` accessibility pass for the franchize storefront so catalog search, filters, cards, header/menu, gallery and modals expose proper ARIA semantics and keyboard affordances. 
- Prevent orphaned pending invoices when Telegram XTR invoice delivery fails by ensuring newly-created pending invoices tied to a rental are removed on send failure.

### Description
- Accessibility: add semantic search region, hidden label, `aria-describedby` live result status, `aria-pressed` on quick filters/options, `aria-label` on CTA/links, `aria-current` on pills, focus-visible affordances, dialog semantics and Escape handling for header/menu, dialog `aria-describedby` for item modal, gallery `role` and live counter, and improved footer/floating-cart labels (`app/franchize/components/*`).
- Invoice cleanup: add `cleanupPendingFranchizeInvoiceAfterSendFailure` and wire it into `createFranchizeOrderInvoiceInternal` so we delete the just-created pending invoice (guarded by invoice id, status and `metadata.rental_id`) when `sendTelegramInvoice` fails or an error occurs (`app/franchize/actions.ts`).
- Tests & docs: extend `tests/franchize/doc-flow.spec.ts` to cover successful DOCX→invoice flow and the Telegram-send-failure cleanup path, and update task tracking in `app/franchize/todo.md` and `docs/THE_FRANCHEEZEPLAN.md`.

supaplan_task: a58aea2f-b6ff-43f1-ad0e-a946ac359d9a, d1a6f7d0-1234-4a1e-bcde-11110001abcd

### Testing
- Ran lint: `npm run lint:target` and `npx eslint --max-warnings=0 tests/franchize/doc-flow.spec.ts` which passed.
- Unit tests: `npm test -- tests/franchize` (Vitest) ran the updated `doc-flow` suite and all added tests passed (3/3); added failure-path test verifies cleanup logic.
- Scoped checks: `npm test -- app/franchize` reported no matching tests under the configured include pattern (informational), and `npx tsc --noEmit` still surfaces unrelated pre-existing syntax issues in other areas of the repo (not introduced by this change).
- SupaPlan status updates: moved both tasks to `ready_for_pr` via the local SupaPlan CLI and verified task status with `node scripts/supaplan-skill.mjs task-status` (succeeded); direct Supabase claim-read from this environment failed due to network/credentials (`fetch failed`) but status API calls succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc9f36ec48324b37ce7a21886c955)