### PR TITLE
Add temporary franchize cart API and client sync; minor typings/comments cleanup

### DIFF
--- a/app/api/franchize/temp-cart/route.ts
+++ b/app/api/franchize/temp-cart/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { upsertTempFranchizeCartAction } from "@/contexts/actions";
+
+export async function POST(request: NextRequest) {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return NextResponse.json({ ok: false, error: "Body must be an object" }, { status: 400 });
+  }
+
+  const { cartId, cartBySlug } = payload as {
+    cartId?: unknown;
+    cartBySlug?: unknown;
+  };
+
+  if (typeof cartId !== "string" || !cartId.trim()) {
+    return NextResponse.json({ ok: false, error: "Missing cartId" }, { status: 400 });
+  }
+
+  if (!cartBySlug || typeof cartBySlug !== "object" || Array.isArray(cartBySlug)) {
+    return NextResponse.json({ ok: false, error: "cartBySlug must be an object" }, { status: 400 });
+  }
+
+  const result = await upsertTempFranchizeCartAction({
+    cartId,
+    cartBySlug: cartBySlug as Record<string, unknown>,
+  });
+
+  return NextResponse.json(result, { status: result.ok ? 200 : 500 });
+}

--- a/app/franchize/hooks/useFranchizeCart.ts
+++ b/app/franchize/hooks/useFranchizeCart.ts
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAppContext } from "@/contexts/AppContext";
-import { upsertTempFranchizeCartAction } from "@/contexts/actions";
 import { isMockUserModeEnabled } from "@/lib/mockUserMode";
 
 export type FranchizeCartOptions = {
@@ -29,6 +28,22 @@ type CartEnvelope = {
 const CART_STORAGE_PREFIX = "franchize-cart";
 const CART_SYNC_EVENT = "franchize-cart-sync";
 const TEMP_CART_ID_KEY = "franchize-temp-cart-id";
+
+async function syncTempFranchizeCart(input: {
+  cartId: string;
+  cartBySlug: Record<string, unknown>;
+}) {
+  try {
+    await fetch("/api/franchize/temp-cart", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+  } catch {
+    // Temporary carts are best-effort. Local storage remains the source of truth
+    // until a server-side checkpoint can persist or consume the anonymous cart.
+  }
+}
 
 const DEFAULT_OPTIONS: FranchizeCartOptions = {
   package: "Базовый",
@@ -204,7 +219,7 @@ export function useFranchizeCart(slug: string) {
     if (window.sessionStorage.getItem(syncHash) === nextHash) return;
     window.sessionStorage.setItem(syncHash, nextHash);
 
-    void upsertTempFranchizeCartAction({ cartId, cartBySlug: payloadBySlug });
+    void syncTempFranchizeCart({ cartId, cartBySlug: payloadBySlug });
   }, [cart, dbUser?.user_id, isHydrated, slug, tempCartFeatureEnabled]);
 
   // 3. Sync Listener

--- a/data/questions.ts
+++ b/data/questions.ts
@@ -1,4 +1,6 @@
 // /data/questions.ts
+
+interface Answer {
   text: string
   result: string
 }
@@ -8,7 +10,7 @@ interface Question {
   text: string
   answers: Answer[]
   theme: string
-}*/
+}
 
 export const questions: Question[] = [
   {

--- a/supabase/functions/arbitrage-scan-instance/index.ts
+++ b/supabase/functions/arbitrage-scan-instance/index.ts
@@ -246,18 +246,16 @@ Network Fee: $${networkFee}
   });
 });
 
-/*
-To Deploy & Schedule:
-1. Set ENV Vars in Supabase Dashboard for this function:
-   - SUPABASE_URL
-   - SUPABASE_SERVICE_ROLE_KEY
-   - TELEGRAM_BOT_TOKEN
-   - CRON_SECRET (for authorizing cron trigger)
-   - TEST_USER_ID_FOR_ARBITRAGE_SCAN (optional, for testing)
-2. Deploy: `supabase functions deploy arbitrage-scan-instance --no-verify-jwt`
-3. Schedule (e.g., every 5 minutes for user-specific scans, or less frequently for batch scans):
-   `SELECT cron.schedule('arbitrage-scan-user-TARGETUSERID', '*/5 * * * *', 'SELECT net.http_post(url:=''https://YOUR_PROJECT_REF.supabase.co/functions/v1/arbitrage-scan-instance'', headers:=''{"Authorization": "Bearer YOUR_CRON_SECRET", "Content-Type": "application/json"}'', body:=''{"userId": "TARGET_USER_ID"}''::jsonb)');`
-   Replace YOUR_PROJECT_REF, YOUR_CRON_SECRET, and TARGET_USER_ID.
-   Or for a generic run (if function logic supports batching users):
-   `SELECT cron.schedule('arbitrage-scan-batch', '0 * * * *', 'SELECT net.http_post(url:=''https://YOUR_PROJECT_REF.supabase.co/functions/v1/arbitrage-scan-instance'', headers:=''{"Authorization": "Bearer YOUR_CRON_SECRET"}'')');`
-*/
+// To Deploy & Schedule:
+// 1. Set ENV Vars in Supabase Dashboard for this function:
+//    - SUPABASE_URL
+//    - SUPABASE_SERVICE_ROLE_KEY
+//    - TELEGRAM_BOT_TOKEN
+//    - CRON_SECRET (for authorizing cron trigger)
+//    - TEST_USER_ID_FOR_ARBITRAGE_SCAN (optional, for testing)
+// 2. Deploy: `supabase functions deploy arbitrage-scan-instance --no-verify-jwt`
+// 3. Schedule (e.g., every 5 minutes for user-specific scans, or less frequently for batch scans):
+//    `SELECT cron.schedule('arbitrage-scan-user-TARGETUSERID', '*/5 * * * *', 'SELECT net.http_post(url:=''https://YOUR_PROJECT_REF.supabase.co/functions/v1/arbitrage-scan-instance'', headers:=''{"Authorization": "Bearer YOUR_CRON_SECRET", "Content-Type": "application/json"}'', body:=''{"userId": "TARGET_USER_ID"}''::jsonb)');`
+//    Replace YOUR_PROJECT_REF, YOUR_CRON_SECRET, and TARGET_USER_ID.
+//    Or for a generic run (if function logic supports batching users):
+//    `SELECT cron.schedule('arbitrage-scan-batch', '0 * * * *', 'SELECT net.http_post(url:=''https://YOUR_PROJECT_REF.supabase.co/functions/v1/arbitrage-scan-instance'', headers:=''{"Authorization": "Bearer YOUR_CRON_SECRET"}'')');`


### PR DESCRIPTION
### Motivation

- Provide a lightweight server endpoint to persist anonymous/franchize temp carts from the client for best-effort synchronization. 
- Replace a direct server-action import with a client-side fetch to avoid server-only action usage in client code and fix some typings/comments in data files.

### Description

- Add `POST /api/franchize/temp-cart` handler in `app/api/franchize/temp-cart/route.ts` that validates JSON input and calls `upsertTempFranchizeCartAction` to persist a `cartId` and `cartBySlug` envelope. 
- Introduce `syncTempFranchizeCart` in `app/franchize/hooks/useFranchizeCart.ts` and switch the hook to call it (`fetch('/api/franchize/temp-cart')`) instead of importing `upsertTempFranchizeCartAction` into client code. 
- Keep local storage/sessionStorage logic to deduplicate syncs and preserve local source-of-truth semantics when the network call fails. 
- Small tidy-ups: add an `Answer` interface and fix brace/comment layout in `data/questions.ts`, and convert a large block comment to line comments in the Supabase function `arbitrage-scan-instance` for readability.

### Testing

- Ran the repository test and lint commands (`pnpm test` and `pnpm lint`) against the modified codebase and they completed successfully. 
- No new automated tests were added for the temp-cart endpoint; existing test coverage was used to validate no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd4dc58008324920df1d55dcd646f)