### PR TITLE
MapRiders: Telegram native live-location bridge, full-screen route replay UI, and VIP BIKE service hub

### DIFF
--- a/app/api/map-riders/todo.md
+++ b/app/api/map-riders/todo.md
@@ -1,0 +1,14 @@
+# MapRiders API backlog
+
+Scope: `app/api/map-riders/*` plus Telegram webhook bridge code that writes MapRiders live-location records.
+
+## RENT-P2.4 — Telegram live-location bridge (native GPS)
+
+- [x] Detect Telegram `message.location` and `edited_message.location` payloads from native live-location sharing.
+- [x] Prefer an active `map_rider_sessions` row for the Telegram `from.id` before legacy crew-shift location handling.
+- [x] Mirror native Telegram GPS into `live_locations`, `map_rider_sessions.latest_*`, and `map_rider_points` so replay/history stays complete.
+- [x] Broadcast `rider:move` on the existing `map-riders:{crewSlug}` realtime channel.
+- [x] Keep duplicate burst filtering for low-distance Telegram edit storms.
+- [x] Guard one-off Telegram locations: only live-period/edited-message updates short-circuit into MapRiders, so SOS/drop-off geotags still fall through to legacy state handlers.
+
+SupaPlan task: `696922bd-8186-4903-ab7b-ef999d7ac11b`

--- a/app/franchize/[slug]/map-riders/todo.md
+++ b/app/franchize/[slug]/map-riders/todo.md
@@ -54,7 +54,7 @@ Port AGI handoff from `./goldmine` into production `MapRiders` in controlled ite
 
 ### I6 — Production-hardening backlog (new)
 - [x] Privacy controls: visibility mode (`crew/public`) + home-blur option + auto-expire presets (1/5/15/60).
-- [ ] Route replay full-screen UI with timeline scrubber.
+- [x] Route replay full-screen UI with timeline scrubber.
 - [ ] Speed-gradient route polyline rendering (segment color by speed).
 - [ ] Long-press meetup creation mode (keep tap safe for exploration UX).
 - [x] Write API hardening: CSRF-style guards (`Authorization` + `Origin` + `X-Requested-With`) and per-user in-memory rate limits for session/meetups/batch writes.
@@ -123,6 +123,10 @@ Port AGI handoff from `./goldmine` into production `MapRiders` in controlled ite
   - Wired privacy payload from client GPS pipeline into `/api/map-riders/batch-points` and fallback `/api/map-riders/location`.
   - Added server-side expire enforcement: expired sessions auto-stop and return 409 to client writes.
   - Added location blur transform when home-blur is enabled and persisted privacy metadata in session stats.
+
+## Investigation notes (2026-05-06)
+- Completed SupaPlan task `b2fb8b78-dc2d-4913-b379-caf22eb1c4e5` (I6 route replay full-screen scrubber UI): replay opens from History into a full-screen cockpit with SVG route projection, current rider marker, timeline range scrubber, play/pause, keyboard controls and speed presets.
+- Continued SupaPlan task `696922bd-8186-4903-ab7b-ef999d7ac11b` (RENT-P2.4 Telegram native GPS bridge): Telegram `message.location`/`edited_message.location` now first checks active MapRiders sessions and persists native live-location updates into live feed + replay history before falling back to legacy crew shift handling.
 
 ## Investigation notes (2026-04-26)
 - SupaPlan task `e9c8f76f-0863-4f20-a871-6a09dd3bf7f8` (I6.1 evidence pack) progressed with fresh `vip-bike` smoke + screenshot refresh:

--- a/app/vipbikerental/VipBikeRentalClient.tsx
+++ b/app/vipbikerental/VipBikeRentalClient.tsx
@@ -523,6 +523,80 @@ function StepsProgress({ items }: { items: CatalogItemVM[] }) {
 }
 
 
+function VipBikeCompanyServiceHub() {
+  const serviceLanes = [
+    {
+      title: "Прокат и выдача",
+      icon: "::FaKey::",
+      text: "Быстрая бронь, договор, экипировка и понятная выдача без лишних звонков.",
+      href: "/franchize/vip-bike",
+      cta: "Выбрать байк",
+    },
+    {
+      title: "Сервис и ремонт",
+      icon: "::FaWrench::",
+      text: "Обслуживание своего мотоцикла, диагностика, сезонная подготовка и расходники на базе VIP BIKE.",
+      href: "https://t.me/salavey13",
+      cta: "Написать в сервис",
+    },
+    {
+      title: "Комьюнити райдеров",
+      icon: "::FaUsersViewfinder::",
+      text: "MapRiders, точки встреч, живые маршруты и социальное доказательство вокруг реальных поездок.",
+      href: "/franchize/vip-bike/map-riders",
+      cta: "Открыть карту",
+    },
+  ];
+
+  const companyFacts = [
+    "Локация: Стригинский переулок 13Б",
+    "Формат: аренда, продажа, сервис, комьюнити",
+    "Фокус: electro-enduro и городские тест-драйвы",
+  ];
+
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-primary/20 bg-card/50 p-5 shadow-2xl shadow-primary/10 sm:p-7">
+      <div className="grid gap-6 lg:grid-cols-[0.9fr,1.1fr]">
+        <div className="rounded-3xl border border-white/10 bg-black/35 p-5 text-white">
+          <p className="text-xs uppercase tracking-[0.24em] text-primary">company hub</p>
+          <h2 className="mt-3 font-orbitron text-3xl sm:text-4xl">VIP BIKE — не только прокат, а база райдера</h2>
+          <p className="mt-4 text-sm leading-relaxed text-white/70">
+            Один экран объясняет компанию простыми словами: где взять байк, где обслужить свой мотоцикл, куда приехать и как попасть в живое сообщество.
+          </p>
+          <div className="mt-5 grid gap-2">
+            {companyFacts.map((fact) => (
+              <div key={fact} className="flex items-start gap-2 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/85">
+                <VibeContentRenderer content="::FaCircleCheck::" className="mt-0.5 text-primary" />
+                <span>{fact}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3 lg:grid-cols-1">
+          {serviceLanes.map((lane) => (
+            <article key={lane.title} className="rounded-3xl border border-border/70 bg-background/55 p-4 transition hover:-translate-y-1 hover:border-primary/50">
+              <div className="flex items-start gap-3">
+                <div className="rounded-2xl bg-primary/10 p-3 text-primary">
+                  <VibeContentRenderer content={lane.icon} />
+                </div>
+                <div>
+                  <h3 className="font-orbitron text-lg">{lane.title}</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">{lane.text}</p>
+                  <Button asChild size="sm" variant="outline" className="mt-3">
+                    <Link href={lane.href}>{lane.cta}</Link>
+                  </Button>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+
 function RentalQuickActionHub({ items, overview }: { items: CatalogItemVM[]; overview: MapRidersOverview | null }) {
   const [selectedAction, setSelectedAction] = useState<"status" | "riders" | "chooser">("status");
   const [isChooserOpen, setIsChooserOpen] = useState(false);
@@ -1560,6 +1634,8 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
         <StepsProgress items={items} />
 
         <RentalQuickActionHub items={items} overview={mapOverview} />
+
+        <VipBikeCompanyServiceHub />
 
         <motion.section
           initial={{ opacity: 0, y: 50 }}

--- a/components/map-riders/RidersDrawer.tsx
+++ b/components/map-riders/RidersDrawer.tsx
@@ -269,6 +269,58 @@ function ReplayFullscreen({
   const [speedMs, setSpeedMs] = useState<250 | 500 | 1000>(500);
   const current = points[index];
 
+  const replayGeometry = useMemo(() => {
+    if (!points.length) {
+      return { path: "", playedPath: "", currentPoint: null as { x: number; y: number } | null, distanceKm: 0, durationLabel: "0 мин" };
+    }
+
+    const padding = 7;
+    const width = 100;
+    const height = 100;
+    const lats = points.map((point) => point.lat);
+    const lons = points.map((point) => point.lon);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const minLon = Math.min(...lons);
+    const maxLon = Math.max(...lons);
+    const latSpan = Math.max(maxLat - minLat, 0.0001);
+    const lonSpan = Math.max(maxLon - minLon, 0.0001);
+
+    const project = (point: { lat: number; lon: number }) => ({
+      x: padding + ((point.lon - minLon) / lonSpan) * (width - padding * 2),
+      y: height - padding - ((point.lat - minLat) / latSpan) * (height - padding * 2),
+    });
+
+    const projected = points.map(project);
+    const makePath = (items: Array<{ x: number; y: number }>) =>
+      items.map((point, pointIndex) => `${pointIndex === 0 ? "M" : "L"} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`).join(" ");
+
+    const played = projected.slice(0, Math.min(index + 1, projected.length));
+    let distanceKm = 0;
+    for (let pointIndex = 1; pointIndex < points.length; pointIndex += 1) {
+      const prev = points[pointIndex - 1];
+      const next = points[pointIndex];
+      const latRad = (next.lat - prev.lat) * (Math.PI / 180);
+      const lonRad = (next.lon - prev.lon) * (Math.PI / 180);
+      const prevLatRad = prev.lat * (Math.PI / 180);
+      const nextLatRad = next.lat * (Math.PI / 180);
+      const a = Math.sin(latRad / 2) ** 2 + Math.cos(prevLatRad) * Math.cos(nextLatRad) * Math.sin(lonRad / 2) ** 2;
+      distanceKm += 6371 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    }
+
+    const startedMs = new Date(points[0]?.capturedAt || Date.now()).getTime();
+    const endedMs = new Date(points[points.length - 1]?.capturedAt || Date.now()).getTime();
+    const durationSeconds = Number.isFinite(startedMs) && Number.isFinite(endedMs) ? Math.max(0, Math.round((endedMs - startedMs) / 1000)) : 0;
+
+    return {
+      path: makePath(projected),
+      playedPath: makePath(played),
+      currentPoint: projected[index] || projected[0] || null,
+      distanceKm,
+      durationLabel: formatRideDuration(durationSeconds),
+    };
+  }, [index, points]);
+
   useEffect(() => {
     if (!playing || total < 2) return;
     const timer = setInterval(() => {
@@ -308,58 +360,101 @@ function ReplayFullscreen({
   }, [onClose, total]);
 
   const progress = total > 1 ? (index / (total - 1)) * 100 : 0;
+  const currentTime = current?.capturedAt ? new Date(current.capturedAt).toLocaleString("ru-RU") : "—";
 
   return (
-    <div className="fixed inset-0 z-[90] flex flex-col bg-black/95 p-4">
-      <div className="flex items-center justify-between">
+    <div className="fixed inset-0 z-[90] flex flex-col bg-black/95 p-4 text-white" role="dialog" aria-modal="true" aria-label="Полноэкранный replay маршрута">
+      <div className="flex items-start justify-between gap-3">
         <div>
-          <div className="text-xs uppercase tracking-wide text-emerald-200/80">Route replay</div>
-          <h3 className="text-base font-semibold text-white">{title}</h3>
+          <div className="text-xs uppercase tracking-wide text-emerald-200/80">Route replay cockpit</div>
+          <h3 className="text-lg font-semibold text-white">{title}</h3>
+          <div className="mt-1 text-xs text-zinc-400">Space — play/pause • ←/→ — шаг • Esc — закрыть</div>
         </div>
-        <Button type="button" size="sm" variant="outline" onClick={onClose}>Закрыть</Button>
+        <Button type="button" size="sm" variant="outline" onClick={onClose} aria-label="Закрыть replay маршрута">
+          Закрыть
+        </Button>
       </div>
 
-      <div className="mt-4 flex-1 rounded-xl border border-white/10 bg-white/5 p-3">
-        {!total ? (
-          <div className="text-sm text-zinc-400">Нет точек маршрута для воспроизведения.</div>
-        ) : (
-          <div className="space-y-3">
-            <div className="grid grid-cols-2 gap-2 text-xs text-zinc-300">
-              <div>Точка: {index + 1} / {total}</div>
-              <div className="text-right">Скорость: {Number(current?.speedKmh || 0).toFixed(1)} км/ч</div>
-              <div className="col-span-2 break-all text-zinc-400">
-                {current?.capturedAt ? new Date(current.capturedAt).toLocaleString("ru-RU") : "—"}
-              </div>
+      <div className="mt-4 grid min-h-0 flex-1 gap-3 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="relative min-h-[46vh] overflow-hidden rounded-2xl border border-emerald-300/20 bg-[radial-gradient(circle_at_30%_20%,rgba(16,185,129,0.22),transparent_36%),linear-gradient(135deg,rgba(15,23,42,0.96),rgba(2,6,23,0.98))] p-3 shadow-2xl shadow-emerald-950/40">
+          <div className="absolute inset-0 opacity-20 [background-image:linear-gradient(rgba(255,255,255,.08)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.08)_1px,transparent_1px)] [background-size:28px_28px]" />
+          {!total ? (
+            <div className="relative z-10 flex h-full items-center justify-center rounded-xl border border-dashed border-white/20 text-sm text-zinc-400">
+              Нет точек маршрута для воспроизведения.
             </div>
-            <div className="h-2 w-full overflow-hidden rounded bg-white/10">
-              <div className="h-full rounded bg-emerald-400 transition-all" style={{ width: `${progress}%` }} />
+          ) : (
+            <svg className="relative z-10 h-full min-h-[46vh] w-full" viewBox="0 0 100 100" preserveAspectRatio="none" aria-label="Схема replay маршрута">
+              <path d={replayGeometry.path} fill="none" stroke="rgba(148,163,184,0.42)" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round" vectorEffect="non-scaling-stroke" />
+              <path d={replayGeometry.playedPath || replayGeometry.path} fill="none" stroke="url(#map-riders-replay-gradient)" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" vectorEffect="non-scaling-stroke" />
+              <defs>
+                <linearGradient id="map-riders-replay-gradient" x1="0" x2="1" y1="0" y2="1">
+                  <stop offset="0%" stopColor="#34d399" />
+                  <stop offset="52%" stopColor="#facc15" />
+                  <stop offset="100%" stopColor="#fb923c" />
+                </linearGradient>
+              </defs>
+              {replayGeometry.currentPoint ? (
+                <g>
+                  <circle cx={replayGeometry.currentPoint.x} cy={replayGeometry.currentPoint.y} r="4.4" fill="rgba(16,185,129,0.22)" />
+                  <circle cx={replayGeometry.currentPoint.x} cy={replayGeometry.currentPoint.y} r="2" fill="#fef3c7" stroke="#10b981" strokeWidth="0.9" />
+                </g>
+              ) : null}
+            </svg>
+          )}
+          <div className="pointer-events-none absolute bottom-3 left-3 right-3 z-20 flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-black/55 px-3 py-2 text-xs backdrop-blur">
+            <span>{replayGeometry.distanceKm.toFixed(2)} км</span>
+            <span>{replayGeometry.durationLabel}</span>
+            <span>{progress.toFixed(0)}%</span>
+          </div>
+        </div>
+
+        <aside className="flex min-h-0 flex-col rounded-2xl border border-white/10 bg-white/5 p-3">
+          <div className="grid grid-cols-2 gap-2 text-xs text-zinc-300">
+            <div className="rounded-xl bg-black/30 p-3">
+              <div className="text-zinc-500">Точка</div>
+              <div className="mt-1 text-lg text-white">{total ? index + 1 : 0} / {total}</div>
             </div>
-            <Label htmlFor="map-riders-replay-position" className="sr-only">
-              Позиция воспроизведения маршрута
-            </Label>
-            <input
-              id="map-riders-replay-position"
-              type="range"
-              min={0}
-              max={Math.max(total - 1, 0)}
-              value={index}
-              onChange={(event) => setIndex(Number(event.target.value))}
-              className="w-full"
-            />
-            <div className="grid grid-cols-3 gap-2">
-              <Button type="button" variant="outline" onClick={() => setIndex((prev) => Math.max(prev - 1, 0))}>← Шаг</Button>
-              <Button type="button" onClick={() => setPlaying((prev) => !prev)} disabled={total < 2}>
-                {playing ? "Пауза" : "Play"}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => setIndex((prev) => Math.min(prev + 1, Math.max(total - 1, 0)))}>Шаг →</Button>
+            <div className="rounded-xl bg-black/30 p-3 text-right">
+              <div className="text-zinc-500">Скорость</div>
+              <div className="mt-1 text-lg text-emerald-200">{Number(current?.speedKmh || 0).toFixed(1)} км/ч</div>
             </div>
-            <div className="grid grid-cols-3 gap-2">
-              <Button type="button" size="sm" variant={speedMs === 250 ? "default" : "outline"} onClick={() => setSpeedMs(250)}>x2</Button>
-              <Button type="button" size="sm" variant={speedMs === 500 ? "default" : "outline"} onClick={() => setSpeedMs(500)}>x1</Button>
-              <Button type="button" size="sm" variant={speedMs === 1000 ? "default" : "outline"} onClick={() => setSpeedMs(1000)}>x0.5</Button>
+            <div className="col-span-2 rounded-xl bg-black/30 p-3">
+              <div className="text-zinc-500">Время GPS</div>
+              <div className="mt-1 break-all text-white">{currentTime}</div>
             </div>
           </div>
-        )}
+
+          <div className="mt-4 h-2 w-full overflow-hidden rounded bg-white/10" aria-hidden="true">
+            <div className="h-full rounded bg-emerald-400 transition-all" style={{ width: `${progress}%` }} />
+          </div>
+          <Label htmlFor="map-riders-replay-position" className="mt-4 text-xs text-zinc-400">
+            Timeline scrubber
+          </Label>
+          <input
+            id="map-riders-replay-position"
+            type="range"
+            min={0}
+            max={Math.max(total - 1, 0)}
+            value={index}
+            onChange={(event) => setIndex(Number(event.target.value))}
+            className="mt-2 w-full accent-emerald-300"
+          />
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            <Button type="button" variant="outline" onClick={() => setIndex((prev) => Math.max(prev - 1, 0))}>← Шаг</Button>
+            <Button type="button" onClick={() => setPlaying((prev) => !prev)} disabled={total < 2} aria-pressed={playing}>
+              {playing ? "Пауза" : "Play"}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => setIndex((prev) => Math.min(prev + 1, Math.max(total - 1, 0)))}>Шаг →</Button>
+          </div>
+          <div className="mt-3 grid grid-cols-3 gap-2">
+            <Button type="button" size="sm" variant={speedMs === 250 ? "default" : "outline"} onClick={() => setSpeedMs(250)} aria-pressed={speedMs === 250}>x2</Button>
+            <Button type="button" size="sm" variant={speedMs === 500 ? "default" : "outline"} onClick={() => setSpeedMs(500)} aria-pressed={speedMs === 500}>x1</Button>
+            <Button type="button" size="sm" variant={speedMs === 1000 ? "default" : "outline"} onClick={() => setSpeedMs(1000)} aria-pressed={speedMs === 1000}>x0.5</Button>
+          </div>
+          <div className="mt-auto pt-4 text-xs text-zinc-500">
+            Replay не пишет данные обратно — это безопасный просмотр уже сохранённого трека.
+          </div>
+        </aside>
       </div>
     </div>
   );

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -181,3 +181,13 @@ This root file stays intentionally compact so operators and agents can load it q
 - `notes`: Completed SupaPlan `RENT-P3.1` and `FIX-ORPHAN-INVOICE`: public storefront controls now expose stronger labels/current/pressed states, overlay focus containment/return was tightened in self-review, and failed Telegram XTR sends clean up newly-created pending franchize invoices.
 - `next_step`: Merge PR, then run browser accessibility smoke on `/franchize/vip-bike` and a Telegram invoice failure-path smoke with test credentials.
 - `risks`: Visual a11y smoke depends on a bootable local/prod runtime; invoice delivery/failure verification depends on Telegram bot credentials.
+
+### 2026-05-06 — FRZ-R6 VIP BIKE company + service hub
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-06T23:58:00Z
+- `owner`: codex
+- `supaplan_task`: 4de0a224-e88d-4bf7-909f-f27e96a2d5e1
+- `notes`: Re-checked the stale ready_for_pr task with no visible PR and implemented the missing public-facing company/service hub on `/vipbikerental`: one section now explains VIP BIKE as rental + service + rider community, links to catalog, service contact and MapRiders, and keeps the existing service cards/FAQ as supporting detail.
+- `next_step`: Production-smoke `/vipbikerental` with real `vip-bike` catalog data and verify service CTA destination with operator.
+- `risks`: Service CTA currently routes to the existing Telegram operator contact until a dedicated service booking route exists.

--- a/gateway/telegram/webhook-handler.ts
+++ b/gateway/telegram/webhook-handler.ts
@@ -28,6 +28,152 @@ function calculateDistanceMeters(lat1: number, lon1: number, lat2: number, lon2:
     return calculateDistance(lat1, lon1, lat2, lon2) * 1000;
 }
 
+
+type TelegramLocationPayload = {
+    latitude: number;
+    longitude: number;
+    speed?: number | null;
+    heading?: number | null;
+    horizontal_accuracy?: number | null;
+};
+
+function getTelegramCapturedAt(message: any) {
+    const unixSeconds = Number(message.edit_date || message.date || 0);
+    if (Number.isFinite(unixSeconds) && unixSeconds > 0) {
+        return new Date(unixSeconds * 1000).toISOString();
+    }
+    return new Date().toISOString();
+}
+
+async function broadcastMapRiderMove(crewSlug: string, payload: Record<string, unknown>) {
+    const channel = supabaseAdmin.channel(`map-riders:${crewSlug}`);
+    await new Promise<void>((resolve) => {
+        const timeout = setTimeout(async () => {
+            await supabaseAdmin.removeChannel(channel);
+            resolve();
+        }, 1200);
+
+        channel.subscribe(async (status) => {
+            if (status !== "SUBSCRIBED") return;
+            await channel.send({ type: "broadcast", event: "rider:move", payload });
+            clearTimeout(timeout);
+            await supabaseAdmin.removeChannel(channel);
+            resolve();
+        });
+    });
+}
+
+async function mirrorTelegramLocationToActiveMapRiderSession(userId: string, location: TelegramLocationPayload, capturedAt: string) {
+    const { data: activeSession, error: sessionError } = await supabaseAdmin
+        .from("map_rider_sessions")
+        .select("id, crew_slug, sharing_enabled, started_at, stats")
+        .eq("user_id", userId)
+        .eq("status", "active")
+        .eq("sharing_enabled", true)
+        .order("started_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+    if (sessionError) {
+        throw sessionError;
+    }
+
+    if (!activeSession) {
+        return false;
+    }
+
+    const crewSlug = activeSession.crew_slug || "vip-bike";
+    const speedKmh = Number(location.speed || 0) * 3.6;
+    const heading = location.heading != null ? Number(location.heading) : null;
+    const accuracyMeters = location.horizontal_accuracy != null ? Number(location.horizontal_accuracy) : null;
+
+    const { data: previousLiveLocation } = await supabaseAdmin
+        .from("live_locations")
+        .select("lat,lng,updated_at")
+        .eq("user_id", userId)
+        .eq("crew_slug", crewSlug)
+        .maybeSingle();
+
+    if (previousLiveLocation?.updated_at) {
+        const lastUpdatedMs = new Date(previousLiveLocation.updated_at).getTime();
+        const currentUpdatedMs = new Date(capturedAt).getTime();
+        const elapsedMs = Math.max(currentUpdatedMs - lastUpdatedMs, 0);
+        const distanceMeters = calculateDistanceMeters(
+            Number(location.latitude),
+            Number(location.longitude),
+            Number(previousLiveLocation.lat),
+            Number(previousLiveLocation.lng),
+        );
+
+        if (elapsedMs < TELEGRAM_LOCATION_DEDUPE_WINDOW_MS && distanceMeters < TELEGRAM_LOCATION_DEDUPE_METERS) {
+            logger.info(`[MapRiders Telegram GPS] Skipping duplicate live-location burst for user ${userId}`);
+            return true;
+        }
+    }
+
+    const [{ error: liveError }, { error: sessionUpdateError }, { error: pointInsertError }] = await Promise.all([
+        supabaseAdmin.from("live_locations").upsert(
+            {
+                user_id: userId,
+                crew_slug: crewSlug,
+                lat: Number(location.latitude),
+                lng: Number(location.longitude),
+                speed_kmh: speedKmh,
+                heading,
+                is_riding: true,
+                updated_at: capturedAt,
+            },
+            { onConflict: "user_id" },
+        ),
+        supabaseAdmin
+            .from("map_rider_sessions")
+            .update({
+                latest_lat: Number(location.latitude),
+                latest_lon: Number(location.longitude),
+                latest_speed_kmh: speedKmh,
+                last_ping_at: capturedAt,
+                updated_at: new Date().toISOString(),
+                stats: {
+                    ...((activeSession.stats as Record<string, unknown> | null) || {}),
+                    telegramNativeGps: {
+                        lastCapturedAt: capturedAt,
+                        lastAccuracyMeters: accuracyMeters,
+                        source: "telegram-webhook",
+                    },
+                },
+            })
+            .eq("id", activeSession.id),
+        supabaseAdmin.from("map_rider_points").insert({
+            session_id: activeSession.id,
+            user_id: userId,
+            crew_slug: crewSlug,
+            lat: Number(location.latitude),
+            lon: Number(location.longitude),
+            speed_kmh: speedKmh,
+            heading_deg: heading,
+            accuracy_meters: accuracyMeters,
+            captured_at: capturedAt,
+        }),
+    ]);
+
+    if (liveError || sessionUpdateError || pointInsertError) {
+        throw liveError || sessionUpdateError || pointInsertError;
+    }
+
+    await broadcastMapRiderMove(crewSlug, {
+        user_id: userId,
+        lat: Number(location.latitude),
+        lng: Number(location.longitude),
+        speed_kmh: speedKmh,
+        heading,
+        updated_at: capturedAt,
+        source: "telegram-native-live-location",
+    });
+
+    logger.info(`[MapRiders Telegram GPS] Mirrored native live-location into active session ${activeSession.id} for user ${userId}`);
+    return true;
+}
+
 async function handlePhotoMessage(message: any) {
     const userId = message.from.id.toString();
     const chatId = message.chat.id;
@@ -164,10 +310,22 @@ async function handlePhotoMessage(message: any) {
 }
 
 // --- ИЗМЕНЕНО: Эта функция теперь является универсальным обработчиком геолокации ---
-async function handleLocationMessage(message: any) {
+async function handleLocationMessage(message: any, options: { preferMapRiders?: boolean } = {}) {
     const userId = message.from.id.toString();
     const chatId = message.chat.id;
     const { latitude, longitude } = message.location;
+    const capturedAt = getTelegramCapturedAt(message);
+
+    if (options.preferMapRiders) {
+        try {
+            const mirroredToMapRiders = await mirrorTelegramLocationToActiveMapRiderSession(userId, message.location, capturedAt);
+            if (mirroredToMapRiders) {
+                return;
+            }
+        } catch (error) {
+            logger.error(`[MapRiders Telegram GPS] Could not mirror native live-location for user ${userId}`, error);
+        }
+    }
 
     // --- ДОБАВЛЕНО: Сценарий 1 - Обновление геолокации члена экипажа на смене ---
     try {
@@ -202,7 +360,7 @@ async function handleLocationMessage(message: any) {
                 }
             }
 
-            const capturedAt = new Date().toISOString();
+            const shiftCapturedAt = new Date().toISOString();
             const { data: previousLiveLocation } = await supabaseAdmin
                 .from("live_locations")
                 .select("lat,lng,updated_at")
@@ -236,7 +394,7 @@ async function handleLocationMessage(message: any) {
                         speed_kmh: Number(message.location?.speed || 0) * 3.6,
                         heading: message.location?.heading != null ? Number(message.location.heading) : null,
                         is_riding: true,
-                        updated_at: capturedAt,
+                        updated_at: shiftCapturedAt,
                     },
                     { onConflict: "user_id" },
                 );
@@ -263,7 +421,7 @@ async function handleLocationMessage(message: any) {
                             lng: Number(longitude),
                             speed_kmh: Number(message.location?.speed || 0) * 3.6,
                             heading: message.location?.heading != null ? Number(message.location.heading) : null,
-                            updated_at: capturedAt,
+                            updated_at: shiftCapturedAt,
                             source: "telegram-webhook",
                         },
                     });
@@ -361,11 +519,11 @@ export async function handleTelegramWebhook(request: Request) {
     } else if (update.message?.photo) {
       await handlePhotoMessage(update.message);
     } else if (update.message?.location) {
-      await handleLocationMessage(update.message);
+      await handleLocationMessage(update.message, { preferMapRiders: Boolean(update.message.location?.live_period) });
     } else if (update.edited_message?.location) {
       // Live-location updates from Telegram arrive as edited_message payloads.
       // We support them to keep MapRiders location feed in sync for Telegram-first flow.
-      await handleLocationMessage(update.edited_message);
+      await handleLocationMessage(update.edited_message, { preferMapRiders: true });
     } else if (update.message?.text || update.callback_query) {
       await handleCommand(update);
     } else {


### PR DESCRIPTION
### Motivation
- Ingest Telegram native live-location updates into the MapRiders write path so Telegram-first GPS sharing updates live feed, session state and replay history instead of being lost to legacy handlers. 
- Provide a focused full-screen route replay cockpit with timeline scrubber, keyboard controls and visual route projection to review saved rides. 
- Add a public-facing company/service hub section to the VIP Bike storefront to expose rental, service and MapRiders links. 

### Description
- Added roadmap/backlog notes (`app/api/map-riders/todo.md` and franchise TODOs) and updated `docs/THE_FRANCHEEZEPLAN.md` to reflect the new tasks and UI slice. 
- Implemented `VipBikeCompanyServiceHub` and inserted it into `VipBikeRentalClient.tsx` to show company facts and service lanes linking to catalog, service contact and MapRiders. 
- Enhanced `RidersDrawer.tsx` with a new `ReplayFullscreen` cockpit that projects GPS points to an SVG, computes path/played-path and summary stats, exposes a timeline scrubber, play/pause/step controls, speed presets and keyboard accessibility. 
- Extended the Telegram webhook handler (`gateway/telegram/webhook-handler.ts`) with helpers (`calculateDistance*`, `getTelegramCapturedAt`, `broadcastMapRiderMove`, `mirrorTelegramLocationToActiveMapRiderSession`) and logic to: dedupe burst updates, detect active `map_rider_sessions`, persist native Telegram GPS into `live_locations`/`map_rider_sessions`/`map_rider_points`, broadcast `rider:move` on `map-riders:{crewSlug}`, and fall back to legacy crew-shift/location handlers when no active MapRiders session exists. 
- Modified `handleLocationMessage` to accept `preferMapRiders` and to route `message.location`/`edited_message.location` appropriately (live_period edits prefer MapRiders). 

### Testing
- Ran the smoke script `npm run qa:map-riders` to exercise the live map and split APIs and the run passed for `vip-bike` and associated endpoints. 
- Playwright browser engines failed in the CI runner due to missing system browser libraries which caused automated headless UI captures to fail, and fallback captures were produced via `thum.io` (runner failure noted). 
- Replayed route UI and telemetry flows were exercised in the smoke evidence pack that produced screenshot artifacts referenced in the repo (automated capture fallback succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd354c48c8324ab5a1d3e7777f26d)
supaplan_task: b2fb8b78-dc2d-4913-b379-caf22eb1c4e5, 696922bd-8186-4903-ab7b-ef999d7ac11b, 4de0a224-e88d-4bf7-909f-f27e96a2d5e1