### PR TITLE
Fix Telegram WebApp BackButton; normalize Seqvens bike id; tighten MapRiders QA

### DIFF
--- a/app/franchize/[slug]/electro-enduro/page.tsx
+++ b/app/franchize/[slug]/electro-enduro/page.tsx
@@ -21,14 +21,10 @@ const isRentEnabled = (value: unknown) =>
   String(value).toLowerCase() === "1" ||
   String(value).toLowerCase() === "true";
 const SALE_ID_OVERRIDES = new Set([
-  "sequence-zero",
-  "seqvenz-zero",
   "falcon-gt-2025",
   "500gt",
 ]);
 const RENT_ID_OVERRIDES = new Set([
-  "sequence-zero",
-  "seqvenz-zero",
   "falcon-gt-2025",
   "500gt",
 ]);
@@ -137,7 +133,7 @@ export default async function ElectroEnduroPage({
     );
   });
   const featuredRentItems = rentItems
-    .filter((item) => item.id.toLowerCase().includes("sequence-zero"))
+    .filter((item) => item.id.toLowerCase().includes("seqvens-zero"))
     .slice(0, 3);
   const featuredSaleItems = saleItems
     .filter((item) => item.id.toLowerCase().includes("falcon-gt-2025"))

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -213,3 +213,12 @@ This root file stays intentionally compact so operators and agents can load it q
 - `risks`: Electro-Enduro fallback prevents an empty showroom but does not replace the need to seed/repair production Supabase crew + catalog rows.
 
 - 2026-05-07 — VIP Bike QA pass: reduced `/vipbikerental` post-hero depth, contained configurator styles, made configurator bike imagery readable with fallback art, removed the mustard footer from the configurator flow, compacted shared footer scale, hardened Electro-Enduro contrast, and added a temporary non-empty VipBike fallback catalog for hydration failures.
+
+### 2026-05-07 — Telegram back + VIP Bike MapRiders triage
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-07T00:00:00Z
+- `owner`: codex
+- `notes`: Fixed Telegram WebApp back handling to use an internal SPA history stack instead of `router.back()`, corrected Seqvens Zero code identifiers to `seqvens-zero` while intentionally preserving existing `carpix/seqvenz-zero/*` storage paths, and tightened MapRiders QA to smoke the requested `vip-bike` slug APIs with JSON success checks.
+- `next_step`: Field-test Telegram BackButton in the real bot WebApp and collect the exact MapRiders failing action if testers still report “doesn't work”.
+- `risks`: CLI smoke confirms the route/APIs are alive, but two-phone live GPS and Telegram BackButton behavior still need real Telegram WebApp device verification.

--- a/hooks/useTelegramBackButton.ts
+++ b/hooks/useTelegramBackButton.ts
@@ -1,51 +1,94 @@
 "use client";
 
-import { useEffect } from 'react';
-import { useRouter, usePathname } from 'next/navigation';
-import { useAppContext } from '@/contexts/AppContext';
-import { debugLogger as logger } from '@/lib/debugLogger';
+import { useEffect, useRef } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { useAppContext } from "@/contexts/AppContext";
+import { debugLogger as logger } from "@/lib/debugLogger";
+
+const MAX_INTERNAL_HISTORY = 20;
+
+function fallbackPathFor(pathname: string) {
+  const franchizeMatch = pathname.match(/^\/franchize\/([^/]+)(?:\/.*)?$/);
+  if (franchizeMatch && pathname !== `/franchize/${franchizeMatch[1]}`) {
+    return `/franchize/${franchizeMatch[1]}`;
+  }
+
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length > 1) {
+    return `/${segments.slice(0, -1).join("/")}`;
+  }
+
+  return "/";
+}
 
 export function useTelegramBackButton() {
   const { tg, isInTelegramContext } = useAppContext();
   const router = useRouter();
   const pathname = usePathname();
+  const internalHistoryRef = useRef<string[]>([]);
+
+  useEffect(() => {
+    if (!pathname) return;
+
+    const currentPath =
+      typeof window !== "undefined"
+        ? `${window.location.pathname}${window.location.search}${window.location.hash}`
+        : pathname;
+    const stack = internalHistoryRef.current;
+    const latest = stack[stack.length - 1];
+
+    if (latest !== currentPath) {
+      stack.push(currentPath);
+      if (stack.length > MAX_INTERNAL_HISTORY) {
+        stack.splice(0, stack.length - MAX_INTERNAL_HISTORY);
+      }
+    }
+  }, [pathname]);
 
   useEffect(() => {
     if (!isInTelegramContext || !tg?.BackButton) {
-      // Если мы не в Telegram или объект кнопки недоступен, ничего не делаем
       return;
     }
 
     const backButton = tg.BackButton;
 
     const handleBackClick = () => {
-      logger.info('[Telegram BackButton] Back button clicked. Navigating back.');
-      router.back();
+      const stack = internalHistoryRef.current;
+      const currentPath =
+        typeof window !== "undefined"
+          ? `${window.location.pathname}${window.location.search}${window.location.hash}`
+          : pathname;
+
+      while (stack.length > 0 && stack[stack.length - 1] === currentPath) {
+        stack.pop();
+      }
+
+      const previousPath = stack.pop();
+      const targetPath = previousPath || fallbackPathFor(pathname || "/");
+
+      logger.info(
+        `[Telegram BackButton] Back button clicked. Navigating with SPA push to "${targetPath}" instead of native history back.`,
+      );
+
+      router.push(targetPath);
     };
 
-    // Показываем кнопку на всех страницах, кроме главной ('/')
-    if (pathname !== '/') {
+    if (pathname !== "/") {
       if (!backButton.isVisible) {
         logger.debug(`[Telegram BackButton] Path is "${pathname}". Showing button.`);
         backButton.show();
       }
-      // Устанавливаем или обновляем обработчик
       backButton.onClick(handleBackClick);
-    } else {
-      // Скрываем кнопку на главной странице
-      if (backButton.isVisible) {
-        logger.debug(`[Telegram BackButton] Path is "/". Hiding button.`);
-        backButton.hide();
-      }
+    } else if (backButton.isVisible) {
+      logger.debug('[Telegram BackButton] Path is "/". Hiding button.');
+      backButton.hide();
     }
 
-    // Очистка при размонтировании компонента или изменении пути
     return () => {
       if (isInTelegramContext && tg?.BackButton) {
         logger.debug(`[Telegram BackButton] Cleanup: removing onClick handler for path "${pathname}".`);
-        // Важно убирать обработчик, чтобы избежать утечек памяти или вызова старых функций
         tg.BackButton.offClick(handleBackClick);
       }
     };
-  }, [pathname, router, tg, isInTelegramContext]); // Перезапускаем эффект при смене пути
+  }, [pathname, router, tg, isInTelegramContext]);
 }

--- a/lib/fleet-manifest.ts
+++ b/lib/fleet-manifest.ts
@@ -117,7 +117,7 @@ export const V_FLEET_ASSETS: VehicleAsset[] = [
     specs: { category: 'Naked', gallery: [] }
   },
   {
-    id: 'seqvenz-zero', make: 'Seqvenz', model: 'Zero',
+    id: 'seqvens-zero', make: 'Seqvens', model: 'Zero',
     description: "Мощный крутой электробайк с дерзким силуэтом и уверенной тягой. Мощность двигателя 15–30 кВт, запас хода до 300 километров. Базовую карточку уже добавили, расширенное описание и детали дополним следующим апдейтом.",
     daily_price_rub: 15000,
     image_url: 'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/seqvenz-zero/image_1.jpg',

--- a/scripts/map-riders-qa-check.mjs
+++ b/scripts/map-riders-qa-check.mjs
@@ -5,12 +5,14 @@ import { execFileSync } from 'node:child_process'
 const baseUrl = (process.env.MAP_RIDERS_QA_BASE_URL || 'https://v0-car-test.vercel.app').replace(/\/$/, '')
 const slug = process.env.MAP_RIDERS_QA_SLUG || 'vip-bike'
 
+const slugQuery = `?slug=${encodeURIComponent(slug)}`
+
 const checks = [
   { name: 'map-page', path: `/franchize/${slug}/map-riders` },
-  { name: 'api-overview', path: '/api/map-riders/overview' },
-  { name: 'api-leaderboard', path: '/api/map-riders/leaderboard' },
-  { name: 'api-health', path: '/api/map-riders/health' },
-  { name: 'api-legacy', path: '/api/map-riders' },
+  { name: 'api-overview', path: `/api/map-riders/overview${slugQuery}`, expectsJsonSuccess: true },
+  { name: 'api-leaderboard', path: `/api/map-riders/leaderboard${slugQuery}`, expectsJsonSuccess: true },
+  { name: 'api-health', path: `/api/map-riders/health${slugQuery}`, expectsJsonSuccess: true },
+  { name: 'api-legacy', path: `/api/map-riders${slugQuery}`, expectsJsonSuccess: true },
 ]
 
 const failures = []
@@ -18,16 +20,26 @@ const failures = []
 for (const check of checks) {
   const url = `${baseUrl}${check.path}`
   try {
-    const statusCode = Number(
-      execFileSync('curl', ['-sS', '-L', '-o', '/dev/null', '-w', '%{http_code}', url], {
-        encoding: 'utf-8',
-      }).trim(),
-    )
+    const response = execFileSync('curl', ['-sS', '-L', '-w', '\n%{http_code}', url], {
+      encoding: 'utf-8',
+    })
+    const splitAt = response.lastIndexOf('\n')
+    const body = splitAt >= 0 ? response.slice(0, splitAt) : ''
+    const statusCode = Number(splitAt >= 0 ? response.slice(splitAt + 1).trim() : response.trim())
 
     if (!Number.isFinite(statusCode) || statusCode < 200 || statusCode > 299) {
       failures.push(`${check.name}: HTTP ${statusCode}`)
       console.error(`❌ ${check.name.padEnd(14)} ${url} -> ${statusCode}`)
       continue
+    }
+
+    if (check.expectsJsonSuccess) {
+      const json = JSON.parse(body)
+      if (json?.success !== true) {
+        failures.push(`${check.name}: JSON success was not true`)
+        console.error(`❌ ${check.name.padEnd(14)} ${url} -> JSON success=false`)
+        continue
+      }
     }
 
     console.log(`✅ ${check.name.padEnd(14)} ${url} -> ${statusCode}`)

--- a/supabase/migrations/20260322120000_add_seqvenz_zero.sql
+++ b/supabase/migrations/20260322120000_add_seqvenz_zero.sql
@@ -13,13 +13,13 @@ INSERT INTO public.cars (
   crew_id
 )
 VALUES (
-  'seqvenz-zero',
-  'Seqvenz',
+  'seqvens-zero',
+  'Seqvens',
   'Zero',
   'Мощный крутой электробайк с дерзким силуэтом и уверенной тягой. Мощность двигателя 15–30 кВт, запас хода до 300 километров. Базовую карточку уже добавили, расширенное описание и детали дополним следующим апдейтом.',
   15000,
   'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/seqvenz-zero/image_1.jpg',
-  '/rent/seqvenz-zero',
+  '/rent/seqvens-zero',
   false,
   'bike',
   jsonb_build_object(


### PR DESCRIPTION
### Motivation
- Prevent Telegram WebApp from collapsing when users press Back by avoiding `router.back()` when browser history is empty and ensuring SPA-safe navigation in the mini-app.
- Remove incorrect hardcoded bike id assumptions that referenced `sequence-zero`/`seqvenz-zero` and align code to the correct identifier `seqvens-zero` while preserving existing image storage paths.
- Verify MapRiders surface health after these changes and make the smoke-check more specific to the operator `vip-bike` slug.

### Description
- Replaced naive `router.back()` handling with an internal SPA history stack, a `fallbackPathFor()` helper and `router.push(...)` navigation in `hooks/useTelegramBackButton.ts` to provide deterministic back behavior inside Telegram WebApp and to keep the BackButton visible/cleaned up correctly.
- Removed the `sequence-zero`/`seqvenz-zero` overrides in `app/franchize/[slug]/electro-enduro/page.tsx` and updated the featured filter to use `seqvens-zero`.
- Normalized local identifiers in `lib/fleet-manifest.ts` and the bootstrap migration `supabase/migrations/20260322120000_add_seqvenz_zero.sql` to `seqvens-zero` / `Seqvens`, while deliberately preserving the existing storage URL paths under `carpix/seqvenz-zero/*` so operator assets already uploaded remain valid.
- Hardened the MapRiders smoke script `scripts/map-riders-qa-check.mjs` to include the `?slug=` query, validate JSON `success` in split API responses, and added a small diary note in `docs/THE_FRANCHEEZEPLAN.md` describing the triage.

### Testing
- Ran `npm run qa:map-riders` and the slug-specific map page and all split APIs returned HTTP 200 with JSON `success: true` (smoke passed).
- Ran `npx eslint hooks/useTelegramBackButton.ts app/franchize/[slug]/electro-enduro/page.tsx scripts/map-riders-qa-check.mjs` which returned clean for the targeted files modified in this PR.
- Built the app with `npm run build` which succeeded and generated the optimized production build (build logs show expected environment warnings unrelated to this change).
- Ran `npm run lint` which exited non-zero due to pre-existing repo-wide lint errors and warnings outside the scope of this PR (reported but unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc450f660c83249f4250465e523ca9)