### PR TITLE
franchize: add partner onboarding & sales pages; extract MapRiders session manager

### DIFF
--- a/app/franchize/[slug]/onboarding/page.tsx
+++ b/app/franchize/[slug]/onboarding/page.tsx
@@ -1,0 +1,139 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CheckCircle2, ClipboardCheck, FileText, Handshake, MessageCircle, ShieldCheck } from "lucide-react";
+import { getFranchizeBySlug } from "@/app/franchize/actions";
+import { CrewFooter } from "@/app/franchize/components/CrewFooter";
+import { CrewHeader } from "@/app/franchize/components/CrewHeader";
+import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { buildFranchizeSectionMetadata } from "../metadata";
+
+interface PartnerOnboardingPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+const checklist = [
+  {
+    title: "Заявка и контакт",
+    text: "Фиксируем Telegram/телефон, город, формат партнёрства и ожидаемый объём байков.",
+    icon: MessageCircle,
+  },
+  {
+    title: "Парк и роли",
+    text: "Описываем модели, статусы аренды/продажи, ответственных за выдачу, сервис и контент.",
+    icon: ClipboardCheck,
+  },
+  {
+    title: "Документы и правила",
+    text: "Согласуем договор, депозит, чеклист выдачи, ограничения по району и страховочные сценарии.",
+    icon: FileText,
+  },
+  {
+    title: "Пилотный запуск",
+    text: "Включаем витрину, тестовый заказ, MapRiders-сценарий и короткий smoke-check в Telegram WebApp.",
+    icon: ShieldCheck,
+  },
+];
+
+const readinessRows = [
+  ["Брендинг", "лого, цвета, оффер, адрес и рабочие часы"],
+  ["Каталог", "аренда, продажа, электробайки, аксессуары"],
+  ["Операции", "выдача, возврат, сервис, админ-доступы"],
+  ["Продажи", "новые/электро/б/у/trade-in лиды и тест-драйв"],
+  ["Комьюнити", "MapRiders, события, партнёры и Telegram-канал"],
+];
+
+export async function generateMetadata({ params }: PartnerOnboardingPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Partner onboarding",
+    sectionDescription: "Чеклист подключения партнёра VIP-bike к франшизной витрине.",
+    pathSuffix: "/onboarding",
+  });
+}
+
+export default async function PartnerOnboardingPage({ params }: PartnerOnboardingPageProps) {
+  const { slug } = await params;
+  const { crew, items } = await getFranchizeBySlug(slug);
+  const crewSlug = crew.slug || slug;
+  const surface = crewPaletteForSurface(crew.theme);
+  const brandName = crew.header.brandName || crew.name || "VIP BIKE";
+  const telegramHref = crew.contacts.telegram ? `https://t.me/${crew.contacts.telegram.replace("@", "")}` : "https://t.me/oneBikePlsBot";
+
+  return (
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader crew={crew} activePath={`/franchize/${crewSlug}/onboarding`} groupLinks={items.map((item) => item.category)} />
+      <div
+        className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-16 pt-20 md:pt-24"
+        style={{
+          ["--onboarding-accent" as string]: crew.theme.palette.accentMain,
+          ["--onboarding-border" as string]: crew.theme.palette.borderSoft,
+          ["--onboarding-card" as string]: surface.subtleCard.backgroundColor,
+          color: crew.theme.palette.textPrimary,
+        }}
+      >
+        <section className="overflow-hidden rounded-3xl border border-[var(--onboarding-border)] bg-[var(--onboarding-card)] p-6 shadow-2xl shadow-black/20 md:p-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--onboarding-accent)]">FRZ-R4 • partner onboarding</p>
+          <div className="mt-4 grid gap-8 lg:grid-cols-[1.1fr,0.9fr] lg:items-end">
+            <div>
+              <h1 className="font-orbitron text-4xl leading-tight md:text-6xl">Подключение партнёра {brandName}</h1>
+              <p className="mt-4 max-w-2xl text-base opacity-70 md:text-lg">
+                Один понятный маршрут от первого сообщения до живой витрины: каталог, продажи, аренда, MapRiders и операционные роли без хаоса в чатах.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <a href={telegramHref} target="_blank" rel="noreferrer" className="rounded-full bg-[var(--onboarding-accent)] px-5 py-3 text-sm font-semibold text-black transition hover:brightness-110">
+                  Начать в Telegram
+                </a>
+                <Link href={`/franchize/${crewSlug}/sales`} className="rounded-full border border-current/20 px-5 py-3 text-sm font-semibold transition hover:border-current/50">
+                  Посмотреть sales vertical
+                </Link>
+              </div>
+            </div>
+            <div className="rounded-3xl border border-current/10 bg-black/25 p-5">
+              <div className="flex items-center gap-3 text-[var(--onboarding-accent)]">
+                <Handshake className="h-6 w-6" />
+                <span className="text-sm font-semibold uppercase tracking-[0.16em]">Definition of ready</span>
+              </div>
+              <ul className="mt-4 space-y-3 text-sm opacity-75">
+                {readinessRows.map(([label, text]) => (
+                  <li key={label} className="grid gap-1 rounded-2xl border border-current/10 bg-white/[0.03] p-3">
+                    <span className="font-semibold opacity-100">{label}</span>
+                    <span>{text}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-2">
+          {checklist.map((item, index) => {
+            const Icon = item.icon;
+            return (
+              <article key={item.title} className="rounded-3xl border border-[var(--onboarding-border)] bg-[var(--onboarding-card)] p-5">
+                <div className="flex items-center justify-between gap-3">
+                  <Icon className="h-6 w-6 text-[var(--onboarding-accent)]" />
+                  <span className="rounded-full border border-[var(--onboarding-accent)]/35 px-3 py-1 text-xs text-[var(--onboarding-accent)]">шаг {index + 1}</span>
+                </div>
+                <h2 className="mt-4 text-2xl font-semibold">{item.title}</h2>
+                <p className="mt-2 text-sm leading-6 opacity-70">{item.text}</p>
+              </article>
+            );
+          })}
+        </section>
+
+        <section className="rounded-3xl border border-[var(--onboarding-border)] bg-black/25 p-6">
+          <div className="flex items-start gap-3">
+            <CheckCircle2 className="mt-1 h-6 w-6 shrink-0 text-[var(--onboarding-accent)]" />
+            <div>
+              <h2 className="font-orbitron text-2xl">Готово к пилоту, когда всё отмечено</h2>
+              <p className="mt-2 text-sm leading-6 opacity-70">
+                После чеклиста партнёр получает рабочие ссылки на каталог, sales-страницу, аренду, MapRiders и админку. Следующий шаг — тестовый заказ и короткая проверка на реальном телефоне в Telegram WebApp.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+      <CrewFooter crew={crew} />
+    </main>
+  );
+}

--- a/app/franchize/[slug]/sales/page.tsx
+++ b/app/franchize/[slug]/sales/page.tsx
@@ -1,0 +1,158 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, BatteryCharging, Bike, ClipboardList, RefreshCcw, Sparkles } from "lucide-react";
+import { getFranchizeBySlug, type CatalogItemVM } from "@/app/franchize/actions";
+import { CrewFooter } from "@/app/franchize/components/CrewFooter";
+import { CrewHeader } from "@/app/franchize/components/CrewHeader";
+import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { buildFranchizeSectionMetadata } from "../metadata";
+
+interface SalesPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+const verticals = [
+  {
+    id: "new",
+    title: "Новые байки",
+    icon: Sparkles,
+    pitch: "Витрина для моделей под заказ, предпродажного расчёта и тест-драйва.",
+    cta: "Заявка на новый",
+  },
+  {
+    id: "electric",
+    title: "Electro / custom",
+    icon: BatteryCharging,
+    pitch: "Электро-эндуро, батареи, мощность, подвеска и сборка под райдера.",
+    cta: "Собрать электро",
+  },
+  {
+    id: "used",
+    title: "Б/у и проверенные",
+    icon: Bike,
+    pitch: "Лиды на технику с историей аренды, диагностикой и прозрачным состоянием.",
+    cta: "Подобрать б/у",
+  },
+  {
+    id: "trade-in",
+    title: "Trade-in",
+    icon: RefreshCcw,
+    pitch: "Быстрый вход для оценки старого байка и обмена на аренду, новый или электро.",
+    cta: "Оценить байк",
+  },
+];
+
+const isTruthySpec = (value: unknown) => value === true || value === 1 || String(value).toLowerCase() === "true" || String(value).toLowerCase() === "1";
+
+function itemMatchesVertical(item: CatalogItemVM, verticalId: string): boolean {
+  const category = `${item.category} ${item.title} ${item.subtitle}`.toLowerCase();
+  const specs = item.rawSpecs || {};
+  if (verticalId === "electric") return category.includes("electro") || category.includes("электро") || category.includes("e-") || isTruthySpec(specs.electric);
+  if (verticalId === "used") return category.includes("used") || category.includes("б/у") || category.includes("пробег") || isTruthySpec(specs.used);
+  if (verticalId === "trade-in") return isTruthySpec(specs.trade_in) || isTruthySpec(specs.tradeIn) || category.includes("trade");
+  return item.saleAvailable || isTruthySpec(specs.sale) || Number(item.salePrice || 0) > 0;
+}
+
+function previewItems(items: CatalogItemVM[], verticalId: string): CatalogItemVM[] {
+  const matches = items.filter((item) => itemMatchesVertical(item, verticalId));
+  return (matches.length ? matches : items.filter((item) => item.saleAvailable)).slice(0, 3);
+}
+
+export async function generateMetadata({ params }: SalesPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Sales vertical",
+    sectionDescription: "Продажи новых, электро, б/у и trade-in байков для франшизной витрины.",
+    pathSuffix: "/sales",
+  });
+}
+
+export default async function FranchizeSalesPage({ params }: SalesPageProps) {
+  const { slug } = await params;
+  const { crew, items } = await getFranchizeBySlug(slug);
+  const crewSlug = crew.slug || slug;
+  const surface = crewPaletteForSurface(crew.theme);
+  const brandName = crew.header.brandName || crew.name || "VIP BIKE";
+  const saleItems = items.filter((item) => item.saleAvailable || Number(item.salePrice || 0) > 0 || isTruthySpec(item.rawSpecs?.sale));
+
+  return (
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader crew={crew} activePath={`/franchize/${crewSlug}/sales`} groupLinks={items.map((item) => item.category)} />
+      <div
+        className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-16 pt-20 md:pt-24"
+        style={{
+          ["--sales-accent" as string]: crew.theme.palette.accentMain,
+          ["--sales-border" as string]: crew.theme.palette.borderSoft,
+          ["--sales-card" as string]: surface.subtleCard.backgroundColor,
+          color: crew.theme.palette.textPrimary,
+        }}
+      >
+        <section className="rounded-3xl border border-[var(--sales-border)] bg-[var(--sales-card)] p-6 shadow-2xl shadow-black/20 md:p-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--sales-accent)]">FRZ-R8 • sales vertical</p>
+          <div className="mt-4 grid gap-8 lg:grid-cols-[1.15fr,0.85fr] lg:items-end">
+            <div>
+              <h1 className="font-orbitron text-4xl leading-tight md:text-6xl">Продажи {brandName}: new / electric / used / trade-in</h1>
+              <p className="mt-4 max-w-2xl text-base opacity-70 md:text-lg">
+                Страница собирает все продажные сценарии в один операторский вход: от заявки на новый байк до trade-in оценки и электро-конфигуратора.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <Link href={`/franchize/${crewSlug}/configurator`} className="rounded-full bg-[var(--sales-accent)] px-5 py-3 text-sm font-semibold text-black transition hover:brightness-110">
+                  Открыть конфигуратор
+                </Link>
+                <Link href={`/franchize/${crewSlug}/onboarding`} className="rounded-full border border-current/20 px-5 py-3 text-sm font-semibold transition hover:border-current/50">
+                  Partner checklist
+                </Link>
+              </div>
+            </div>
+            <aside className="rounded-3xl border border-current/10 bg-black/25 p-5">
+              <div className="flex items-center gap-3 text-[var(--sales-accent)]">
+                <ClipboardList className="h-6 w-6" />
+                <span className="text-sm font-semibold uppercase tracking-[0.16em]">pipeline snapshot</span>
+              </div>
+              <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
+                <div className="rounded-2xl border border-current/10 bg-white/[0.03] p-3">
+                  <dt className="opacity-55">Продажных SKU</dt>
+                  <dd className="mt-1 text-2xl font-semibold text-[var(--sales-accent)]">{saleItems.length}</dd>
+                </div>
+                <div className="rounded-2xl border border-current/10 bg-white/[0.03] p-3">
+                  <dt className="opacity-55">Вертикалей</dt>
+                  <dd className="mt-1 text-2xl font-semibold text-[var(--sales-accent)]">4</dd>
+                </div>
+              </dl>
+            </aside>
+          </div>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-2">
+          {verticals.map((vertical) => {
+            const Icon = vertical.icon;
+            const previews = previewItems(items, vertical.id);
+            return (
+              <article key={vertical.id} className="rounded-3xl border border-[var(--sales-border)] bg-[var(--sales-card)] p-5">
+                <div className="flex items-start justify-between gap-3">
+                  <Icon className="h-7 w-7 text-[var(--sales-accent)]" />
+                  <span className="rounded-full border border-[var(--sales-accent)]/35 px-3 py-1 text-xs text-[var(--sales-accent)]">{vertical.id}</span>
+                </div>
+                <h2 className="mt-4 text-2xl font-semibold">{vertical.title}</h2>
+                <p className="mt-2 text-sm leading-6 opacity-70">{vertical.pitch}</p>
+                <div className="mt-4 space-y-2">
+                  {previews.map((item) => (
+                    <Link key={`${vertical.id}-${item.id}`} href={`/franchize/${crewSlug}/market/${item.id}/buy`} className="flex items-center justify-between gap-3 rounded-2xl border border-current/10 bg-black/20 px-3 py-2 text-sm transition hover:border-[var(--sales-accent)]/60">
+                      <span className="min-w-0 truncate">{item.title}</span>
+                      <span className="shrink-0 text-xs opacity-65">{item.salePrice ? `${item.salePrice.toLocaleString("ru-RU")} ₽` : item.rentPriceLabel}</span>
+                    </Link>
+                  ))}
+                  {!previews.length ? <p className="rounded-2xl border border-dashed border-current/15 p-3 text-sm opacity-60">Добавьте SKU в каталог, чтобы включить карточки этой вертикали.</p> : null}
+                </div>
+                <Link href={`/franchize/${crewSlug}/contacts?intent=${vertical.id}`} className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-[var(--sales-accent)]">
+                  {vertical.cta} <ArrowRight className="h-4 w-4" />
+                </Link>
+              </article>
+            );
+          })}
+        </section>
+      </div>
+      <CrewFooter crew={crew} />
+    </main>
+  );
+}

--- a/app/franchize/hooks/useSessionManager.ts
+++ b/app/franchize/hooks/useSessionManager.ts
@@ -1,0 +1,149 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { useAppContext } from "@/contexts/AppContext";
+import { useMapRiders } from "@/hooks/useMapRidersContext";
+import { getMapRidersWriteHeaders } from "@/lib/map-riders-client-auth";
+
+interface UseSessionManagerOptions {
+  startSuccessMessage?: string;
+  stopSuccessMessage?: string;
+  authErrorMessage?: string;
+  refreshOnStart?: boolean;
+  refreshOnStop?: boolean;
+}
+
+interface SessionManagerResult {
+  isSubmitting: boolean;
+  canStart: boolean;
+  canStop: boolean;
+  startSession: () => Promise<boolean>;
+  stopSession: () => Promise<boolean>;
+  toggleSession: () => Promise<boolean>;
+}
+
+export function useSessionManager(options: UseSessionManagerOptions = {}): SessionManagerResult {
+  const {
+    startSuccessMessage = "MapRiders активирован!",
+    stopSuccessMessage = "Заезд завершён!",
+    authErrorMessage = "Авторизуйся в Telegram/VIP BIKE",
+    refreshOnStart = true,
+    refreshOnStop = true,
+  } = options;
+  const { dbUser } = useAppContext();
+  const { state, dispatch, crewSlug, fetchSnapshot } = useMapRiders();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const startSession = useCallback(async () => {
+    if (!dbUser?.user_id) {
+      toast.error(authErrorMessage);
+      return false;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const headers = await getMapRidersWriteHeaders();
+      const response = await fetch("/api/map-riders/session", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          action: "start",
+          userId: dbUser.user_id,
+          crewSlug,
+          rideName: state.rideName,
+          vehicleLabel: state.vehicleLabel,
+          rideMode: state.rideMode,
+          visibility: state.visibilityMode === "public" ? "all_auth" : "crew",
+          privacy: {
+            homeBlurEnabled: state.homeBlurEnabled,
+            autoExpireMinutes: state.autoExpireMinutes,
+          },
+        }),
+      });
+      const json = await response.json();
+      if (!response.ok || !json.success) throw new Error(json.error || "Ошибка запуска");
+
+      dispatch({
+        type: "share/started",
+        payload: {
+          sessionId: json.data.id,
+          rideName: state.rideName,
+          vehicleLabel: state.vehicleLabel,
+          rideMode: state.rideMode,
+        },
+      });
+      if (refreshOnStart) await fetchSnapshot();
+      toast.success(startSuccessMessage);
+      return true;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Ошибка запуска");
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    authErrorMessage,
+    crewSlug,
+    dbUser?.user_id,
+    dispatch,
+    fetchSnapshot,
+    refreshOnStart,
+    startSuccessMessage,
+    state.autoExpireMinutes,
+    state.homeBlurEnabled,
+    state.rideMode,
+    state.rideName,
+    state.vehicleLabel,
+    state.visibilityMode,
+  ]);
+
+  const stopSession = useCallback(async () => {
+    if (!dbUser?.user_id || !state.sessionId) {
+      if (!dbUser?.user_id) toast.error(authErrorMessage);
+      return false;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const headers = await getMapRidersWriteHeaders();
+      const response = await fetch("/api/map-riders/session", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          action: "stop",
+          sessionId: state.sessionId,
+          userId: dbUser.user_id,
+          crewSlug,
+          routePoints: [],
+        }),
+      });
+      const json = await response.json();
+      if (!response.ok || !json.success) throw new Error(json.error || "Ошибка остановки");
+
+      dispatch({ type: "share/stopped" });
+      if (refreshOnStop) await fetchSnapshot();
+      toast.success(stopSuccessMessage);
+      return true;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Ошибка остановки");
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [authErrorMessage, crewSlug, dbUser?.user_id, dispatch, fetchSnapshot, refreshOnStop, state.sessionId, stopSuccessMessage]);
+
+  const toggleSession = useCallback(() => (state.shareEnabled ? stopSession() : startSession()), [startSession, state.shareEnabled, stopSession]);
+
+  return useMemo(
+    () => ({
+      isSubmitting,
+      canStart: !state.shareEnabled && !isSubmitting,
+      canStop: state.shareEnabled && Boolean(state.sessionId) && !isSubmitting,
+      startSession,
+      stopSession,
+      toggleSession,
+    }),
+    [dbUser?.user_id, isSubmitting, startSession, state.sessionId, state.shareEnabled, stopSession, toggleSession],
+  );
+}

--- a/app/franchize/todo.md
+++ b/app/franchize/todo.md
@@ -21,3 +21,18 @@
 - Public contract: `app/franchize/CONTRACT.md`
 - Hydration notes: `app/franchize/hydration.md`
 - Core extraction tracker: `app/core/todo.md`
+
+## 2026-05-07 — SupaPlan FRZ-R4 / FRZ-R8 / CQ-01 slice
+- Status: `ready_for_pr`
+- Owner: `codex`
+- Scope:
+  - FRZ-R4 added `/franchize/[slug]/onboarding` partner checklist page for VIP-bike onboarding readiness.
+  - FRZ-R8 added `/franchize/[slug]/sales` vertical hub for new/electric/used/trade-in flows.
+  - CQ-01 extracted MapRiders start/stop session writes into `app/franchize/hooks/useSessionManager.ts` and reused it from the map cockpit + floating FAB.
+- Next action: smoke `vip-bike` routes in preview/Telegram WebApp after merge and consider adding the new routes to default crew metadata menu links.
+
+## 2026-05-07 — Self-review polish after FRZ-R4 / FRZ-R8
+- Status: `ready_for_pr`
+- Owner: `codex`
+- Scope: Added the new onboarding and sales pages to `docs/sql/vip-bike-franchize-hydration.sql` header/footer link lists so hydrated VIP-bike crews can discover them from seeded navigation.
+- Next action: Re-apply the VIP-bike hydration SQL in staging/production, then smoke header/footer navigation for `/onboarding` and `/sales`.

--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -34,6 +34,7 @@ import { SpeedGradientRoute } from "@/components/map-riders/SpeedGradientRoute";
 import { MapRidersDebugPanel } from "@/components/map-riders/MapRidersDebugPanel";
 import { MapRidersSkeleton } from "@/components/map-riders/LoadingSkeleton";
 import { BeginnerRiderOnboardingQuiz } from "@/components/map-riders/BeginnerRiderOnboardingQuiz";
+import { useSessionManager } from "@/app/franchize/hooks/useSessionManager";
 
 // Lazy-load map (SSR disabled)
 const RacingMap = dynamic(() => import("@/components/maps/RacingMap").then((mod) => mod.RacingMap), { ssr: false });
@@ -64,6 +65,10 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
     defaultTileLayer: "cartodb-dark",
   });
   const { createMeetup } = useMeetupCreator(crewSlug);
+  const { canStart, canStop, startSession, stopSession } = useSessionManager({
+    authErrorMessage: "Авторизуйся",
+    stopSuccessMessage: "Заезд завершён",
+  });
 
   // ── GPS tracking hook ──
   const { isUsingTelegram, lastBroadcastAt, queuedPoints } = useLiveRiders({
@@ -504,39 +509,12 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
                 {state.homeBlurEnabled ? "Дом размыт: ВКЛ" : "Дом размыт: ВЫКЛ"}
               </Button>
             </div>
-            {/* TODO: Wire up session start/stop from useSessionManager */}
             <Button
               type="button"
-              disabled={state.shareEnabled}
+              disabled={!canStart}
               className="w-full text-black"
               style={{ backgroundColor: crew.theme.palette.accentMain }}
-              onClick={async () => {
-                if (!dbUser?.user_id) { toast.error("Авторизуйся"); return; }
-                try {
-                  const headers = await getMapRidersWriteHeaders();
-                  const res = await fetch("/api/map-riders/session", {
-                    method: "POST",
-                    headers,
-                    body: JSON.stringify({
-                      action: "start",
-                      userId: dbUser.user_id,
-                      crewSlug,
-                      rideName: state.rideName,
-                      vehicleLabel: state.vehicleLabel,
-                      rideMode: state.rideMode,
-                      visibility: state.visibilityMode === "public" ? "all_auth" : "crew",
-                      privacy: {
-                        homeBlurEnabled: state.homeBlurEnabled,
-                        autoExpireMinutes: state.autoExpireMinutes,
-                      },
-                    }),
-                  });
-                  const json = await res.json();
-                  if (!res.ok || !json.success) throw new Error(json.error);
-                  dispatch({ type: "share/started", payload: { sessionId: json.data.id, rideName: state.rideName, vehicleLabel: state.vehicleLabel, rideMode: state.rideMode } });
-                  toast.success("MapRiders активирован!");
-                } catch (err) { toast.error(err instanceof Error ? err.message : "Ошибка запуска"); }
-              }}
+              onClick={startSession}
             >
               <VibeContentRenderer content="::FaLocationArrow::" className="mr-2" />
               Включить геошеринг
@@ -554,24 +532,9 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
             <Button
               type="button"
               variant="outline"
-              disabled={!state.shareEnabled}
+              disabled={!canStop}
               className="w-full"
-              onClick={async () => {
-                if (!dbUser?.user_id || !state.sessionId) return;
-                try {
-                  const headers = await getMapRidersWriteHeaders();
-                  const res = await fetch("/api/map-riders/session", {
-                    method: "POST",
-                    headers,
-                    body: JSON.stringify({ action: "stop", sessionId: state.sessionId, userId: dbUser.user_id, crewSlug, routePoints: [] }),
-                  });
-                  const json = await res.json();
-                  if (!res.ok || !json.success) throw new Error(json.error);
-                  dispatch({ type: "share/stopped" });
-                  await fetchSnapshot();
-                  toast.success("Заезд завершён");
-                } catch (err) { toast.error(err instanceof Error ? err.message : "Ошибка остановки"); }
-              }}
+              onClick={stopSession}
             >
               <VibeContentRenderer content="::FaPowerOff::" className="mr-2" />
               Завершить заезд

--- a/components/map-riders/RiderFAB.tsx
+++ b/components/map-riders/RiderFAB.tsx
@@ -4,100 +4,20 @@
 
 "use client";
 
-import { useCallback, useState } from "react";
-import { toast } from "sonner";
 import { useMapRiders } from "@/hooks/useMapRidersContext";
-import { useAppContext } from "@/contexts/AppContext";
 import { VibeContentRenderer } from "@/components/VibeContentRenderer";
-import { getMapRidersWriteHeaders } from "@/lib/map-riders-client-auth";
+import { useSessionManager } from "@/app/franchize/hooks/useSessionManager";
 
 export function RiderFAB() {
-  const { state, dispatch, crewSlug, fetchSnapshot } = useMapRiders();
-  const { dbUser } = useAppContext();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleToggle = useCallback(async () => {
-    if (!dbUser?.user_id) {
-      toast.error("Авторизуйся в Telegram/VIP BIKE");
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      if (!state.shareEnabled) {
-        // START
-        const headers = await getMapRidersWriteHeaders();
-        const res = await fetch("/api/map-riders/session", {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            action: "start",
-            userId: dbUser.user_id,
-            crewSlug,
-            rideName: state.rideName,
-            vehicleLabel: state.vehicleLabel,
-            rideMode: state.rideMode,
-            visibility: state.visibilityMode === "public" ? "all_auth" : "crew",
-            privacy: {
-              homeBlurEnabled: state.homeBlurEnabled,
-              autoExpireMinutes: state.autoExpireMinutes,
-            },
-          }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) throw new Error(json.error);
-        dispatch({
-          type: "share/started",
-          payload: { sessionId: json.data.id, rideName: state.rideName, vehicleLabel: state.vehicleLabel, rideMode: state.rideMode },
-        });
-        await fetchSnapshot();
-        toast.success("MapRiders активирован!");
-      } else {
-        // STOP
-        const headers = await getMapRidersWriteHeaders();
-        const res = await fetch("/api/map-riders/session", {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            action: "stop",
-            sessionId: state.sessionId,
-            userId: dbUser.user_id,
-            crewSlug,
-            routePoints: [],
-          }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) throw new Error(json.error);
-        dispatch({ type: "share/stopped" });
-        await fetchSnapshot();
-        toast.success("Заезд завершён!");
-      }
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Ошибка");
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [
-    dbUser,
-    state.shareEnabled,
-    state.sessionId,
-    state.rideName,
-    state.vehicleLabel,
-    state.rideMode,
-    state.visibilityMode,
-    state.homeBlurEnabled,
-    state.autoExpireMinutes,
-    crewSlug,
-    dispatch,
-    fetchSnapshot,
-  ]);
+  const { state } = useMapRiders();
+  const { isSubmitting, toggleSession } = useSessionManager();
 
   const isRecording = state.shareEnabled;
 
   return (
     <button
       type="button"
-      onClick={handleToggle}
+      onClick={toggleSession}
       disabled={isSubmitting}
       className={`
         fixed bottom-20 right-4 z-50 flex h-14 w-14 items-center justify-center

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -271,3 +271,23 @@ This root file stays intentionally compact so operators and agents can load it q
 - `notes`: Addressed Codex review P1: auth bypass no longer reads caller-controlled URL/query/origin/referer; it now depends only on server-known Vercel deployment metadata (`VERCEL_ENV=preview` + deployment URL containing `salavey13`) or exact `TELEGRAM_AUTH_BYPASS_ALLOWED_HOSTS`. Added regression tests for forged `?salavey13` production URLs, live-like Telegram initData recreation, and preview/allowlist behavior. Updated VIP Bike seed SQL header/footer with `/franchize/{slug}/community`, and replaced `/vipbikerental` hardcoded Стригинский address with `ул. Комсомольская 2`.
 - `next_step`: Apply updated `docs/sql/vip-bike-franchize-hydration.sql` to staging/prod Supabase after merge, then smoke header/footer navigation.
 - `risks`: Bypass now requires Vercel preview metadata or explicit allowlist; if a preview runtime lacks `VERCEL_ENV/VERCEL_URL`, set `TELEGRAM_AUTH_BYPASS_ALLOWED_HOSTS` to the exact preview host.
+
+### 2026-05-07 — FRZ-R4 + FRZ-R8 + CQ-01 partner/sales/session slice
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-07T00:00:00Z
+- `owner`: codex
+- `supaplan_tasks`: `941503e4-9092-4d1f-bc93-3bf3147dbd69`, `b6180fa5-a62e-434b-b4c0-437cf996430e`, `b3950a88-bbd2-4eeb-9db4-b29da8026be8`
+- `notes`: Added VIP-bike partner onboarding checklist route, added four-lane sales vertical route for new/electric/used/trade-in intent capture, and extracted duplicated MapRiders session start/stop write logic into `useSessionManager` for the map panel + floating FAB.
+- `next_step`: Preview-smoke `/franchize/vip-bike/onboarding`, `/franchize/vip-bike/sales`, and `/franchize/vip-bike/map-riders`; after production data is verified, add onboarding/sales links to default crew menu metadata.
+- `risks`: Local checks validate TypeScript/lint shape, but real Telegram GPS/session writes still require device QA with configured runtime secrets.
+
+### 2026-05-07 — FRZ self-review navigation polish
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-07T00:00:00Z
+- `owner`: codex-review
+- `supaplan_tasks`: `941503e4-9092-4d1f-bc93-3bf3147dbd69`, `b6180fa5-a62e-434b-b4c0-437cf996430e`, `b3950a88-bbd2-4eeb-9db4-b29da8026be8`
+- `notes`: Self-review found the new partner onboarding and sales routes were only direct URLs, so the VIP-bike hydration SQL now seeds both routes into header menu links and footer section links.
+- `next_step`: Re-apply `docs/sql/vip-bike-franchize-hydration.sql` after merge and smoke `/franchize/vip-bike/onboarding` + `/franchize/vip-bike/sales` from hydrated navigation.
+- `risks`: Existing production metadata will not show the new links until the updated seed/hydration SQL is applied.

--- a/docs/sql/vip-bike-franchize-hydration.sql
+++ b/docs/sql/vip-bike-franchize-hydration.sql
@@ -116,6 +116,8 @@ set
             jsonb_build_object('label', 'Корзина', 'href', '/franchize/{slug}/cart'),
             jsonb_build_object('label', 'Мои аренды', 'href', '/franchize/{slug}/rentals'),
             jsonb_build_object('label', 'Сообщество', 'href', '/franchize/{slug}/community'),
+            jsonb_build_object('label', 'Партнёрам', 'href', '/franchize/{slug}/onboarding'),
+            jsonb_build_object('label', 'Продажи', 'href', '/franchize/{slug}/sales'),
             jsonb_build_object('label', 'Конфигуратор', 'href', '/franchize/{slug}/configurator'),
             jsonb_build_object('label', 'Enduro', 'href', '/franchize/{slug}/electro-enduro')
           ),
@@ -140,6 +142,8 @@ set
                 jsonb_build_object('type', 'link', 'label', 'Зал Славы', 'href', '/leaderboard', 'icon', 'FaTrophy'),
                 jsonb_build_object('type', 'link', 'label', 'Экипажи', 'href', '/crews', 'icon', 'FaUsers'),
                 jsonb_build_object('type', 'link', 'label', 'Сообщество', 'href', '/franchize/{slug}/community', 'icon', 'FaUsersViewfinder'),
+                jsonb_build_object('type', 'link', 'label', 'Партнёрам', 'href', '/franchize/{slug}/onboarding', 'icon', 'FaHandshake'),
+                jsonb_build_object('type', 'link', 'label', 'Продажи', 'href', '/franchize/{slug}/sales', 'icon', 'FaTags'),
                 jsonb_build_object('type', 'link', 'label', 'О Нас', 'href', '/vipbikerental', 'icon', 'FaCircleInfo')
               )
             ),


### PR DESCRIPTION
### Motivation
- Provide operator-facing partner onboarding and sales vertical pages for VIP-bike franchize to centralize partner checklist and sales flows.
- Remove duplicated MapRiders session start/stop logic by extracting a reusable client-side session manager for consistent session writes across UI controls.
- Surface the new routes in VIP Bike seed/hydration so crews discover them from header/footer navigation.

### Description
- Added `/app/franchize/[slug]/onboarding/page.tsx` implementing a Partner onboarding checklist and readiness UI with crew theming and Telegram CTA.
- Added `/app/franchize/[slug]/sales/page.tsx` implementing a Sales vertical hub (new / electric / used / trade-in) with SKU previews and CTAs.
- Introduced `app/franchize/hooks/useSessionManager.ts` to encapsulate MapRiders session start/stop, success/error toasts, and optional snapshot refresh.
- Updated `MapRidersClientRefactored.tsx` and `RiderFAB.tsx` to use the new `useSessionManager` hook and removed duplicated request code, plus updated docs and SQL hydration: `app/franchize/todo.md`, `docs/THE_FRANCHEEZEPLAN.md`, and `docs/sql/vip-bike-franchize-hydration.sql` to include the new routes in seeded navigation.

### Testing
- Ran TypeScript type-check with `yarn tsc --noEmit` which completed successfully.
- Ran linting with `yarn lint` which passed without errors.
- Performed a local production build with `yarn build` which succeeded and ensured SSR/SSRless boundaries compiled.
- Executed the test suite with `yarn test` (unit and vitest runners) which passed for the modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7049bfd48324ae419910215d2ef4)
supaplan_task: 941503e4-9092-4d1f-bc93-3bf3147dbd69, b6180fa5-a62e-434b-b4c0-437cf996430e, b3950a88-bbd2-4eeb-9db4-b29da8026be8