### PR TITLE
fix: harden telegram auth and start params

### DIFF
--- a/docs/AGENT_DIARY.md
+++ b/docs/AGENT_DIARY.md
@@ -45,3 +45,9 @@ Open archive only for deep forensics on:
 - Upgraded `/supaplan/franchize` from simple mapping to operator-grade execution board: phased sections, R1-R4 task-type legend, and expanded live task details (`task_id`, `todo_path`, `updated_at`, `pr_url`, `body`).
 - Added explicit epic decomposition hints per franchize capability so implementation can spawn child tasks deterministically instead of keeping oversized epics.
 - Screenshot captured via fallback skill (`scripts/page-screenshot-skill.mjs`) because browser container tooling was unavailable in this runner.
+
+### 2026-05-07
+- Symptom: production Telegram Mini App auth could show `No user data available for authentication` / hash mismatch after Telegram added the `signature` launch field.
+- Root cause: HMAC data-check-string incorrectly omitted `signature`; client also depended only on `window.Telegram.WebApp.initData`, missing raw `tgWebAppData` URL-hash fallback when WebApp bootstrap was unavailable or late.
+- Fix/workaround: include every initData field except `hash` for bot-token HMAC validation, parse `tgWebAppData`/`tgWebAppStartParam` from launch URL fallback, and keep handled start params guarded while stale URL params remain.
+- Verification command: `npm test -- tests/franchize/telegram-webapp-auth.spec.ts && npm run lint && git diff --check`.

--- a/hooks/useStartParamRouter.ts
+++ b/hooks/useStartParamRouter.ts
@@ -66,6 +66,7 @@ export function useStartParamRouter() {
   const startParamRunIdRef = useRef(0);
   const mountedRef = useRef(false);
   const consumedTempCartRef = useRef<string | null>(null);
+  const ignoredUrlStartParamRef = useRef<string | null>(null);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -146,12 +147,23 @@ export function useStartParamRouter() {
 
   useEffect(() => {
     const processStartParam = async () => {
-      const rawStartParam = startParamPayload || searchParams.get("tgWebAppStartParam");
+      const urlStartParam = searchParams.get("tgWebAppStartParam");
+      const rawStartParam = startParamPayload || urlStartParam;
       const paramToProcess = normalizeStartParamPath(rawStartParam);
+      const normalizedUrlStartParam = normalizeStartParamPath(urlStartParam);
+
+      if (normalizedUrlStartParam !== ignoredUrlStartParamRef.current) {
+        ignoredUrlStartParamRef.current = null;
+      }
 
       if (!paramToProcess) {
         activeStartParamRef.current = null;
         lastHandledStartParamRef.current = null;
+        ignoredUrlStartParamRef.current = null;
+        return;
+      }
+
+      if (!startParamPayload && normalizedUrlStartParam && ignoredUrlStartParamRef.current === normalizedUrlStartParam) {
         return;
       }
 
@@ -264,6 +276,9 @@ export function useStartParamRouter() {
         }
 
         lastHandledStartParamRef.current = paramToProcess;
+        if (startParamPayload && normalizedUrlStartParam) {
+          ignoredUrlStartParamRef.current = normalizedUrlStartParam;
+        }
 
         if (targetPath && targetPath !== pathname) {
           logger.info(`[ClientLayout] Redirecting to ${targetPath}`);

--- a/hooks/useTelegram.ts
+++ b/hooks/useTelegram.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { debugLogger } from "@/lib/debugLogger"; 
 import { logger as globalLogger } from "@/lib/logger"; 
 import { isAllowedMockContext } from "@/lib/telegram-mock-context";
+import { getTelegramLaunchParamsFromWindow } from "@/lib/telegram-launch-params";
 import { 
   fetchDbUserAction,
   upsertTelegramUserAction
@@ -238,21 +239,21 @@ export function useTelegram() {
       
       let authCandidate: WebAppUser | null = null;
       let inTgContextReal = false; 
-      let tempTgWebApp: TelegramWebApp | null = null; 
       let rawStartParam: string | null = null;
 
       try { 
         globalLogger.log("[HOOK_TELEGRAM initialize TRY_BLOCK_START] STEP 3: Checking for window.Telegram.WebApp...");
-        if (typeof window !== "undefined" && (window as any).Telegram?.WebApp) {
-          const telegram = (window as any).Telegram.WebApp;
-          tempTgWebApp = telegram; 
+        const launchParams = getTelegramLaunchParamsFromWindow();
+        const telegram = typeof window !== "undefined" ? (window as any).Telegram?.WebApp : null;
+        const initDataForValidation = telegram?.initData || launchParams.initData || "";
+
+        if (telegram) {
           if (canUpdateState()) {
             setTgWebApp(telegram);
             globalLogger.log("[HOOK_TELEGRAM initialize] STEP 3.1: Telegram WebApp object FOUND and set to state (tgWebApp).");
           }
           
-          inTgContextReal = !!telegram.initData && telegram.initData.length > 0; 
-          rawStartParam = telegram.initDataUnsafe?.start_param || null;
+          rawStartParam = telegram.initDataUnsafe?.start_param || launchParams.startParam || null;
           if (canUpdateState() && rawStartParam) {
             setStartParam(rawStartParam);
             globalLogger.info(`[HOOK_TELEGRAM initialize] STEP 3.1.1: start_param found: "${rawStartParam}" and set to state.`);
@@ -261,7 +262,7 @@ export function useTelegram() {
           if (canUpdateState()) {
             safeReady(telegram);
             globalLogger.log("[HOOK_TELEGRAM initialize] STEP 3.3: Called telegram.ready()");
-            if (inTgContextReal && telegram.expand) {
+            if (initDataForValidation && telegram.expand) {
               const expanded = await safeExpand(telegram, { attempts: 3, delayMs: 120 });
               if (!canUpdateState()) {
                 return;
@@ -274,29 +275,36 @@ export function useTelegram() {
               detachVisibilityRecovery = attachVisibilityExpandRecovery(telegram, { attempts: 2, delayMs: 150 });
             }
           }
-
-          if (inTgContextReal) { 
-              globalLogger.log("[HOOK_TELEGRAM initialize] STEP 4A: REAL Telegram initData found. Validating via API...");
-              const validatedUserFromApi = await validateTelegramAuthWithApi(telegram.initData); 
-              if (validatedUserFromApi) {
-                  authCandidate = validatedUserFromApi;
-                  globalLogger.info(`[HOOK_TELEGRAM initialize] STEP 4A.1: REAL Telegram auth validated successfully via API. Auth Candidate User ID: ${authCandidate.id}`);
-              } else {
-                  globalLogger.warn("[HOOK_TELEGRAM initialize] STEP 4A.2: REAL Telegram initData validation FAILED via API or returned no user.");
-                  if (MOCK_USER && isAllowedMockContext()) {
-                    globalLogger.warn("[HOOK_TELEGRAM initialize] STEP 4A.3: Validation failed, but preview/dev mock context is allowed. Falling back to MOCK_USER without blocking.");
-                  } else if (canUpdateState()) {
-                    const validationError = new Error("Telegram data validation failed. Please open this page through the Telegram App to continue.");
-                    setError((prev) => prev ?? validationError);
-                  }
-              }
-          } else if (telegram.initDataUnsafe?.user?.id && process.env.NODE_ENV === 'development') {
-             globalLogger.warn("[HOOK_TELEGRAM initialize] STEP 4B: Using initDataUnsafe.user as fallback. INSECURE - DEV ONLY.");
-             authCandidate = telegram.initDataUnsafe.user;
-             inTgContextReal = true; 
-          }
         } else {
-          globalLogger.log("[HOOK_TELEGRAM initialize] STEP 3 (FAIL): window.Telegram.WebApp not found.");
+          rawStartParam = launchParams.startParam;
+          globalLogger.log("[HOOK_TELEGRAM initialize] STEP 3 (FALLBACK): window.Telegram.WebApp not found; checking launch params from URL.");
+          if (canUpdateState() && rawStartParam) {
+            setStartParam(rawStartParam);
+            globalLogger.info(`[HOOK_TELEGRAM initialize] STEP 3.1.1_FALLBACK: start_param found in URL: "${rawStartParam}" and set to state.`);
+          }
+        }
+
+        inTgContextReal = initDataForValidation.length > 0;
+
+        if (initDataForValidation) {
+            globalLogger.log("[HOOK_TELEGRAM initialize] STEP 4A: REAL Telegram initData found. Validating via API...");
+            const validatedUserFromApi = await validateTelegramAuthWithApi(initDataForValidation);
+            if (validatedUserFromApi) {
+                authCandidate = validatedUserFromApi;
+                globalLogger.info(`[HOOK_TELEGRAM initialize] STEP 4A.1: REAL Telegram auth validated successfully via API. Auth Candidate User ID: ${authCandidate.id}`);
+            } else {
+                globalLogger.warn("[HOOK_TELEGRAM initialize] STEP 4A.2: REAL Telegram initData validation FAILED via API or returned no user.");
+                if (MOCK_USER && isAllowedMockContext()) {
+                  globalLogger.warn("[HOOK_TELEGRAM initialize] STEP 4A.3: Validation failed, but preview/dev mock context is allowed. Falling back to MOCK_USER without blocking.");
+                } else if (canUpdateState()) {
+                  const validationError = new Error("Telegram data validation failed. Please open this page through the Telegram App to continue.");
+                  setError((prev) => prev ?? validationError);
+                }
+            }
+        } else if (telegram?.initDataUnsafe?.user?.id && process.env.NODE_ENV === 'development') {
+           globalLogger.warn("[HOOK_TELEGRAM initialize] STEP 4B: Using initDataUnsafe.user as fallback. INSECURE - DEV ONLY.");
+           authCandidate = telegram.initDataUnsafe.user;
+           inTgContextReal = true;
         }
 
         // Preview/Dev safety net: Allows mockuser bypass ONLY when the URL contains

--- a/lib/telegram-launch-params.ts
+++ b/lib/telegram-launch-params.ts
@@ -1,0 +1,46 @@
+export interface TelegramLaunchParams {
+  initData: string | null;
+  startParam: string | null;
+}
+
+function readLaunchParam(params: URLSearchParams, key: string): string | null {
+  const value = params.get(key);
+  return value && value.trim() ? value : null;
+}
+
+function collectParamsFromUrl(url: string): URLSearchParams[] {
+  try {
+    const parsed = new URL(url, "https://telegram.local");
+    const paramSets = [parsed.searchParams];
+    const hash = parsed.hash.replace(/^#/, "");
+
+    if (hash) {
+      paramSets.push(new URLSearchParams(hash));
+    }
+
+    return paramSets;
+  } catch {
+    return [];
+  }
+}
+
+export function extractTelegramLaunchParams(url: string): TelegramLaunchParams {
+  const paramSets = collectParamsFromUrl(url);
+  let initData: string | null = null;
+  let startParam: string | null = null;
+
+  for (const params of paramSets) {
+    initData ??= readLaunchParam(params, "tgWebAppData");
+    startParam ??= readLaunchParam(params, "tgWebAppStartParam");
+  }
+
+  return { initData, startParam };
+}
+
+export function getTelegramLaunchParamsFromWindow(): TelegramLaunchParams {
+  if (typeof window === "undefined") {
+    return { initData: null, startParam: null };
+  }
+
+  return extractTelegramLaunchParams(window.location.href);
+}

--- a/lib/telegram-webapp-auth.ts
+++ b/lib/telegram-webapp-auth.ts
@@ -12,7 +12,7 @@ export function buildTelegramDataCheckString(initDataString: string): { dataChec
   const params = new URLSearchParams(initDataString);
   const hashFromClient = params.get("hash");
   const keys = Array.from(params.keys())
-    .filter((key) => key !== "hash" && key !== "signature")
+    .filter((key) => key !== "hash")
     .sort();
 
   return {

--- a/tests/franchize/telegram-webapp-auth.spec.ts
+++ b/tests/franchize/telegram-webapp-auth.spec.ts
@@ -3,9 +3,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { isTrustedTelegramBypassDeployment } from "@/lib/telegram-bypass-context";
 import { isAllowedMockContext } from "@/lib/telegram-mock-context";
 import { buildTelegramDataCheckString, computeTelegramWebAppHash } from "@/lib/telegram-webapp-auth";
+import { extractTelegramLaunchParams } from "@/lib/telegram-launch-params";
 
 function signInitData(initDataWithoutHash: string, botToken: string): string {
   const { dataCheckString } = buildTelegramDataCheckString(initDataWithoutHash);
+  const secret = createHmac("sha256", "WebAppData").update(botToken).digest();
+  return createHmac("sha256", secret).update(dataCheckString).digest("hex");
+}
+
+function signLegacyInitDataWithoutSignature(initDataWithoutHash: string, botToken: string): string {
+  const params = new URLSearchParams(initDataWithoutHash);
+  params.delete("signature");
+  const keys = Array.from(params.keys()).sort();
+  const dataCheckString = keys.map((key) => `${key}=${params.get(key)}`).join("\n");
   const secret = createHmac("sha256", "WebAppData").update(botToken).digest();
   return createHmac("sha256", secret).update(dataCheckString).digest("hex");
 }
@@ -23,13 +33,38 @@ describe("Telegram WebApp initData validation", () => {
     signature: "ignored-third-party-signature",
   }).toString();
 
-  it("builds Telegram data-check-string by sorting fields and excluding hash/signature", () => {
+  it("builds Telegram data-check-string by sorting fields and excluding only hash", () => {
     const hash = signInitData(initDataWithoutHash, botToken);
     const initData = `${initDataWithoutHash}&hash=${hash}`;
 
     expect(buildTelegramDataCheckString(initData)).toEqual({
       hashFromClient: hash,
-      dataCheckString: `auth_date=1710000000\nquery_id=AAHdF6IQAAAAAN0XohDhrOrc\nuser=${user}`,
+      dataCheckString: `auth_date=1710000000
+query_id=AAHdF6IQAAAAAN0XohDhrOrc
+signature=ignored-third-party-signature
+user=${user}`,
+    });
+  });
+
+  it("rejects legacy signatures that omit Telegram's third-party signature field", async () => {
+    const legacyHash = signLegacyInitDataWithoutSignature(initDataWithoutHash, botToken);
+    const result = await computeTelegramWebAppHash(`${initDataWithoutHash}&hash=${legacyHash}`, botToken);
+
+    expect(result.isValid).toBe(false);
+    expect(result.computedHash).not.toBe(legacyHash);
+  });
+
+  it("extracts initData and start_param from Telegram launch URL hash fallback", () => {
+    const launchInitData = new URLSearchParams({
+      query_id: "AAE_HASH_FALLBACK",
+      user,
+      auth_date: "1710000000",
+    }).toString();
+    const href = `https://vip-bike.ee/franchize/vip-bike#tgWebAppData=${encodeURIComponent(launchInitData)}&tgWebAppStartParam=mapriders_vip-bike`;
+
+    expect(extractTelegramLaunchParams(href)).toEqual({
+      initData: launchInitData,
+      startParam: "mapriders_vip-bike",
     });
   });
 


### PR DESCRIPTION
### Motivation
- Prevent double-processing of Telegram `start_param` when a Telegram-provided payload is cleared but the legacy URL fallback `tgWebAppStartParam` still exists. 
- Fix production Telegram WebApp HMAC/hash mismatch caused by Telegram adding a third-party `signature` field that was previously excluded from the bot-token data-check-string. 
- Support validation when `window.Telegram.WebApp` init data is missing or delayed by reading launch params from the URL hash/search as a fallback.

### Description
- Adjusted HMAC data-check string logic in `lib/telegram-webapp-auth.ts` to exclude only `hash` so other fields (including `signature`) participate in the computed message. 
- Added `lib/telegram-launch-params.ts` to extract `tgWebAppData` and `tgWebAppStartParam` from the URL search and hash as a robust fallback source. 
- Updated `hooks/useTelegram.ts` to prefer `window.Telegram.WebApp.initData` but fall back to URL-provided `tgWebAppData` for validation and to wire `start_param` from either source. 
- Hardened `hooks/useStartParamRouter.ts` by adding an `ignoredUrlStartParamRef` guard to avoid re-processing stale URL `tgWebAppStartParam` after a Telegram payload has been handled and cleared. 
- Added/updated focused tests in `tests/franchize/telegram-webapp-auth.spec.ts` to cover signature-inclusive HMAC behavior, rejection of legacy-signature-omission hashes, and URL-hash extraction. 
- Recorded the incident and mitigation in `docs/AGENT_DIARY.md`.

### Testing
- Ran `npm test -- tests/franchize/telegram-webapp-auth.spec.ts` and all tests passed (9 tests). 
- Ran `npm run lint` and ESLint reported no warnings or errors. 
- Ran `git diff --check` with no trailing-diff failures. 
- Attempted `npx tsc --noEmit` but typechecking still reports broad pre-existing repository errors unrelated to this patch (Deno/supabase worker files, admin pages, etc.), so full `tsc` is not clean in this repo and was not used as a gate for this scoped change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcac9ac86483249b139e59158e45f5)