### PR TITLE
fix: show first-paint loading and webapp auth links

### DIFF
--- a/app/franchize/[slug]/loading.tsx
+++ b/app/franchize/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { Loading } from "@/components/Loading";
+
+export default function FranchizeSlugLoading() {
+  return <Loading variant="bike" text="СИНХРОНИЗИРУЕМ ГАРАЖ И КАТАЛОГ..." />;
+}

--- a/app/franchize/[slug]/market/[bike_id]/buy/loading.tsx
+++ b/app/franchize/[slug]/market/[bike_id]/buy/loading.tsx
@@ -1,28 +1,5 @@
+import { Loading } from "@/components/Loading";
+
 export default function BuyBikeLoading() {
-  return (
-    <main className="min-h-screen px-3 pb-20 pt-4 sm:px-6 sm:pt-6">
-      <div className="mx-auto flex w-full max-w-6xl animate-pulse flex-col gap-4">
-        <div className="h-10 w-36 rounded-xl bg-white/10" />
-        <div className="overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03]">
-          <div className="grid lg:grid-cols-[1.3fr_1fr]">
-            <div className="space-y-2 p-2 sm:p-3">
-              <div className="aspect-[9/16] rounded-2xl bg-white/10 sm:aspect-[4/3]" />
-              <div className="grid grid-cols-5 gap-2">
-                {Array.from({ length: 5 }).map((_, idx) => (
-                  <div key={idx} className="aspect-[4/3] rounded-xl bg-white/10" />
-                ))}
-              </div>
-            </div>
-            <div className="space-y-3 p-4">
-              <div className="h-6 w-24 rounded-full bg-white/10" />
-              <div className="h-10 w-4/5 rounded-xl bg-white/10" />
-              <div className="h-20 rounded-2xl bg-white/10" />
-              <div className="h-12 rounded-xl bg-white/10" />
-              <div className="h-12 rounded-xl bg-white/10" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </main>
-  );
+  return <Loading variant="bike" text="ГОТОВИМ ПОКУПКУ БАЙКА..." />;
 }

--- a/app/franchize/components/FranchizeProfileButton.tsx
+++ b/app/franchize/components/FranchizeProfileButton.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/app/franchize/profile-actions";
 import { toast } from "sonner";
 
-const TELEGRAM_WEB_APP_URL = "https://t.me/oneBikePlBVot/app";
+const TELEGRAM_WEB_APP_URL = "https://t.me/oneBikePlsBot/app";
 
 const DEFAULT_NOTIFICATION_PREFERENCES: FranchizeNotificationPreferences = {
   orderUpdates: true,

--- a/app/franchize/components/FranchizeProfileButton.tsx
+++ b/app/franchize/components/FranchizeProfileButton.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Bell, ChevronDown, Palette, Settings, Shield, User, IdCard, MessageCircle } from "lucide-react";
+import { Bell, ChevronDown, Palette, Settings, Shield, User, IdCard, MessageCircle, Send } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useAppContext } from "@/contexts/AppContext";
 import { useIsAdmin } from "@/app/franchize/hooks/useIsAdmin";
@@ -22,6 +22,8 @@ import {
   type FranchizeNotificationPreferences,
 } from "@/app/franchize/profile-actions";
 import { toast } from "sonner";
+
+const TELEGRAM_WEB_APP_URL = "https://t.me/oneBikePlBVot/app";
 
 const DEFAULT_NOTIFICATION_PREFERENCES: FranchizeNotificationPreferences = {
   orderUpdates: true,
@@ -127,6 +129,22 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
     if (!tempCartId) return null;
     return `https://t.me/oneBikePlsBot/app?startapp=cart_id_${encodeURIComponent(tempCartId)}`;
   }, [tempCartId]);
+
+  if (!effectiveUser) {
+    return (
+      <a
+        href={TELEGRAM_WEB_APP_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Открыть Telegram WebApp"
+        className="inline-flex h-11 items-center gap-2 rounded-xl border px-3 text-sm font-semibold transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+        style={{ backgroundColor: bgColor, color: textColor, borderColor }}
+      >
+        <Send className="h-4 w-4" />
+        <span className="hidden sm:inline">WebApp</span>
+      </a>
+    );
+  }
 
   return (
     <div style={{ isolation: "isolate" }}>

--- a/app/franchize/loading.tsx
+++ b/app/franchize/loading.tsx
@@ -1,0 +1,5 @@
+import { Loading } from "@/components/Loading";
+
+export default function FranchizeLoading() {
+  return <Loading variant="bike" text="ЗАВОДИМ ВИТРИНУ ЭКИПАЖА..." />;
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,5 @@
+import { Loading } from "@/components/Loading";
+
+export default function GlobalLoading() {
+  return <Loading variant="bike" text="🏴‍☠️ LOADING VIBE..." />;
+}

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -158,32 +158,31 @@ const MatrixRain = () => {
 
 // --- COMPONENT: PARTICLE FIELD ---
 const ParticleField = () => {
-  const particleCount = 50;
-  
+  const particles = useMemo(() => {
+    return Array.from({ length: 50 }, (_, i) => ({
+      id: i,
+      left: `${seededRandom(i + 11) * 100}%`,
+      top: `${seededRandom(i + 101) * 100}%`,
+      drift: -(seededRandom(i + 211) * 360 + 120),
+      scale: seededRandom(i + 307) * 2 + 1,
+      opacity: seededRandom(i + 401) * 0.5 + 0.3,
+      duration: seededRandom(i + 503) * 10 + 10,
+      delay: seededRandom(i + 607) * 5,
+    }));
+  }, []);
+
   return (
     <div className="absolute inset-0 overflow-hidden pointer-events-none">
-      {Array.from({ length: particleCount }).map((_, i) => (
+      {particles.map((particle) => (
         <motion.div
-          key={i}
-          className="absolute w-1 h-1 bg-cyan-500 rounded-full"
-          initial={{ 
-            x: Math.random() * (typeof window !== 'undefined' ? window.innerWidth : 1000),
-            y: Math.random() * (typeof window !== 'undefined' ? window.innerHeight : 1000),
-            scale: 0,
-            opacity: 0 
-          }}
-          animate={{ 
-            y: [null, Math.random() * -500],
-            scale: [0, Math.random() * 2 + 1, 0],
-            opacity: [0, Math.random() * 0.5 + 0.3, 0]
-          }}
-          transition={{ 
-            duration: Math.random() * 10 + 10,
-            repeat: Infinity,
-            delay: Math.random() * 5,
-            ease: "linear"
-          }}
+          key={particle.id}
+          className="absolute h-1 w-1 rounded-full bg-cyan-500"
+          initial={{ y: 0, scale: 0, opacity: 0 }}
+          animate={{ y: [0, particle.drift], scale: [0, particle.scale, 0], opacity: [0, particle.opacity, 0] }}
+          transition={{ duration: particle.duration, repeat: Infinity, delay: particle.delay, ease: "linear" }}
           style={{
+            left: particle.left,
+            top: particle.top,
             boxShadow: '0 0 6px rgba(6,182,212,0.8)'
           }}
         />
@@ -482,9 +481,7 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
     return () => clearInterval(interval);
   }, [mounted, variant]);
 
-  if (!mounted) return null;
-
-  const displayProgress = Math.min(progress, 100);
+  const displayProgress = mounted ? Math.min(progress, 100) : 18;
 
   // ================= KINETIC VARIANT (Next Level) =================
   if (variant === 'kinetic') {
@@ -595,18 +592,24 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
   if (variant === 'bike') {
     return (
       <div className={cn(
-        "min-h-screen bg-gradient-to-br from-slate-950 via-orange-950/20 to-slate-950 text-slate-200 flex flex-col items-center justify-center overflow-hidden relative",
+        "min-h-screen min-h-[100svh] bg-gradient-to-br from-slate-950 via-orange-950/20 to-slate-950 text-slate-200 flex flex-col items-center justify-center overflow-hidden relative px-4",
         className
       )}>
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_35%,rgba(251,146,60,0.18),transparent_42%),linear-gradient(120deg,transparent,rgba(251,191,36,0.06),transparent)]" />
+        <div className="absolute left-0 right-0 top-1/2 h-px bg-gradient-to-r from-transparent via-orange-400/60 to-transparent" />
         <BikeSpeedster />
         
         <motion.div 
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.3 }}
-          className="mt-12 text-center space-y-4 z-10"
+          className="z-10 mt-8 w-full max-w-md space-y-4 text-center sm:mt-12"
         >
-          <h2 className="font-orbitron font-black text-3xl md:text-5xl uppercase tracking-wider text-orange-400 drop-shadow-[0_0_15px_rgba(251,191,36,0.5)]">
+          <div className="inline-flex items-center gap-2 rounded-full border border-orange-300/20 bg-black/30 px-3 py-1 text-[10px] font-mono uppercase tracking-[0.28em] text-orange-200/80 shadow-[0_0_22px_rgba(251,146,60,0.18)]">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_10px_rgba(52,211,153,0.9)]" />
+            first-paint loader online
+          </div>
+          <h2 className="font-orbitron text-3xl font-black uppercase tracking-wider text-orange-400 drop-shadow-[0_0_15px_rgba(251,191,36,0.5)] md:text-5xl">
             RIDE LINK
           </h2>
           
@@ -622,7 +625,7 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
             />
           </div>
           
-          <p className="font-mono text-sm text-orange-300/80">
+          <p className="mx-auto max-w-sm font-mono text-sm text-orange-300/80">
             {text || 'Синхронизируем телеметрию экипажа...'}
           </p>
           

--- a/components/user-info.tsx
+++ b/components/user-info.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
-import { User, Bot } from "lucide-react";
+import { Bot, Send } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useAppContext } from "@/contexts/AppContext";
@@ -9,6 +9,8 @@ import { cn } from "@/lib/utils";
 import { debugLogger as logger } from "@/lib/debugLogger";
 import { Button } from "@/components/ui/button"; 
 import { VibeContentRenderer } from "@/components/VibeContentRenderer";
+
+const TELEGRAM_WEB_APP_URL = "https://t.me/oneBikePlBVot/app";
 
 // Исправление 1: Делаем именованный экспорт (убрано default)
 export function UserInfo() {
@@ -37,7 +39,7 @@ export function UserInfo() {
             <span className="font-mono text-xs">Auth Error!</span>
         </div>
         <Button asChild variant="outline" size="sm" className="text-xs border-destructive/50 text-destructive-foreground/80 hover:bg-destructive/70 hover:text-destructive-foreground">
-            <Link href="/profile">Войти/Регистрация</Link>
+            <a href={TELEGRAM_WEB_APP_URL} target="_blank" rel="noopener noreferrer">Открыть WebApp</a>
         </Button>
       </motion.div>
     );
@@ -47,20 +49,21 @@ export function UserInfo() {
 
   if (!effectiveUser) {
     return ( 
-      <Button 
-        asChild 
-        variant="ghost" 
+      <Button
+        asChild
+        variant="ghost"
         className={cn(
-            "p-2 rounded-full transition-all",
+            "rounded-full px-3 py-2 transition-all",
             "bg-gradient-to-br from-brand-purple/30 via-brand-pink/30 to-brand-orange/30",
             "hover:from-brand-purple/50 hover:via-brand-pink/50 hover:to-brand-orange/50",
             "text-light-text hover:text-white",
             "shadow-[0_0_10px_rgba(var(--brand-pink-rgb),0.4)] hover:shadow-[0_0_15px_rgba(var(--brand-pink-rgb),0.6)]"
         )}
-        >
-        <Link href="/profile" aria-label="Профиль пользователя">
-          <User className="h-6 w-6" />
-        </Link>
+      >
+        <a href={TELEGRAM_WEB_APP_URL} target="_blank" rel="noopener noreferrer" aria-label="Открыть Telegram WebApp" className="inline-flex items-center gap-2">
+          <Send className="h-5 w-5" />
+          <span className="hidden text-xs font-semibold sm:inline">WebApp</span>
+        </a>
       </Button>
     );
   }

--- a/components/user-info.tsx
+++ b/components/user-info.tsx
@@ -10,7 +10,7 @@ import { debugLogger as logger } from "@/lib/debugLogger";
 import { Button } from "@/components/ui/button"; 
 import { VibeContentRenderer } from "@/components/VibeContentRenderer";
 
-const TELEGRAM_WEB_APP_URL = "https://t.me/oneBikePlBVot/app";
+const TELEGRAM_WEB_APP_URL = "https://t.me/oneBikePlsBot/app";
 
 // Исправление 1: Делаем именованный экспорт (убрано default)
 export function UserInfo() {


### PR DESCRIPTION
### Motivation
- Users saw a black screen on first load and franchize pages because there was no route-level loading boundary and the shared loader returned `null` before mount, which is hydration-sensitive.  
- Franchize flows must show a consistent "bike" loading UX and unauthenticated header/profile actions should direct users to the Telegram WebApp link rather than internal `/profile` when not signed in.

### Description
- Add route-level loading boundaries: `app/loading.tsx`, `app/franchize/loading.tsx`, and `app/franchize/[slug]/loading.tsx` that render the shared `Loading` (`variant="bike"`) during SSR/streaming fallbacks.  
- Replace the buy-page skeleton with the shared bike loader (`app/franchize/[slug]/market/[bike_id]/buy/loading.tsx`) for consistent franchize loading behavior.  
- Improve `components/Loading.tsx`: make particle animation deterministic via `useMemo`, avoid returning `null` before mount (provide a safe `displayProgress` fallback), and enhance the `bike` variant with first-paint chrome and full-viewport treatment.  
- Update unauthenticated entrypoints to open the Telegram WebApp: `components/user-info.tsx` and `app/franchize/components/FranchizeProfileButton.tsx` now link to `https://t.me/oneBikePlBVot/app` when the user is not logged in.

### Testing
- Ran typecheck slice: `npm run typecheck:franchize` — passed for the franchize allowlist.  
- Ran lint on changed files: `npx eslint components/Loading.tsx components/user-info.tsx app/franchize/components/FranchizeProfileButton.tsx app/franchize/loading.tsx app/franchize/[slug]/loading.tsx app/franchize/[slug]/market/[bike_id]/buy/loading.tsx app/loading.tsx` — executed (no blocking lint errors surfaced for modified files).  
- Attempted visual smoke capture: `node scripts/capture-screenshot.mjs --url http://127.0.0.1:3000/franchize/vip-bike` — Playwright failed to run due to missing system browser libraries in the environment (e.g. `libatk-1.0.so.0`), so automated screenshot capture could not complete.  
- Production build: `npm run build` was started during verification but did not complete within the interactive run budget and was stopped (no new diagnostics produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7ea83ab4832499c55b9dbffcf456)