### PR TITLE
VIP Bike landing: client-side catalog hydration, Russian localization, UI & loading polish

### DIFF
--- a/app/api/franchize/catalog/route.ts
+++ b/app/api/franchize/catalog/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { getFranchizeBySlug } from "@/app/franchize/actions";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const slug = searchParams.get("slug") || "vip-bike";
+
+  const data = await getFranchizeBySlug(slug);
+
+  return NextResponse.json({ success: true, data });
+}

--- a/app/buy-subscription/page.tsx
+++ b/app/buy-subscription/page.tsx
@@ -177,7 +177,7 @@ const WAREHOUSE_PLANS = [
       "::FaUserTie className='text-purple-500 mr-2 align-middle w-4 h-4':: Dedicated менеджер",
       "::FaTools className='text-purple-500 mr-2 align-middle w-4 h-4':: Индивидуальные доработки",
       "::FaChalkboardTeacher className='text-purple-500 mr-2 align-middle w-4 h-4':: Обучение команды (5 часов)",
-      "::FaShieldAlt className='text-purple-500 mr-2 align-middle w-4 h-4':: Гарантия снижения недостач на 50%+"
+      "::FaShieldCat className='text-purple-500 mr-2 align-middle w-4 h-4':: Гарантия снижения недостач на 50%+"
     ],
     who_is_this_for: "Для крупных сетей и бизнесов с высокими оборотами. Когда нужны индивидуальные решения и гарантированный результат.",
     hormozi_easter_egg_title: "::FaChessKing className='text-purple-500':: ДЛЯ ТЕХ, КТО ИГРАЕТ В ДОЛГУЮ",

--- a/app/franchize/actions-runtime.ts
+++ b/app/franchize/actions-runtime.ts
@@ -475,15 +475,15 @@ function extractFooterSocialLinks(franchize: UnknownRecord, fallbackTelegram: st
 const emptyCrew = (slug: string): FranchizeCrewVM => ({
   id: "",
   slug,
-  name: "Crew not found",
-  description: "No franchise crew found for this slug yet.",
+  name: "Экипаж не найден",
+  description: "Для этого slug пока нет витрины экипажа.",
   logoUrl: "",
   hqLocation: "",
   isFound: false,
   theme: defaultTheme,
   header: {
-    brandName: "Franchize",
-    tagline: "Hydration pending",
+    brandName: "Франшиза",
+    tagline: "Витрина готовится",
     logoUrl: "",
     logoHref: `/franchize/${slug}`,
     menuLinks: fallbackMenuLinks(slug),
@@ -613,14 +613,14 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
 
     const resolvedTheme = resolveFranchizeTheme(franchize);
     const menuLinksRaw = readArrayPath<UnknownRecord>(franchize, ["header", "menuLinks"], fallbackMenuLinks(safeSlug)).map((link) => ({
-      label: readPath(link, ["label"], "Link"),
+      label: readPath(link, ["label"], "Ссылка"),
       href: withSlug(readPath(link, ["href"], `/franchize/${crew.slug ?? safeSlug}`), crew.slug ?? safeSlug),
     }));
     const menuLinks = menuLinksRaw.some((link) => link.href === `/franchize/${crew.slug ?? safeSlug}/map-riders`)
       ? menuLinksRaw
       : [
           ...menuLinksRaw.slice(0, 1),
-          { label: "Map Riders", href: `/franchize/${crew.slug ?? safeSlug}/map-riders` },
+          { label: "Карта райдеров", href: `/franchize/${crew.slug ?? safeSlug}/map-riders` },
           ...menuLinksRaw.slice(1),
         ];
 
@@ -628,7 +628,7 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
     const showcaseGroups = (metadataShowcaseGroups.length > 0
       ? metadataShowcaseGroups.map((group, index) => ({
           id: readPath(group, ["id"], `showcase-${index + 1}`),
-          label: readPath(group, ["label"], readPath(group, ["title"], `Showcase ${index + 1}`)),
+          label: readPath(group, ["label"], readPath(group, ["title"], `Витрина ${index + 1}`)),
           mode: readPath(group, ["mode"], "subtype") as "subtype" | "price",
           subtype: readPath(group, ["subtype"], ""),
           minPrice: Number(readPath(group, ["minPrice"], 0)),
@@ -640,7 +640,7 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
     const hydratedCrew: FranchizeCrewVM = {
       id: crew.id,
       slug: crew.slug ?? safeSlug,
-      name: crew.name ?? "Unnamed crew",
+      name: crew.name ?? "Экипаж без названия",
       description: crew.description ?? "",
       logoUrl: crew.logo_url ?? "",
       hqLocation: crew.hq_location ?? "",
@@ -735,7 +735,7 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
         (typeof specs.bike_subtype === "string" && specs.bike_subtype.trim()) ||
         (typeof specs.segment === "string" && specs.segment.trim()) ||
         (typeof specs.type === "string" && specs.type.trim().toLowerCase() !== "bike" && specs.type.trim()) ||
-        "Unsorted";
+        "Без категории";
 
       const mediaUrls = Array.from(new Set([
         car.image_url ?? "",
@@ -775,7 +775,7 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
       return {
         id: car.id,
         title: `${car.make} ${car.model}`.trim(),
-        subtitle: (typeof specs.subtitle === "string" ? specs.subtitle : "Ready to ride") as string,
+        subtitle: (typeof specs.subtitle === "string" ? specs.subtitle : "Готов к выезду") as string,
         description: car.description ?? (typeof specs.description === "string" ? specs.description : "Подробности откроются в карточке"),
         imageUrl: mediaUrls[0] ?? "",
         mediaUrls,
@@ -947,11 +947,11 @@ function parseAdCards(lines: string, slug: string): Array<{ id: string; title: s
       const [id, title, subtitle, href, imageUrl, badge, activeFrom, activeTo, priority, ctaLabel] = line.split("|").map((value) => value.trim());
       return {
         id: id || `ad-${index + 1}`,
-        title: trimCampaignTitle(title || "", `Ad ${index + 1}`),
+        title: trimCampaignTitle(title || "", `Анонс ${index + 1}`),
         subtitle: subtitle || "",
         href: normalizeCampaignHref(href || "", slug),
         imageUrl: imageUrl || "",
-        badge: badge || "Ad",
+        badge: badge || "Анонс",
         activeFrom: activeFrom || "",
         activeTo: activeTo || "",
         priority: Number.isFinite(Number(priority)) ? Number(priority) : 40,
@@ -968,7 +968,7 @@ function parseMenuLinks(lines: string, slug: string): Array<{ label: string; hre
     .map((line) => {
       const [label, href] = line.split("|").map((value) => value.trim());
       return {
-        label: label || "Link",
+        label: label || "Ссылка",
         href: withSlug(href || `/franchize/${slug}`, slug),
       };
     });
@@ -1066,7 +1066,7 @@ async function toFranchizeConfigInput(crew: UnknownRecord, slug: string): Promis
       .map((entry) => `${entry.label}|${entry.href}`)
       .join("\n"),
     menuLinksText: menuLinks
-      .map((entry) => `${readPath(entry, ["label"], "Link")}|${readPath(entry, ["href"], `/franchize/${slug}`)}`)
+      .map((entry) => `${readPath(entry, ["label"], "Ссылка")}|${readPath(entry, ["href"], `/franchize/${slug}`)}`)
       .join("\n"),
     categoryOrderText: readArrayPath<string>(franchize, ["catalog", "groupOrder"]).join(", "),
     promoBannersText: readArrayPath<unknown>(franchize, ["catalog", "promoBanners"])

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -26,7 +26,7 @@ const QUICK_FILTERS: Array<{ key: QuickFilterKey; label: string }> = [
   { key: "budget", label: "До 5000" },
   { key: "premium", label: "Премиум 7000+" },
   { key: "newbie", label: "Для новичка" },
-  { key: "topRated", label: "Top rated" },
+  { key: "topRated", label: "Лучшие отзывы" },
 ];
 
 const sortWbItemLast = <T extends { category: string }>(groups: T[]) => {
@@ -34,6 +34,26 @@ const sortWbItemLast = <T extends { category: string }>(groups: T[]) => {
   const wbItems = groups.filter((group) => group.category.toLowerCase().includes("wbitem"));
   return [...regular, ...wbItems];
 };
+
+
+function CatalogCardSkeleton({ index }: { index: number }) {
+  return (
+    <article className="overflow-hidden rounded-3xl border border-[var(--catalog-border)] bg-[var(--catalog-card-bg)]" aria-hidden="true">
+      <div className="relative aspect-[4/3] overflow-hidden bg-black/20 lg:aspect-square">
+        <div
+          className="absolute inset-y-0 w-1/2 animate-shimmer bg-gradient-to-r from-transparent via-white/15 to-transparent"
+          style={{ animationDelay: `${index * 120}ms` }}
+        />
+      </div>
+      <div className="space-y-3 p-3">
+        <div className="h-4 w-2/3 rounded-full bg-[var(--catalog-muted)]/25" />
+        <div className="h-3 w-full rounded-full bg-[var(--catalog-muted)]/20" />
+        <div className="h-3 w-4/5 rounded-full bg-[var(--catalog-muted)]/20" />
+        <div className="h-10 rounded-xl bg-[var(--catalog-accent)]/25" />
+      </div>
+    </article>
+  );
+}
 
 export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogClientProps) {
   const surface = crewPaletteForSurface(crew.theme);
@@ -64,7 +84,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
         subtitle: item.subtitle,
         href: item.href,
         imageUrl: item.imageUrl,
-        badge: item.code || "Promo",
+        badge: item.code || "Промо",
         priority: item.priority ?? 50,
         activeFrom: item.activeFrom ?? "",
         activeTo: item.activeTo ?? "",
@@ -76,7 +96,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
         subtitle: item.subtitle,
         href: item.href,
         imageUrl: item.imageUrl,
-        badge: item.badge || "Ad",
+        badge: item.badge || "Анонс",
         priority: item.priority ?? 40,
         activeFrom: item.activeFrom ?? "",
         activeTo: item.activeTo ?? "",
@@ -109,7 +129,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
       subtitle: "",
       href: item.href?.trim() || `/franchize/${crew.slug || slug}#catalog-sections`,
       imageUrl: "",
-      badge: "Promo",
+      badge: "Промо",
       priority: 0,
       activeFrom: "",
       activeTo: "",
@@ -399,9 +419,15 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
         </div>
 
         {items.length === 0 ? (
-          <div className="rounded-2xl border border-dashed p-4 text-sm" style={surface.mutedText}>
-            Каталог пуст. Добавь позиции типов `bike`, `accessories`, `gear` или `wbitem`, чтобы наполнить витрину.
-          </div>
+          <section aria-label="Загружаем каталог" className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-2xl font-bold uppercase leading-tight tracking-tight text-[var(--catalog-text)]">Каталог</h2>
+              <span className="inline-flex rounded-full bg-[var(--catalog-card-bg)] px-2.5 py-1 text-[11px] font-medium text-[var(--catalog-muted)]">обновляем наличие</span>
+            </div>
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-4">
+              {[0, 1, 2, 3].map((index) => <CatalogCardSkeleton key={index} index={index} />)}
+            </div>
+          </section>
         ) : itemsByCategory.length === 0 ? (
           <div className="rounded-2xl border border-dashed p-4 text-sm" style={surface.mutedText}>
             По запросу ничего не найдено. Попробуй другое название или категорию.
@@ -447,7 +473,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
                           <div className="mb-2 flex flex-wrap gap-1.5">
                             {item.isHot && (
                               <span className="inline-flex rounded-full bg-[color:color-mix(in_srgb,var(--catalog-accent)_86%,transparent)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--catalog-accent-contrast)]">
-                                HOT 🔥
+                                Горячее 🔥
                               </span>
                             )}
                             <span

--- a/app/franchize/components/FranchizeAdminClient.tsx
+++ b/app/franchize/components/FranchizeAdminClient.tsx
@@ -349,7 +349,7 @@ export function FranchizeAdminClient({ initialSlug, editId }: FranchizeAdminClie
 
         <div className="mt-4 rounded-2xl border p-3" style={{ ...surface.subtleCard, borderColor: "var(--fr-admin-border)" }}>
           <div className="flex items-center justify-between gap-3">
-            <p className="text-sm font-semibold text-[var(--fr-admin-text)]">Rental reviews moderation</p>
+            <p className="text-sm font-semibold text-[var(--fr-admin-text)]">Модерация отзывов аренды</p>
             <span className="rounded-full border px-2 py-1 text-xs text-[var(--fr-admin-muted)]" style={{ borderColor: "var(--fr-admin-border)" }}>{reviews.length}</span>
           </div>
           {!reviews.length ? (
@@ -364,7 +364,7 @@ export function FranchizeAdminClient({ initialSlug, editId }: FranchizeAdminClie
                       {review.hiddenAt ? "Показать" : "Скрыть"}
                     </Button>
                   </div>
-                  <p className="mt-1 text-xs text-[var(--fr-admin-muted)]">bike: {review.bikeId} · user: {review.userId}</p>
+                  <p className="mt-1 text-xs text-[var(--fr-admin-muted)]">байк: {review.bikeId} · пользователь: {review.userId}</p>
                   {review.text && <p className="mt-2 text-sm text-[var(--fr-admin-text)]">{review.text}</p>}
                 </div>
               ))}

--- a/app/franchize/components/FranchizeProfileButton.tsx
+++ b/app/franchize/components/FranchizeProfileButton.tsx
@@ -190,7 +190,7 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
           <DropdownMenuItem asChild>
             <Link href="/franchize/create" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
               <Palette className="mr-2 h-4 w-4 shrink-0" />
-              <span className="truncate">Branding (экипаж)</span>
+              <span className="truncate">Оформление экипажа</span>
             </Link>
           </DropdownMenuItem>
 
@@ -198,7 +198,7 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
             <DropdownMenuItem asChild>
               <Link href={franchizeAdminHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
                 <Shield className="mr-2 h-4 w-4 shrink-0" />
-                <span className="truncate">Franchize admin</span>
+                <span className="truncate">Админка франшизы</span>
               </Link>
             </DropdownMenuItem>
           ) : null}
@@ -206,7 +206,7 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
           <DropdownMenuItem asChild>
             <Link href={franchizeProfileHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
               <IdCard className="mr-2 h-4 w-4 shrink-0" />
-              <span className="truncate">Franchize profile</span>
+              <span className="truncate">Профиль франшизы</span>
             </Link>
           </DropdownMenuItem>
 
@@ -265,7 +265,7 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
               <DropdownMenuItem asChild>
                 <Link href="/admin" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
                   <Shield className="mr-2 h-4 w-4" />
-                  <span className="truncate">Admin</span>
+                  <span className="truncate">Админка</span>
                 </Link>
               </DropdownMenuItem>
             </>

--- a/app/franchize/components/FranchizeRentalDocumentsPanel.tsx
+++ b/app/franchize/components/FranchizeRentalDocumentsPanel.tsx
@@ -60,10 +60,10 @@ export function FranchizeRentalDocumentsPanel({ rentalId, ownerId, status, metad
         notes: freezeNotes,
       });
       if (!result.success) {
-        toast.error(result.error || "Не удалось сохранить Pickup Freeze");
+        toast.error(result.error || "Не удалось сохранить выдачу");
         return;
       }
-      toast.success("Pickup Freeze сохранен. Теперь можно подтверждать выдачу.");
+      toast.success("Выдача сохранена. Теперь можно подтверждать старт аренды.");
     });
   };
 
@@ -79,11 +79,11 @@ export function FranchizeRentalDocumentsPanel({ rentalId, ownerId, status, metad
         notes: damageNotes,
       });
       if (!result.success) {
-        toast.error(result.error || "Не удалось добавить Damage Report");
+        toast.error(result.error || "Не удалось добавить отчёт о повреждении");
         return;
       }
       setDamageNotes("");
-      toast.success("Damage Report добавлен в Rental Documents.");
+      toast.success("Отчёт о повреждении добавлен в документы аренды.");
     });
   };
 
@@ -93,14 +93,14 @@ export function FranchizeRentalDocumentsPanel({ rentalId, ownerId, status, metad
       style={{ borderColor: palette.borderSoft, backgroundColor: `${palette.bgCard}CC` }}
     >
       <p className="text-xs uppercase tracking-[0.16em]" style={{ color: palette.textSecondary }}>
-        Rental Documents
+        Документы аренды
       </p>
       <h3 className="mt-1 text-base font-semibold" style={{ color: palette.textPrimary }}>
-        Pickup Freeze + Damage Report
+        Фиксация выдачи и повреждений
       </h3>
 
       <div className="mt-3 rounded-xl border p-3" style={{ borderColor: palette.borderSoft }}>
-        <p className="text-sm font-medium">Pickup Freeze</p>
+        <p className="text-sm font-medium">Фиксация выдачи</p>
         {pickupFreeze?.frozen_at ? (
           <div className="mt-2 space-y-1 text-xs" style={{ color: palette.textSecondary }}>
             <p>Статус: зафиксировано {new Date(pickupFreeze.frozen_at).toLocaleString("ru-RU")}</p>
@@ -108,7 +108,7 @@ export function FranchizeRentalDocumentsPanel({ rentalId, ownerId, status, metad
             <p>Чеклист: {(pickupFreeze.checklist || []).join(", ") || "—"}</p>
           </div>
         ) : (
-          <p className="mt-2 text-xs" style={{ color: palette.textSecondary }}>Freeze пока не зафиксирован.</p>
+          <p className="mt-2 text-xs" style={{ color: palette.textSecondary }}>Выдача пока не зафиксирована.</p>
         )}
 
         {canFreeze && (
@@ -131,7 +131,7 @@ export function FranchizeRentalDocumentsPanel({ rentalId, ownerId, status, metad
                 </button>
               ))}
             </div>
-            <textarea className="min-h-16 w-full rounded-lg border px-2 py-1.5" style={{ borderColor: palette.borderSoft }} value={freezeNotes} onChange={(e) => setFreezeNotes(e.target.value)} placeholder="Комментарий к freeze (опционально)" />
+            <textarea className="min-h-16 w-full rounded-lg border px-2 py-1.5" style={{ borderColor: palette.borderSoft }} value={freezeNotes} onChange={(e) => setFreezeNotes(e.target.value)} placeholder="Комментарий к выдаче (опционально)" />
             <button
               type="button"
               disabled={isPending}
@@ -139,22 +139,22 @@ export function FranchizeRentalDocumentsPanel({ rentalId, ownerId, status, metad
               className="rounded-lg px-3 py-2 text-sm font-semibold"
               style={{ backgroundColor: palette.accentMain, color: "#16130A" }}
             >
-              {isPending ? "Сохраняем..." : "Сохранить Pickup Freeze"}
+              {isPending ? "Сохраняем..." : "Сохранить выдачу"}
             </button>
           </div>
         )}
       </div>
 
       <div className="mt-3 rounded-xl border p-3" style={{ borderColor: palette.borderSoft }}>
-        <p className="text-sm font-medium">Damage Reports ({damageReports.length})</p>
+        <p className="text-sm font-medium">Отчёты о повреждениях ({damageReports.length})</p>
         <div className="mt-2 grid gap-2 sm:grid-cols-2">
           <select className="rounded-lg border px-2 py-1.5 text-sm" style={{ borderColor: palette.borderSoft }} value={damagePhase} onChange={(e) => setDamagePhase(e.target.value as "pickup" | "return")}>
             <option value="pickup">На выдаче</option>
             <option value="return">На возврате</option>
           </select>
           <select className="rounded-lg border px-2 py-1.5 text-sm" style={{ borderColor: palette.borderSoft }} value={damageSeverity} onChange={(e) => setDamageSeverity(e.target.value as "minor" | "major")}>
-            <option value="minor">Minor</option>
-            <option value="major">Major</option>
+            <option value="minor">Лёгкое</option>
+            <option value="major">Серьёзное</option>
           </select>
         </div>
         <textarea className="mt-2 min-h-16 w-full rounded-lg border px-2 py-1.5 text-sm" style={{ borderColor: palette.borderSoft }} value={damageNotes} onChange={(e) => setDamageNotes(e.target.value)} placeholder="Описание повреждения / замечания" />
@@ -165,7 +165,7 @@ export function FranchizeRentalDocumentsPanel({ rentalId, ownerId, status, metad
           className="mt-2 rounded-lg border px-3 py-2 text-sm"
           style={{ borderColor: palette.borderSoft, color: palette.textPrimary }}
         >
-          Добавить Damage Report
+          Добавить отчёт
         </button>
 
         <ul className="mt-3 space-y-2 text-xs" style={{ color: palette.textSecondary }}>
@@ -175,7 +175,7 @@ export function FranchizeRentalDocumentsPanel({ rentalId, ownerId, status, metad
                 {report.phase === "pickup" ? "Выдача" : "Возврат"} · {report.severity}
               </p>
               <p>{report.notes}</p>
-              <p>{report.reporter_role || "user"} · {report.reported_at ? new Date(report.reported_at).toLocaleString("ru-RU") : "—"}</p>
+              <p>{report.reporter_role || "пользователь"} · {report.reported_at ? new Date(report.reported_at).toLocaleString("ru-RU") : "—"}</p>
             </li>
           ))}
           {damageReports.length === 0 && <li>Отчётов о повреждениях пока нет.</li>}

--- a/app/franchize/components/FranchizeRentalLifecycleActions.tsx
+++ b/app/franchize/components/FranchizeRentalLifecycleActions.tsx
@@ -117,7 +117,7 @@ export function FranchizeRentalLifecycleActions({
                   return;
                 }
                 if (!hasPickupFreeze) {
-                  toast.error("Сначала заполните Pickup Freeze в Rental Documents.");
+                  toast.error("Сначала сохраните выдачу в документах аренды.");
                   return;
                 }
                 const result = await confirmVehiclePickup(rentalId, dbUser.user_id);
@@ -210,7 +210,7 @@ export function FranchizeRentalLifecycleActions({
       {role === "guest" && <p className="mt-3 text-xs text-[var(--lifecycle-muted)]">Действия доступны владельцу или арендатору этой сделки.</p>}
       {pickupActionBlockedByFreeze && (
         <p className="mt-3 text-xs text-[var(--lifecycle-muted)]">
-          Подтверждение выдачи будет доступно после сохранения Pickup Freeze в разделе Rental Documents.
+          Подтверждение выдачи будет доступно после сохранения выдачи в документах аренды.
         </p>
       )}
     </div>

--- a/app/franchize/components/OrderPageClient.tsx
+++ b/app/franchize/components/OrderPageClient.tsx
@@ -415,7 +415,7 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
       if (!result.success) {
         toast.error(result.error ?? "Не удалось отправить заказ.");
         if (values.payment === "telegram_xtr") {
-          setPaymentRetryHint("XTR-оплата не завершилась. Проверьте Telegram WebApp и повторите отправку или выберите fallback-оплату.");
+          setPaymentRetryHint("XTR-оплата не завершилась. Проверьте Telegram WebApp и повторите отправку или выберите резервную оплату.");
         }
         lastSubmitFingerprintRef.current = null;
         return;
@@ -505,7 +505,7 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
   const handleSwitchToFallbackPayment = () => {
     setValue("payment", "card", { shouldDirty: true, shouldValidate: true });
     setPaymentRetryHint(null);
-    toast.message("Переключили на fallback-оплату картой. Проверьте данные и отправьте заказ снова.");
+    toast.message("Переключили на резервную оплату картой. Проверьте данные и отправьте заказ снова.");
   };
 
   return (
@@ -760,7 +760,7 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
           <p className="text-sm" style={surface.mutedText}>Заказ #{orderId}</p>
           <div className="mt-3 rounded-xl border border-[var(--order-border)] px-3 py-2" style={surface.subtleCard}>
             <div className="flex items-center justify-between gap-2">
-              <p className="text-xs uppercase tracking-[0.18em]" style={surface.mutedText}>Checkout vibe</p>
+              <p className="text-xs uppercase tracking-[0.18em]" style={surface.mutedText}>Финальная проверка</p>
               <span
                 className="rounded-full px-2 py-0.5 text-[11px] font-semibold"
                 style={{
@@ -804,9 +804,9 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
 
           <div className="mt-3 rounded-xl border border-[var(--order-border)] p-3" style={surface.subtleCard}>
             <div className="flex items-start justify-between gap-2">
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--order-accent)]">Checkout copilot</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--order-accent)]">Помощник заказа</p>
               <span className="rounded-full bg-[var(--order-accent-soft)] px-2 py-0.5 text-[10px] font-semibold text-[var(--order-accent)]">
-                {checkoutBlockers.length === 0 ? "ready" : `${checkoutBlockers.length} blockers`}
+                {checkoutBlockers.length === 0 ? "готово" : `${checkoutBlockers.length} стоп-фактор${checkoutBlockers.length === 1 ? "" : "а"}`}
               </span>
             </div>
             {checkoutBlockers.length === 0 ? (

--- a/app/franchize/create/CreateFranchizeForm.tsx
+++ b/app/franchize/create/CreateFranchizeForm.tsx
@@ -126,7 +126,7 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
   const [form, setForm] = useState<FranchizeConfigInput>({
     slug: "",
     brandName: "VIP BIKE",
-    tagline: "Ride the vibe",
+    tagline: "Маршрут начинается здесь",
     logoUrl: "",
     themeMode: "pepperolli_dark",
     bgBase: "#0B0C10",
@@ -155,9 +155,9 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
     mapBoundsRight: "44.12",
     socialLinksText: "Telegram|https://t.me/oneBikePlsBot",
     menuLinksText: "Каталог|/franchize/{slug}\nО нас|/franchize/{slug}/about\nКонтакты|/franchize/{slug}/contacts\nКорзина|/franchize/{slug}/cart",
-    categoryOrderText: "Naked, Supersport, Touring, Neo-retro",
-    promoBannersText: "weekend-boost|Weekend boost|Скидка 10% на выходные|WEEKEND10|/franchize/{slug}#catalog-sections||2026-02-01|2026-12-31|90|Забрать скидку",
-    adCardsText: "safety-kit|Экипировка PRO|Подбор шлема и защиты перед выдачей|/franchize/{slug}/about||Safety|2026-02-01|2026-12-31|70|Смотреть детали",
+    categoryOrderText: "Электроэндуро, Город, Туризм, Экип",
+    promoBannersText: "weekend-boost|Выходные на байке|Скидка 10% на выходные|WEEKEND10|/franchize/{slug}#catalog-sections||2026-02-01|2026-12-31|90|Забрать скидку",
+    adCardsText: "safety-kit|Экипировка PRO|Подбор шлема и защиты перед выдачей|/franchize/{slug}/about||Безопасность|2026-02-01|2026-12-31|70|Смотреть детали",
     allowPromo: true,
     deliveryModesText: "pickup, delivery",
     paymentOptionsText: "telegram_xtr, card, sbp, cash",
@@ -230,12 +230,12 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
       const lightContrastPass = contrastRatio(form.lightBgCard, form.lightTextPrimary);
       const hasContrast = (darkContrastPass ?? 0) >= 4.5 && (lightContrastPass ?? 0) >= 4.5;
       const checks = [
-        { id: "slug", label: "Crew slug + brand identity", done: hasSlug && hasBrand && hasTagline, hint: "Задайте slug, название и читаемый слоган." },
-        { id: "contacts", label: "Telegram-first контакты", done: hasContacts, hint: "Добавьте телефон + Telegram @handle." },
-        { id: "map", label: "VibeMap комплект", done: hasMap, hint: "Проверьте GPS и map image URL." },
-        { id: "menu", label: "Маршрутная сетка /franchize/{slug}", done: hasMenuLinks, hint: "В menu links должна быть canonical ссылка /franchize/{slug}." },
-        { id: "catalog", label: "Каталог готов к запуску", done: hasCategories, hint: "Укажите минимум 3 категории для rail/filter UX." },
-        { id: "contrast", label: "Контраст dark/light", done: hasContrast, hint: "Цель: контраст 4.5+ для главного текста в dark и light." },
+        { id: "slug", label: "Slug экипажа + бренд", done: hasSlug && hasBrand && hasTagline, hint: "Задайте slug, название и читаемый слоган." },
+        { id: "contacts", label: "Контакты для Telegram", done: hasContacts, hint: "Добавьте телефон + Telegram @handle." },
+        { id: "map", label: "VibeMap комплект", done: hasMap, hint: "Проверьте координаты и ссылку на карту." },
+        { id: "menu", label: "Маршрутная сетка /franchize/{slug}", done: hasMenuLinks, hint: "В меню должна быть основная ссылка /franchize/{slug}." },
+        { id: "catalog", label: "Каталог готов к запуску", done: hasCategories, hint: "Укажите минимум 3 категории для витрины и фильтров." },
+        { id: "contrast", label: "Контраст тёмной/светлой темы", done: hasContrast, hint: "Цель: контраст 4.5+ для главного текста в обеих темах." },
       ];
       const doneCount = checks.filter((item) => item.done).length;
       const score = Math.round((doneCount / checks.length) * 100);
@@ -407,7 +407,7 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
           ["content", "Фаза 2: Контент"],
           ["map", "Фаза 3: Карта"],
           ["ai", "Фаза 4: AI JSON"],
-          ["ops", "Launch cockpit"],
+          ["ops", "Пульт запуска"],
         ].map(([value, label]) => (
           <button
             key={value}
@@ -462,11 +462,11 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
             ))}
           </div>
           <div className="rounded-xl border p-3" style={{ borderColor: form.lightBorderSoft, backgroundColor: form.lightBgBase, color: form.lightTextPrimary }}>
-            <p className="text-xs uppercase tracking-[0.12em]" style={{ color: form.lightAccentMain }}>Light preview</p>
+            <p className="text-xs uppercase tracking-[0.12em]" style={{ color: form.lightAccentMain }}>Светлая тема</p>
             <div className="mt-2 rounded-lg border p-3" style={{ borderColor: form.lightBorderSoft, backgroundColor: form.lightBgCard }}>
               <h4 className="font-semibold" style={{ color: form.lightTextPrimary }}>Карточка в светлой теме</h4>
               <p className="mt-1 text-sm" style={{ color: form.lightTextSecondary }}>Проверьте читаемость текста и заметность CTA.</p>
-              <button type="button" className="mt-2 rounded-lg px-3 py-2 text-sm font-semibold" style={{ backgroundColor: form.lightAccentMain, color: "#16130A" }}>Light action</button>
+              <button type="button" className="mt-2 rounded-lg px-3 py-2 text-sm font-semibold" style={{ backgroundColor: form.lightAccentMain, color: "#16130A" }}>Проверить действие</button>
             </div>
           </div>
           <div className="rounded-xl border p-3 text-sm" style={{ borderColor: ui.border, backgroundColor: ui.inputBg }}>
@@ -488,17 +488,17 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
             <textarea className={`${inputClass} min-h-28`} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.menuLinksText} onChange={(e) => updateField("menuLinksText", e.target.value)} />
           </label>
           <label className="text-sm">Категории (CSV)<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.categoryOrderText} onChange={(e) => updateField("categoryOrderText", e.target.value)} /></label>
-          <label className="text-sm md:col-span-3">Promo cards (`id|title|subtitle|code|href|imageUrl|activeFrom|activeTo|priority|ctaLabel`)
+          <label className="text-sm md:col-span-3">Промо-карточки (`id|title|subtitle|code|href|imageUrl|activeFrom|activeTo|priority|ctaLabel`)
             <textarea className={`${inputClass} min-h-24`} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.promoBannersText} onChange={(e) => updateField("promoBannersText", e.target.value)} />
           </label>
-          <label className="text-sm md:col-span-3">Ad cards (`id|title|subtitle|href|imageUrl|badge|activeFrom|activeTo|priority|ctaLabel`)
+          <label className="text-sm md:col-span-3">Рекламные карточки (`id|title|subtitle|href|imageUrl|badge|activeFrom|activeTo|priority|ctaLabel`)
             <textarea className={`${inputClass} min-h-24`} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.adCardsText} onChange={(e) => updateField("adCardsText", e.target.value)} />
           </label>
           <label className="text-sm flex items-center gap-2"><input type="checkbox" checked={form.allowPromo} onChange={(e) => updateField("allowPromo", e.target.checked)} /> Разрешить промокод</label>
           <label className="text-sm">Режимы выдачи (CSV)<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.deliveryModesText} onChange={(e) => updateField("deliveryModesText", e.target.value)} /></label>
           <label className="text-sm">Оплата (CSV: telegram_xtr, card, sbp, cash ...)<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.paymentOptionsText} onChange={(e) => updateField("paymentOptionsText", e.target.value)} /></label>
           <label className="text-sm">Режим по умолчанию<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.defaultMode} onChange={(e) => updateField("defaultMode", e.target.value)} /></label>
-          <h3 className="md:col-span-3 mt-2 text-base font-semibold" style={{ color: ui.text }}>Private crew secrets (contract defaults)</h3>
+          <h3 className="md:col-span-3 mt-2 text-base font-semibold" style={{ color: ui.text }}>Приватные настройки экипажа и договора</h3>
           <label className="text-sm">Юрлицо / issuerName<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.issuerName} onChange={(e) => updateField("issuerName", e.target.value)} /></label>
           <label className="text-sm">Представитель / issuer_representative<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.issuerRepresentative} onChange={(e) => updateField("issuerRepresentative", e.target.value)} /></label>
           <label className="text-sm">Пробег включён (км)<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.includedMileage} onChange={(e) => updateField("includedMileage", e.target.value)} /></label>
@@ -507,10 +507,10 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
           <label className="text-sm">Оценка байка (прописью)<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.bikeValueWords} onChange={(e) => updateField("bikeValueWords", e.target.value)} /></label>
           <label className="text-sm">Штраф за просрочку (руб)<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.lateReturnPenaltyRub} onChange={(e) => updateField("lateReturnPenaltyRub", e.target.value)} /></label>
           <label className="text-sm md:col-span-2">Адрес возврата<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.returnAddress} onChange={(e) => updateField("returnAddress", e.target.value)} /></label>
-          <label className="text-sm md:col-span-3">Contract defaults JSON (private.crew_secrets.contract_defaults)
+          <label className="text-sm md:col-span-3">Настройки договора JSON (private.crew_secrets.contract_defaults)
             <textarea className={`${inputClass} min-h-24 font-mono text-xs`} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.contractDefaultsJson} onChange={(e) => updateField("contractDefaultsJson", e.target.value)} />
           </label>
-          <label className="text-sm md:col-span-3">DOC templates JSON (private.crew_secrets.doc_templates)
+          <label className="text-sm md:col-span-3">Шаблоны документов JSON (private.crew_secrets.doc_templates)
             <textarea className={`${inputClass} min-h-24 font-mono text-xs`} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.docTemplatesJson} onChange={(e) => updateField("docTemplatesJson", e.target.value)} />
           </label>
         </section>
@@ -521,28 +521,28 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
         <section className={`${sectionClass} grid gap-3 md:grid-cols-2`} style={{ borderColor: ui.border, backgroundColor: ui.sectionBg }}>
           <h2 className="md:col-span-2 text-lg font-medium" style={{ color: ui.text }}>Карта и онлайн-каналы</h2>
           <label className="text-sm">Telegram экипажа<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.telegram} onChange={(e) => updateField("telegram", e.target.value)} placeholder="@oneBikePlsBot" /></label>
-          <label className="text-sm">GPS (lat, lon)<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapGps} onChange={(e) => updateField("mapGps", e.target.value)} placeholder="56.2042, 43.7985" /></label>
-          <label className="text-sm md:col-span-2">Map image URL (VibeMap)
+          <label className="text-sm">Координаты (lat, lon)<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapGps} onChange={(e) => updateField("mapGps", e.target.value)} placeholder="56.2042, 43.7985" /></label>
+          <label className="text-sm md:col-span-2">Картинка карты (VibeMap)
             <input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapImageUrl} onChange={(e) => updateField("mapImageUrl", e.target.value)} />
           </label>
-          <label className="text-sm">Bounds top<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapBoundsTop} onChange={(e) => updateField("mapBoundsTop", e.target.value)} /></label>
-          <label className="text-sm">Bounds bottom<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapBoundsBottom} onChange={(e) => updateField("mapBoundsBottom", e.target.value)} /></label>
-          <label className="text-sm">Bounds left<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapBoundsLeft} onChange={(e) => updateField("mapBoundsLeft", e.target.value)} /></label>
-          <label className="text-sm">Bounds right<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapBoundsRight} onChange={(e) => updateField("mapBoundsRight", e.target.value)} /></label>
+          <label className="text-sm">Верхняя граница<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapBoundsTop} onChange={(e) => updateField("mapBoundsTop", e.target.value)} /></label>
+          <label className="text-sm">Нижняя граница<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapBoundsBottom} onChange={(e) => updateField("mapBoundsBottom", e.target.value)} /></label>
+          <label className="text-sm">Левая граница<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapBoundsLeft} onChange={(e) => updateField("mapBoundsLeft", e.target.value)} /></label>
+          <label className="text-sm">Правая граница<input className={inputClass} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.mapBoundsRight} onChange={(e) => updateField("mapBoundsRight", e.target.value)} /></label>
           <label className="text-sm md:col-span-2">Соцсети (`название|ссылка`)
             <textarea className={`${inputClass} min-h-28`} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.socialLinksText} onChange={(e) => updateField("socialLinksText", e.target.value)} />
           </label>
           <div className="md:col-span-2 rounded-2xl border p-4" style={{ borderColor: ui.border, backgroundColor: ui.cardBg }}>
-            <p className="text-xs uppercase tracking-[0.16em]" style={{ color: ui.accent }}>Map control center</p>
+            <p className="text-xs uppercase tracking-[0.16em]" style={{ color: ui.accent }}>Центр карты</p>
             <p className="mt-2 text-sm" style={{ color: ui.muted }}>
-              Вся полезная map-инфраструктура теперь в одном месте: кастомизация, map-riders, публичные контакты и калибратор для новых presets.
+              Всё для карты в одном месте: оформление, MapRiders, публичные контакты и калибратор для новых пресетов.
             </p>
             <div className="mt-3 grid gap-2 sm:grid-cols-2">
               {[
-                { label: "MapRiders preview", href: `/franchize/${form.slug || "vip-bike"}/map-riders` },
-                { label: "Contacts map", href: `/franchize/${form.slug || "vip-bike"}/contacts` },
-                { label: "Franchize admin", href: `/franchize/${form.slug || "vip-bike"}/admin` },
-                { label: "Map calibrator", href: "/admin/map-calibrator" },
+                { label: "Превью MapRiders", href: `/franchize/${form.slug || "vip-bike"}/map-riders` },
+                { label: "Карта контактов", href: `/franchize/${form.slug || "vip-bike"}/contacts` },
+                { label: "Админка франшизы", href: `/franchize/${form.slug || "vip-bike"}/admin` },
+                { label: "Калибратор карты", href: "/admin/map-calibrator" },
               ].map((item) => (
                 <Link key={item.href} href={item.href} className="rounded-xl border px-3 py-2 text-sm font-medium transition hover:opacity-90" style={{ borderColor: ui.border, color: ui.text }}>
                   {item.label}
@@ -554,10 +554,10 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
       )}
       {stage === "ai" && (
         <section className={`${sectionClass} grid gap-3`} style={{ borderColor: ui.border, backgroundColor: ui.sectionBg }}>
-          <h2 className="text-lg font-medium" style={{ color: ui.text }}>AI-фаза: экономим мозговое время</h2>
+          <h2 className="text-lg font-medium" style={{ color: ui.text }}>AI-фаза: экономим время</h2>
           <div className="grid gap-2 sm:grid-cols-3">
-            <button type="button" className="rounded-xl px-3 py-2 text-sm font-semibold" style={{ backgroundColor: ui.accent, color: ui.accentText }} onClick={() => copyToClipboard(JSON.stringify(TEMPLATE_PAYLOAD, null, 2), "Template скопирован")}>Copy template</button>
-            <button type="button" className="rounded-xl border px-3 py-2 text-sm font-semibold" style={{ borderColor: ui.border, color: ui.text }} onClick={() => copyToClipboard(BOT_PROMPT, "Промпт скопирован")}>Copy prompt for bot</button>
+            <button type="button" className="rounded-xl px-3 py-2 text-sm font-semibold" style={{ backgroundColor: ui.accent, color: ui.accentText }} onClick={() => copyToClipboard(JSON.stringify(TEMPLATE_PAYLOAD, null, 2), "Шаблон скопирован")}>Скопировать шаблон</button>
+            <button type="button" className="rounded-xl border px-3 py-2 text-sm font-semibold" style={{ borderColor: ui.border, color: ui.text }} onClick={() => copyToClipboard(BOT_PROMPT, "Промпт скопирован")}>Скопировать промпт для бота</button>
             <button type="button" className="rounded-xl border px-3 py-2 text-sm font-semibold" style={{ borderColor: ui.border, color: ui.text }} onClick={applyAdvancedJsonLocally}>Применить JSON локально</button>
           </div>
           <textarea className={`${inputClass} min-h-[420px] font-mono text-xs`} style={{ borderColor: ui.border, backgroundColor: ui.inputBg, color: ui.text }} value={form.advancedJson} onChange={(e) => updateField("advancedJson", e.target.value)} />
@@ -570,8 +570,8 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
           <div className="rounded-2xl border p-4" style={{ borderColor: ui.border, backgroundColor: ui.cardBg }}>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
-                <p className="text-xs uppercase tracking-[0.16em]" style={{ color: ui.accent }}>Franchize launch cockpit</p>
-                <h2 className="mt-1 text-lg font-semibold">Сводный readiness score</h2>
+                <p className="text-xs uppercase tracking-[0.16em]" style={{ color: ui.accent }}>Пульт запуска франшизы</p>
+                <h2 className="mt-1 text-lg font-semibold">Готовность к запуску</h2>
               </div>
               <span className="rounded-full px-3 py-1 text-sm font-semibold" style={{ backgroundColor: `${ui.accent}22`, color: ui.accent }}>
                 {launchChecks.score}%
@@ -581,13 +581,13 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
               <div className="h-full rounded-full transition-all duration-500" style={{ width: `${launchChecks.score}%`, background: `linear-gradient(90deg, ${ui.accent}, ${form.accentMainHover})` }} />
             </div>
             <p className="mt-2 text-xs" style={{ color: ui.muted }}>
-              Пройдено {launchChecks.doneCount} из {launchChecks.checks.length} launch-checkов. Цель перед релизом: 100%.
+              Пройдено {launchChecks.doneCount} из {launchChecks.checks.length} проверок. Цель перед релизом: 100%.
             </p>
           </div>
 
           <div className="grid gap-3 lg:grid-cols-2">
             <div className="rounded-2xl border p-4" style={{ borderColor: ui.border, backgroundColor: ui.cardBg }}>
-              <h3 className="text-sm font-semibold uppercase tracking-[0.14em]" style={{ color: ui.accent }}>Launch checks</h3>
+              <h3 className="text-sm font-semibold uppercase tracking-[0.14em]" style={{ color: ui.accent }}>Проверки запуска</h3>
               <ul className="mt-3 space-y-2 text-sm">
                 {launchChecks.checks.map((check) => (
                   <li key={check.id} className="rounded-xl border px-3 py-2" style={{ borderColor: check.done ? `${ui.accent}88` : ui.border, backgroundColor: check.done ? `${ui.accent}15` : ui.sectionBg }}>
@@ -599,7 +599,7 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
             </div>
 
             <div className="rounded-2xl border p-4" style={{ borderColor: ui.border, backgroundColor: ui.cardBg }}>
-              <h3 className="text-sm font-semibold uppercase tracking-[0.14em]" style={{ color: ui.accent }}>Execution surfaces</h3>
+              <h3 className="text-sm font-semibold uppercase tracking-[0.14em]" style={{ color: ui.accent }}>Публичные разделы</h3>
               <p className="mt-2 text-xs" style={{ color: ui.muted }}>Быстрые переходы по каноническому маршруту: каталог → инфо → контакты → корзина.</p>
               <div className="mt-3 grid gap-2 sm:grid-cols-2">
                 {[
@@ -614,11 +614,11 @@ export default function CreateFranchizeForm({ initialSlug = "" }: { initialSlug?
                 ))}
               </div>
               <div className="mt-4 rounded-xl border p-3" style={{ borderColor: ui.border, backgroundColor: ui.sectionBg }}>
-                <p className="text-xs uppercase tracking-[0.12em]" style={{ color: ui.accent }}>Next strategic beat</p>
+                <p className="text-xs uppercase tracking-[0.12em]" style={{ color: ui.accent }}>Следующий шаг</p>
                 <p className="mt-1 text-sm" style={{ color: ui.muted }}>
                   {launchChecks.blockers[0]
-                    ? `Закройте первым: ${launchChecks.blockers[0].label}. Потом прогоните smoke на /franchize/${form.slug || "vip-bike"}.`
-                    : "Конфиг готов к launch. Следом можно идти в QA smoke + скриншоты и ship в PR."}
+                    ? `Закройте первым: ${launchChecks.blockers[0].label}. Потом проверьте страницу /franchize/${form.slug || "vip-bike"}.`
+                    : "Конфиг готов к запуску. Следом — проверка, скриншоты и PR."}
                 </p>
               </div>
             </div>

--- a/app/vipbikerental/VipBikeRentalClient.tsx
+++ b/app/vipbikerental/VipBikeRentalClient.tsx
@@ -117,7 +117,7 @@ const fallbackHeroPanels: Record<HeroMode, HeroPanel> = {
     mode: "map",
     label: "Карта",
     icon: "::FaMapLocationDot::",
-    eyebrow: "MapRiders live",
+    eyebrow: "Живая карта",
     title: "Райдеры, маршруты и встречи",
     description: "Смотри активность комьюнити, ближайшие точки сбора и недельный прогресс прямо перед выездом.",
     href: "/franchize/vip-bike/map-riders",
@@ -125,7 +125,7 @@ const fallbackHeroPanels: Record<HeroMode, HeroPanel> = {
     meta: [
       { label: "онлайн", value: "3 райдера" },
       { label: "маршруты", value: "речные точки" },
-      { label: "встречи", value: "2 meetup" },
+      { label: "встречи", value: "2" },
     ],
   },
   rentals: {
@@ -225,9 +225,9 @@ const heroMetrics = [
 ];
 
 const conversionPilotChecks = [
-  { label: "Hero", value: "понятный старт", icon: "::FaLayerGroup::" },
-  { label: "Trust", value: "экип + ОСАГО", icon: "::FaShieldHeart::" },
-  { label: "Action", value: "3 пути", icon: "::FaBolt::" },
+  { label: "Старт", value: "понятный", icon: "::FaLayerGroup::" },
+  { label: "Защита", value: "экип + ОСАГО", icon: "::FaShieldHeart::" },
+  { label: "Путь", value: "3 сценария", icon: "::FaBolt::" },
 ];
 
 const decisionRoutes = [
@@ -247,33 +247,10 @@ const decisionRoutes = [
   },
   {
     title: "Кататься с группой",
-    text: "Если важен вайб комьюнити: открой райдеров рядом, точки старта и ближайшие meetup.",
+    text: "Если важен вайб комьюнити: открой райдеров рядом, точки старта и ближайшие встречи.",
     href: "/franchize/vip-bike/map-riders",
     cta: "Смотреть карту",
     icon: "::FaMapLocationDot::",
-  },
-];
-
-const partnerLinks = [
-  {
-    name: "Каталог аренды VIP Bike",
-    href: "/franchize/vip-bike",
-    note: "Подбор электроэндуро по уровню, трассе и формату аренды.",
-  },
-  {
-    name: "Конфигуратор электричек и заказ",
-    href: "/franchize/vip-bike/configurator",
-    note: "Актуальная конфигурация: модель → батарея → допы → корзина.",
-  },
-  {
-    name: "MapRiders",
-    href: "/franchize/vip-bike/map-riders",
-    note: "Карта райдеров, маршруты и точки встречи.",
-  },
-  {
-    name: "Личный раздел аренды",
-    href: "/franchize/vip-bike/rentals",
-    note: "Активные заказы, подтверждения, управление поездками.",
   },
 ];
 
@@ -301,7 +278,7 @@ const newbieFlow = [
   },
 ];
 
-function ConversionPilot({ items, overview }: { items: CatalogItemVM[]; overview: MapRidersOverview | null }) {
+function ConversionPilot({ items, overview, isCatalogLoading = false }: { items: CatalogItemVM[]; overview: MapRidersOverview | null; isCatalogLoading?: boolean }) {
   const rentableItems = items.filter((item) => item.availabilityStatus === "available" && item.pricePerDay > 0);
   const pricedRentalItems = items.filter((item) => item.pricePerDay > 0);
   const availableItems = rentableItems.length > 0 ? rentableItems : pricedRentalItems;
@@ -317,8 +294,8 @@ function ConversionPilot({ items, overview }: { items: CatalogItemVM[]; overview
   const riderLabel = getRussianRiderLabel(activeRidersCount);
   const scoreReasons = [
     `${availableItems.length || fallbackElectroItems.length} вариантов аренды`,
-    saleItems.length > 0 ? "есть sale-конфиг" : "тест-драйв перед покупкой",
-    overview ? "live MapRiders подключен" : "MapRiders fallback готов",
+    saleItems.length > 0 ? "покупка доступна" : "тест-драйв перед покупкой",
+    overview ? "карта подключена" : "карта готова",
   ];
 
   return (
@@ -327,10 +304,6 @@ function ConversionPilot({ items, overview }: { items: CatalogItemVM[]; overview
         <div>
           <p className="text-xs uppercase tracking-[0.24em] text-primary">быстрый выбор</p>
           <h2 className="mt-2 font-orbitron text-3xl sm:text-4xl">Выбери сценарий за 30 секунд</h2>
-          <p className="mt-2 max-w-3xl text-sm leading-relaxed text-muted-foreground">
-            После первого вау-экрана не нужно искать следующий шаг: выбери аренду, покупку после теста или групповую поездку —
-            лендинг сразу ведёт в нужный раздел VIP Bike.
-          </p>
         </div>
         <div className="rounded-2xl border border-primary/30 bg-primary/10 px-4 py-3 text-sm">
           <span className="text-xs uppercase tracking-[0.18em] text-muted-foreground">готовность</span>
@@ -343,10 +316,10 @@ function ConversionPilot({ items, overview }: { items: CatalogItemVM[]; overview
           <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_0%,rgba(255,179,71,0.25),transparent_38%),radial-gradient(circle_at_80%_70%,rgba(34,197,94,0.16),transparent_34%)]" />
           <div className="relative z-10 flex h-full flex-col justify-between gap-8">
             <div>
-              <p className="text-xs uppercase tracking-[0.24em] text-brand-yellow">best next action</p>
+              <p className="text-xs uppercase tracking-[0.24em] text-brand-yellow">следующий шаг</p>
               <h3 className="mt-3 font-orbitron text-3xl sm:text-4xl">{leadItem?.title || "VIP Bike"}</h3>
               <p className="mt-3 text-sm leading-relaxed text-white/75">
-                От {minDayPrice.toLocaleString("ru-RU")} ₽ / день · {activeRiders} {riderLabel} · быстрый старт из каталога VIP Bike.
+                {isCatalogLoading ? "Подтягиваем актуальные карточки..." : `От ${minDayPrice.toLocaleString("ru-RU")} ₽ / день · ${activeRiders} ${riderLabel}`}
               </p>
               <div className="mt-5 flex flex-wrap gap-2">
                 {scoreReasons.map((reason) => (
@@ -597,7 +570,7 @@ function VipBikeCompanyServiceHub() {
 }
 
 
-function RentalQuickActionHub({ items, overview }: { items: CatalogItemVM[]; overview: MapRidersOverview | null }) {
+function RentalQuickActionHub({ items, overview, isCatalogLoading = false }: { items: CatalogItemVM[]; overview: MapRidersOverview | null; isCatalogLoading?: boolean }) {
   const [selectedAction, setSelectedAction] = useState<"status" | "riders" | "chooser">("status");
   const [isChooserOpen, setIsChooserOpen] = useState(false);
   const [activeFilter, setActiveFilter] = useState<(typeof quickChooserFilters)[number]["id"]>("first");
@@ -620,7 +593,7 @@ function RentalQuickActionHub({ items, overview }: { items: CatalogItemVM[]; ove
       title: "Статус аренды",
       icon: "::FaTicket::",
       metric: "3 шага",
-      text: "Проверь, что уже закрыто перед поездкой: байк, экип и слот выдачи.",
+      text: "Байк, экип и слот выдачи — в одном личном разделе.",
       cta: "Открыть сделки",
       href: "/franchize/vip-bike/rentals",
     },
@@ -629,7 +602,7 @@ function RentalQuickActionHub({ items, overview }: { items: CatalogItemVM[]; ove
       title: "Райдеры рядом",
       icon: "::FaMapLocationDot::",
       metric: `${activeRiders} онлайн`,
-      text: `За неделю комьюнити проехало ${weeklyDistance} км, активных встреч: ${meetupCount}.`,
+      text: `Неделя: ${weeklyDistance} км · встречи: ${meetupCount}.`,
       cta: "Открыть карту",
       href: "/franchize/vip-bike/map-riders",
     },
@@ -638,7 +611,7 @@ function RentalQuickActionHub({ items, overview }: { items: CatalogItemVM[]; ove
       title: "Быстрый подбор",
       icon: "::FaBolt::",
       metric: leadItem?.title || "VIP Bike",
-      text: "Открой мини-подбор прямо здесь: цель поездки → карточки байков → следующий шаг.",
+      text: isCatalogLoading ? "Готовим актуальные карточки..." : "Подборка по цели поездки и доступности.",
       cta: "Подобрать байк",
       href: "/franchize/vip-bike",
     },
@@ -649,10 +622,7 @@ function RentalQuickActionHub({ items, overview }: { items: CatalogItemVM[]; ove
   return (
     <section>
       <div className="mb-8 text-center">
-        <h2 className="font-orbitron text-3xl sm:text-4xl">Rental-флоу — живые действия вместо ссылок</h2>
-        <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">
-          Быстрые карточки теперь не просто уводят в разделы: они показывают статус аренды, live-счётчик райдеров и мини-подбор байка прямо на лендинге.
-        </p>
+        <h2 className="font-orbitron text-3xl sm:text-4xl">Быстрые действия VIP Bike</h2>
       </div>
 
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-[0.95fr_1.05fr]">
@@ -722,7 +692,7 @@ function RentalQuickActionHub({ items, overview }: { items: CatalogItemVM[]; ove
               {selectedCard.id === "riders" && (
                 <div className="grid gap-5 md:grid-cols-[0.9fr_1.1fr]">
                   <div>
-                    <p className="text-xs uppercase tracking-[0.22em] text-primary">live rider counter</p>
+                    <p className="text-xs uppercase tracking-[0.22em] text-primary">райдеры сейчас</p>
                     <h3 className="mt-2 font-orbitron text-2xl">{activeRiders} райдера онлайн</h3>
                     <p className="mt-2 text-sm text-muted-foreground">Смотри активность перед стартом и решай: ехать соло или присоединиться к группе.</p>
                     <Button asChild variant="outline" className="mt-5 w-full sm:w-fit">
@@ -732,9 +702,9 @@ function RentalQuickActionHub({ items, overview }: { items: CatalogItemVM[]; ove
                   <div className="grid grid-cols-2 gap-3">
                     {[
                       { label: "онлайн", value: activeRiders },
-                      { label: "meetup", value: meetupCount },
+                      { label: "встречи", value: meetupCount },
                       { label: "за неделю", value: `${weeklyDistance} км` },
-                      { label: "формат", value: "group ride" },
+                      { label: "формат", value: "группа" },
                     ].map((stat) => (
                       <div key={stat.label} className="rounded-2xl border border-border/70 bg-background/45 p-4">
                         <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{stat.label}</p>
@@ -917,35 +887,39 @@ function MapRidersLivePreview({ overview }: { overview: MapRidersOverview | null
       <div className="mb-8 text-center">
         <h2 className="font-orbitron text-3xl sm:text-4xl">MapRiders — карта, которой реально хочется пользоваться</h2>
         <p className="mx-auto mt-3 max-w-3xl text-muted-foreground">
-          Мини-превью теперь показывает живой слой без тяжелой Leaflet-карты: райдеры, встреча, недельный прогресс и последняя поездка
-          видны прямо на лендинге, а полный режим открывается одним кликом.
+          Райдеры, встречи и последние поездки — без тяжёлой карты на первом экране.
         </p>
       </div>
 
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1.1fr_0.9fr]">
         <Link
           href="/franchize/vip-bike/map-riders"
-          className="group relative min-h-[360px] overflow-hidden rounded-3xl border border-primary/30 bg-[#07100d] p-5 shadow-2xl shadow-black/25"
+          className="group relative min-h-[360px] overflow-hidden rounded-3xl border border-primary/35 bg-[#d8c99b] p-5 text-[#182016] shadow-2xl shadow-black/20"
           aria-label="Открыть полную карту MapRiders"
         >
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,179,71,0.22),transparent_28%),radial-gradient(circle_at_72%_60%,rgba(34,197,94,0.20),transparent_26%),linear-gradient(135deg,rgba(255,255,255,0.06),transparent)]" />
-          <div className="absolute inset-x-6 top-1/2 h-px rotate-[-12deg] bg-primary/60 shadow-[0_0_24px_rgba(255,170,80,0.75)]" />
-          <div className="absolute left-10 right-8 top-[38%] h-px rotate-[8deg] bg-emerald-300/45 shadow-[0_0_18px_rgba(74,222,128,0.45)]" />
-          <div className="absolute bottom-10 left-8 right-14 h-px rotate-[-4deg] bg-cyan-300/30 shadow-[0_0_18px_rgba(103,232,249,0.35)]" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_16%_18%,rgba(255,244,196,0.78),transparent_28%),radial-gradient(circle_at_72%_64%,rgba(48,142,94,0.30),transparent_30%),linear-gradient(135deg,rgba(255,249,219,0.82),rgba(96,131,91,0.42))]" />
+          <svg className="absolute inset-0 h-full w-full opacity-80" viewBox="0 0 100 100" aria-hidden="true" preserveAspectRatio="none">
+            <path d="M-6 78 C18 66 30 54 52 54 C70 54 84 42 106 30" fill="none" stroke="rgba(31,54,36,0.20)" strokeWidth="10" strokeLinecap="round" />
+            <path d="M-4 76 C18 64 30 52 52 52 C70 52 84 40 104 28" fill="none" stroke="rgba(255,246,210,0.78)" strokeWidth="3" strokeLinecap="round" />
+            <path d="M8 14 C24 22 28 36 42 42 C56 49 68 44 91 56" fill="none" stroke="rgba(23,88,63,0.42)" strokeWidth="2" strokeLinecap="round" strokeDasharray="7 4" />
+            <path d="M2 40 C20 35 28 28 42 26 C58 23 69 16 98 12" fill="none" stroke="rgba(171,112,38,0.45)" strokeWidth="1.7" strokeLinecap="round" />
+            <path d="M12 92 C22 78 34 72 48 72 C64 72 74 82 92 78" fill="none" stroke="rgba(24,89,116,0.32)" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+          <div className="absolute inset-0 bg-[linear-gradient(rgba(24,32,22,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(24,32,22,0.08)_1px,transparent_1px)] bg-[size:34px_34px] mix-blend-multiply" />
 
           {liveLocations.map((location, index) => {
             const point = normalizeMapPoint(location.lat, location.lng, index);
             return (
               <div
                 key={location.user_id || `${location.lat}-${location.lng}-${index}`}
-                className="absolute flex -translate-x-1/2 -translate-y-1/2 items-center gap-2"
+                className="absolute z-20 flex -translate-x-1/2 -translate-y-1/2 items-center gap-2"
                 style={{ left: `${point.left}%`, top: `${point.top}%` }}
               >
                 <span className="relative flex h-4 w-4">
-                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-60" />
-                  <span className="relative inline-flex h-4 w-4 rounded-full border-2 border-black bg-primary" />
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-600 opacity-50" />
+                  <span className="relative inline-flex h-4 w-4 rounded-full border-2 border-white bg-emerald-600 shadow-[0_0_16px_rgba(22,163,74,0.8)]" />
                 </span>
-                <span className="rounded-full border border-white/15 bg-black/55 px-2 py-1 text-[10px] text-white backdrop-blur-sm">
+                <span className="rounded-full border border-emerald-900/15 bg-white/75 px-2 py-1 text-[10px] font-semibold text-emerald-950 shadow-sm backdrop-blur-sm">
                   {Math.round(Number(location.speed_kmh || 0)) || 18} км/ч
                 </span>
               </div>
@@ -956,31 +930,31 @@ function MapRidersLivePreview({ overview }: { overview: MapRidersOverview | null
             const point = normalizeMapPoint(meetup.lat, meetup.lng, index + 4);
             return (
               <div
-                key={`${meetup.title || "meetup"}-${index}`}
-                className="absolute -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-brand-yellow/45 bg-black/60 px-3 py-2 text-xs text-white backdrop-blur-sm"
+                key={`${meetup.title || "vstrecha"}-${index}`}
+                className="absolute z-20 -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-amber-900/20 bg-amber-100/85 px-3 py-2 text-xs font-semibold text-amber-950 shadow-sm backdrop-blur-sm"
                 style={{ left: `${point.left}%`, top: `${point.top}%` }}
               >
-                <VibeContentRenderer content="::FaLocationDot::" className="mr-1 inline text-brand-yellow" />
+                <VibeContentRenderer content="::FaLocationDot::" className="mr-1 inline text-amber-700" />
                 {meetup.title || "Точка встречи"}
               </div>
             );
           })}
 
           <div className="relative z-10 flex h-full min-h-[320px] flex-col justify-between">
-            <div>
-              <p className="text-xs uppercase tracking-[0.22em] text-brand-yellow">live preview</p>
-              <h3 className="mt-2 font-orbitron text-2xl text-white">Райдеры на карте прямо сейчас</h3>
-              <p className="mt-2 max-w-md text-sm text-white/70">Клик по превью открывает полный MapRiders с GPS, meetup и лидербордом.</p>
+            <div className="max-w-md rounded-2xl border border-white/60 bg-white/60 p-4 shadow-sm backdrop-blur-md">
+              <p className="text-xs uppercase tracking-[0.22em] text-emerald-900/70">превью маршрута</p>
+              <h3 className="mt-2 font-orbitron text-2xl text-[#182016]">Райдеры на карте прямо сейчас</h3>
+              <p className="mt-2 text-sm text-[#354131]">Откроется полная карта с геопозицией, встречами и рейтингом.</p>
             </div>
             <div className="grid grid-cols-3 gap-2">
               {[
                 { label: "онлайн", value: activeRiders },
                 { label: "за неделю", value: `${weeklyDistance} км` },
-                { label: "meetup", value: meetupCount },
+                { label: "встречи", value: meetupCount },
               ].map((stat) => (
-                <div key={stat.label} className="rounded-2xl border border-white/15 bg-black/45 p-3 backdrop-blur-sm">
-                  <p className="text-[10px] uppercase tracking-[0.18em] text-white/45">{stat.label}</p>
-                  <p className="mt-1 font-orbitron text-lg text-white">{stat.value}</p>
+                <div key={stat.label} className="rounded-2xl border border-white/60 bg-white/70 p-3 shadow-sm backdrop-blur-md">
+                  <p className="text-[10px] uppercase tracking-[0.18em] text-[#52604d]">{stat.label}</p>
+                  <p className="mt-1 font-orbitron text-lg text-[#182016]">{stat.value}</p>
                 </div>
               ))}
             </div>
@@ -1088,7 +1062,33 @@ const fallbackElectroItems: ElectroPreviewItem[] = [
   },
 ];
 
-function ElectroEnduroShowcase({ items }: { items: CatalogItemVM[] }) {
+
+function BikeCardSkeleton({ index }: { index: number }) {
+  return (
+    <article className="relative min-w-[280px] snap-start overflow-hidden rounded-2xl border border-border/70 bg-background/45 shadow-xl shadow-black/10 sm:min-w-[340px]" aria-hidden="true">
+      <div className="relative h-52 overflow-hidden bg-black/40">
+        <motion.div
+          className="absolute inset-y-0 w-1/2 bg-gradient-to-r from-transparent via-primary/25 to-transparent"
+          initial={{ x: "-120%" }}
+          animate={{ x: "260%" }}
+          transition={{ duration: 1.25, repeat: Infinity, delay: index * 0.12, ease: "easeInOut" }}
+        />
+        <div className="absolute bottom-3 left-3 h-6 w-28 rounded-full bg-white/15" />
+      </div>
+      <div className="space-y-3 p-4">
+        <div className="h-5 w-2/3 rounded-full bg-muted/60" />
+        <div className="h-4 w-full rounded-full bg-muted/35" />
+        <div className="grid grid-cols-2 gap-2">
+          <div className="h-16 rounded-xl bg-muted/35" />
+          <div className="h-16 rounded-xl bg-muted/35" />
+        </div>
+        <div className="h-10 rounded-xl bg-primary/20" />
+      </div>
+    </article>
+  );
+}
+
+function ElectroEnduroShowcase({ items, isCatalogLoading = false }: { items: CatalogItemVM[]; isCatalogLoading?: boolean }) {
   const [selectedItem, setSelectedItem] = useState<ElectroPreviewItem | null>(null);
   const [selectedColorId, setSelectedColorId] = useState(DEFAULT_COLOR_OPTIONS[2]?.id ?? DEFAULT_COLOR_OPTIONS[0]?.id ?? "black");
   const [selectedConfigId, setSelectedConfigId] = useState(DEFAULT_CONFIG_OPTIONS[0]?.id ?? "standard");
@@ -1126,18 +1126,14 @@ function ElectroEnduroShowcase({ items }: { items: CatalogItemVM[] }) {
   return (
     <section>
       <div className="mb-8 text-center">
-        <h2 className="font-orbitron text-3xl sm:text-4xl">Electro-Enduro: аренда + продажа в одном потоке</h2>
-        <p className="mx-auto mt-3 max-w-3xl text-muted-foreground">
-          Реальные карточки из каталога теперь можно пролистать прямо здесь: увидеть фото, тариф, сценарий аренды/покупки
-          и открыть быстрый просмотр с мини-конфигурацией без ухода со страницы.
-        </p>
+        <h2 className="font-orbitron text-3xl sm:text-4xl">Electro-Enduro: аренда и покупка</h2>
       </div>
 
       <div className="overflow-hidden rounded-3xl border border-primary/30 bg-card/50 p-4 backdrop-blur-sm sm:p-6">
         <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <p className="text-xs uppercase tracking-[0.22em] text-primary">живой горизонтальный слайдер</p>
-            <h3 className="mt-1 font-orbitron text-2xl">Выбери электроэндуро и открой быстрый конфиг</h3>
+            <p className="text-xs uppercase tracking-[0.22em] text-primary">гараж на витрине</p>
+            <h3 className="mt-1 font-orbitron text-2xl">Свободные модели и быстрый конфиг</h3>
           </div>
           <Button asChild variant="outline" className="sm:w-fit">
             <Link href="/franchize/vip-bike/electro-enduro">Полный раздел Electro-Enduro</Link>
@@ -1145,7 +1141,8 @@ function ElectroEnduroShowcase({ items }: { items: CatalogItemVM[] }) {
         </div>
 
         <div className="flex snap-x gap-4 overflow-x-auto pb-3 [scrollbar-width:thin]">
-          {electroItems.map((item) => {
+          {isCatalogLoading && items.length === 0 && [0, 1, 2].map((index) => <BikeCardSkeleton key={index} index={index} />)}
+          {(!isCatalogLoading || items.length > 0) && electroItems.map((item) => {
             const imageUrl = getBikeGallery(item)[0];
 
             return (
@@ -1324,9 +1321,36 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
   const y = useTransform(scrollYProgress, [0, 1], [0, -90]);
   const [heroMode, setHeroMode] = useState<HeroMode>("rent");
   const [mapOverview, setMapOverview] = useState<MapRidersOverview | null>(null);
+  const [catalogItems, setCatalogItems] = useState<CatalogItemVM[]>(items);
+  const [isCatalogLoading, setIsCatalogLoading] = useState(items.length === 0);
+
+  useEffect(() => {
+    setCatalogItems(items);
+    setIsCatalogLoading(items.length === 0);
+  }, [items]);
 
   useEffect(() => {
     let isMounted = true;
+
+    if (items.length === 0) {
+      fetch("/api/franchize/catalog?slug=vip-bike")
+        .then((response) => (response.ok ? response.json() : null))
+        .then((payload) => {
+          if (isMounted && payload?.success && Array.isArray(payload.data?.items)) {
+            setCatalogItems(payload.data.items as CatalogItemVM[]);
+          }
+        })
+        .catch(() => {
+          if (isMounted) {
+            setCatalogItems([]);
+          }
+        })
+        .finally(() => {
+          if (isMounted) {
+            setIsCatalogLoading(false);
+          }
+        });
+    }
 
     fetch("/api/map-riders/overview?slug=vip-bike")
       .then((response) => (response.ok ? response.json() : null))
@@ -1344,11 +1368,11 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [items.length]);
 
   const heroPanels = useMemo<Record<HeroMode, HeroPanel>>(() => {
-    const rentItem = items.find((item) => item.availabilityStatus === "available" && item.pricePerDay > 0) ?? items.find((item) => item.pricePerDay > 0);
-    const saleItem = items.find((item) => item.saleAvailable || isEnabled(item.rawSpecs?.sale));
+    const rentItem = catalogItems.find((item) => item.availabilityStatus === "available" && item.pricePerDay > 0) ?? catalogItems.find((item) => item.pricePerDay > 0);
+    const saleItem = catalogItems.find((item) => item.saleAvailable || isEnabled(item.rawSpecs?.sale));
 
     return {
       ...fallbackHeroPanels,
@@ -1385,11 +1409,11 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
         meta: [
           { label: "онлайн", value: `${formatCompactNumber(mapOverview?.stats?.activeRiders, 3)} райдера` },
           { label: "за неделю", value: `${formatCompactNumber(mapOverview?.stats?.totalWeeklyDistanceKm, 127)} км` },
-          { label: "встречи", value: `${formatCompactNumber(mapOverview?.stats?.meetupCount, 2)} meetup` },
+          { label: "встречи", value: formatCompactNumber(mapOverview?.stats?.meetupCount, 2) },
         ],
       },
     };
-  }, [items, mapOverview]);
+  }, [catalogItems, mapOverview]);
 
   const activeHeroPanel = heroPanels[heroMode];
 
@@ -1454,7 +1478,7 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
         >
           <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-white/25 bg-black/45 px-4 py-2 text-sm text-white/90 backdrop-blur-sm">
             <VibeContentRenderer content="::FaBolt::" className="text-brand-yellow" />
-            <span>VIPBIKE RENTAL ECOSYSTEM</span>
+            <span>VIP BIKE · ПРОКАТ И МАРШРУТЫ</span>
           </div>
           <div className="mb-5 w-full max-w-2xl rounded-2xl border border-white/20 bg-black/40 p-4 text-left text-sm text-white/90 backdrop-blur-sm">
             <div className="mb-1 font-medium text-brand-yellow"><VibeContentRenderer content={vibeProfile.badge} /></div>
@@ -1487,7 +1511,7 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
                     className={cn(
                       "rounded-2xl border px-3 py-3 text-left transition-all duration-300",
                       isActive
-                        ? "border-brand-yellow bg-brand-yellow text-black shadow-lg shadow-brand-yellow/25"
+                        ? "border-brand-yellow bg-brand-yellow/20 text-white shadow-lg shadow-brand-yellow/25 ring-1 ring-brand-yellow/40"
                         : "border-white/15 bg-white/5 text-white/75 hover:border-white/40 hover:bg-white/10 hover:text-white",
                     )}
                   >
@@ -1547,7 +1571,7 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
                   <div className="absolute bottom-4 left-4 right-4 rounded-2xl border border-white/15 bg-black/50 p-4 backdrop-blur-sm">
                     <div className="flex items-center justify-between gap-3 text-sm text-white/80">
                       <span>Интерактивный режим</span>
-                      <span className="rounded-full bg-brand-yellow px-3 py-1 font-orbitron text-xs text-black">{activeHeroPanel.label}</span>
+                      <span className="rounded-full border border-brand-yellow/40 bg-black/55 px-3 py-1 font-orbitron text-xs text-brand-yellow">{activeHeroPanel.label}</span>
                     </div>
                   </div>
                 </div>
@@ -1570,39 +1594,9 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
       </motion.section>
 
       <div className="container mx-auto max-w-7xl space-y-20 px-4 py-16 sm:space-y-24 sm:py-24">
-        <ConversionPilot items={items} overview={mapOverview} />
+        <ConversionPilot items={catalogItems} overview={mapOverview} isCatalogLoading={isCatalogLoading} />
 
-        <section className="rounded-2xl border border-border/60 bg-card/40 p-5 sm:p-8">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h2 className="font-orbitron text-2xl sm:text-3xl">Актуальность контента / партнёрских ссылок</h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Раздел обновлён под новый franchize-поток: Electro-Enduro + Configurator + MapRiders.
-                Последний аудит контента: <span className="font-medium text-foreground">04 мая 2026</span>.
-              </p>
-            </div>
-            <Button asChild variant="outline">
-              <Link href="/franchize/vip-bike/configurator">Начать с конфигуратора</Link>
-            </Button>
-          </div>
-          <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2">
-            {partnerLinks.map((item) => (
-              <Card key={item.name} className="border-border/70 bg-background/40">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-base">{item.name}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="mb-3 text-sm text-muted-foreground">{item.note}</p>
-                  <Button asChild size="sm" variant="outline" className="w-full">
-                    <Link href={item.href}>Открыть раздел</Link>
-                  </Button>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </section>
-
-        <ElectroEnduroShowcase items={items} />
+        <ElectroEnduroShowcase items={catalogItems} isCatalogLoading={isCatalogLoading} />
 
         <MapRidersLivePreview overview={mapOverview} />
 
@@ -1631,9 +1625,9 @@ export function VipBikeRentalClient({ items }: { items: CatalogItemVM[] }) {
           </div>
         </section>
 
-        <StepsProgress items={items} />
+        <StepsProgress items={catalogItems} />
 
-        <RentalQuickActionHub items={items} overview={mapOverview} />
+        <RentalQuickActionHub items={catalogItems} overview={mapOverview} isCatalogLoading={isCatalogLoading} />
 
         <VipBikeCompanyServiceHub />
 

--- a/app/vipbikerental/loading.tsx
+++ b/app/vipbikerental/loading.tsx
@@ -1,0 +1,5 @@
+import { Loading } from "@/components/Loading";
+
+export default function VipBikeRentalLoading() {
+  return <Loading variant="bike" text="ОТКРЫВАЕМ VIP BIKE..." />;
+}

--- a/app/vipbikerental/page.tsx
+++ b/app/vipbikerental/page.tsx
@@ -1,8 +1,5 @@
-import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { VipBikeRentalClient } from "./VipBikeRentalClient";
 
-export default async function HomePage() {
-  const { items } = await getFranchizeBySlug("vip-bike");
-
-  return <VipBikeRentalClient items={items} />;
+export default function HomePage() {
+  return <VipBikeRentalClient items={[]} />;
 }

--- a/app/vipbikerental/todo.md
+++ b/app/vipbikerental/todo.md
@@ -3,12 +3,12 @@
 ## Current status
 - Status: `ready_for_pr`
 - Owner: Codex / franchize integration lane
-- Scope: interactive `vip-bike` landing is complete for the current slice.
+- Scope: interactive `vip-bike` landing is complete for the current slice; latest polish removed redundant copy, moved catalog cards to client-side skeleton hydration, russified fresh UI labels, and brightened the MapRiders preview card.
 - Archive: see `app/vipbikerental/TODO_ARCHIVE.md` for completed implementation notes and older backlog detail.
 
 ## Next action
 - No automatic follow-up. Only resume when the operator explicitly asks for `/vipbikerental` follow-up work.
-- If resumed, prioritize protected OSRM/fallback routing and lighter route/POI loading.
+- If resumed, prioritize protected OSRM/fallback routing, lighter route/POI loading, and production QA of the skeleton-to-real-catalog transition.
 
 ## Blockers
 - Production QA with live Supabase/runtime data still needs an environment with real credentials and mobile coverage.

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -204,13 +204,13 @@ const ScannerLine = () => (
 // --- COMPONENT: TERMINAL LOGS ---
 const TerminalLogs = ({ text }: { text?: string }) => {
   const logs = useMemo(() => [
-    "> Initializing neural handshake...",
-    "> Bypassing security protocols...",
-    "> Decrypting data streams...",
-    "> Establishing secure connection...",
-    text || "> Loading assets...",
-    "> Optimizing performance...",
-    "> Rendering interface..."
+    "> Готовим связь...",
+    "> Проверяем доступ...",
+    "> Собираем данные...",
+    "> Открываем защищённый канал...",
+    text || "> Загружаем интерфейс...",
+    "> Ускоряем отрисовку...",
+    "> Показываем экран..."
   ], [text]);
 
   const [visibleLogs, setVisibleLogs] = useState<string[]>([]);
@@ -361,7 +361,7 @@ const KineticCore = () => {
 };
 
 // --- COMPONENT: BIKE SPEEDSTER (Enhanced) ---
-const BikeSpeedster = () => {
+const BikeSpeedster = ({ gear }: { gear: number }) => {
   return (
     <div className="relative mx-auto flex h-64 w-full max-w-lg items-center justify-center overflow-hidden">
       {/* Speed Lines Background */}
@@ -372,10 +372,10 @@ const BikeSpeedster = () => {
             className="absolute h-[2px] w-40 rounded-full bg-gradient-to-r from-transparent via-orange-500/90 to-transparent"
             style={{
               top: `${16 + i * 5}%`,
-              left: "8%",
+              right: "8%",
             }}
             animate={{
-              x: [0, 300],
+              x: [280, -220],
               opacity: [0, 1, 0]
             }}
             transition={{
@@ -409,22 +409,30 @@ const BikeSpeedster = () => {
         >
           <div className="relative h-28 w-[260px]">
             <motion.div
-              className="absolute left-[36px] top-[58px] h-[72px] w-[72px] rounded-full border-4 border-orange-400/90"
-              animate={{ rotate: -360 }}
-              transition={{ duration: 0.45, repeat: Infinity, ease: "linear" }}
+              key={`wheel-pack-${gear}`}
+              className="absolute inset-0"
+              initial={{ scale: 0.96, opacity: 0.86 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ duration: 0.18, ease: "easeOut" }}
             >
-              {[0, 45, 90, 135].map((deg) => (
-                <div key={deg} className="absolute left-1/2 top-1/2 h-[2px] w-[30px] -translate-x-1/2 -translate-y-1/2 bg-orange-200/90" style={{ transform: `translate(-50%, -50%) rotate(${deg}deg)` }} />
-              ))}
-            </motion.div>
-            <motion.div
-              className="absolute left-[152px] top-[58px] h-[72px] w-[72px] rounded-full border-4 border-orange-400/90"
-              animate={{ rotate: -360 }}
-              transition={{ duration: 0.45, repeat: Infinity, ease: "linear" }}
-            >
-              {[0, 45, 90, 135].map((deg) => (
-                <div key={deg} className="absolute left-1/2 top-1/2 h-[2px] w-[30px] -translate-x-1/2 -translate-y-1/2 bg-orange-200/90" style={{ transform: `translate(-50%, -50%) rotate(${deg}deg)` }} />
-              ))}
+              <motion.div
+                className="absolute left-[41px] top-[63px] h-[63px] w-[63px] rounded-full border-4 border-orange-400/90"
+                animate={{ rotate: -360 }}
+                transition={{ duration: 0.45, repeat: Infinity, ease: "linear" }}
+              >
+                {[0, 45, 90, 135].map((deg) => (
+                  <div key={deg} className="absolute left-1/2 top-1/2 h-[2px] w-[26px] -translate-x-1/2 -translate-y-1/2 bg-orange-200/90" style={{ transform: `translate(-50%, -50%) rotate(${deg}deg)` }} />
+                ))}
+              </motion.div>
+              <motion.div
+                className="absolute left-[157px] top-[63px] h-[63px] w-[63px] rounded-full border-4 border-orange-400/90"
+                animate={{ rotate: -360 }}
+                transition={{ duration: 0.45, repeat: Infinity, ease: "linear" }}
+              >
+                {[0, 45, 90, 135].map((deg) => (
+                  <div key={deg} className="absolute left-1/2 top-1/2 h-[2px] w-[26px] -translate-x-1/2 -translate-y-1/2 bg-orange-200/90" style={{ transform: `translate(-50%, -50%) rotate(${deg}deg)` }} />
+                ))}
+              </motion.div>
             </motion.div>
 
             <Bike size={170} className="absolute left-1/2 top-[-10px] -translate-x-1/2 text-orange-300 drop-shadow-[0_0_12px_rgba(251,191,36,0.65)]" strokeWidth={1.5} />
@@ -506,7 +514,7 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
             className="mt-8 text-center space-y-6 w-full max-w-md"
           >
             <GlitchText 
-              text="NEURAL SYNC" 
+              text="СВЯЗЬ ГОТОВА"
               className="text-4xl md:text-6xl bg-gradient-to-r from-cyan-400 via-purple-400 to-pink-400 bg-clip-text text-transparent"
             />
             
@@ -525,15 +533,15 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
             <div className="flex items-center justify-center gap-4 text-xs font-mono text-slate-500">
               <span className="flex items-center gap-1">
                 <Wifi className="w-3 h-3 text-emerald-400" />
-                SECURE
+                ЗАЩИТА
               </span>
               <span className="flex items-center gap-1">
                 <Shield className="w-3 h-3 text-cyan-400" />
-                ENCRYPTED
+                ШИФР
               </span>
               <span className="flex items-center gap-1">
                 <Radio className="w-3 h-3 text-amber-400 animate-pulse" />
-                LIVE
+                ЖИВОЙ
               </span>
             </div>
           </motion.div>
@@ -565,7 +573,7 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
               animate={{ opacity: [0.5, 1, 0.5] }}
               transition={{ duration: 2, repeat: Infinity }}
             >
-              SYSTEM BOOT
+              ЗАПУСК
             </motion.h2>
             
             <div className="flex items-center gap-2 justify-center">
@@ -580,7 +588,7 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
             </div>
             
             <p className="font-mono text-sm text-slate-500">
-              {text || 'Initializing modules...'}
+              {text || 'Запускаем модули...'}
             </p>
           </motion.div>
         </div>
@@ -597,7 +605,7 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
       )}>
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_35%,rgba(251,146,60,0.18),transparent_42%),linear-gradient(120deg,transparent,rgba(251,191,36,0.06),transparent)]" />
         <div className="absolute left-0 right-0 top-1/2 h-px bg-gradient-to-r from-transparent via-orange-400/60 to-transparent" />
-        <BikeSpeedster />
+        <BikeSpeedster gear={bikeTelemetry.gear} />
         
         <motion.div 
           initial={{ opacity: 0, y: 20 }}
@@ -607,10 +615,10 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
         >
           <div className="inline-flex items-center gap-2 rounded-full border border-orange-300/20 bg-black/30 px-3 py-1 text-[10px] font-mono uppercase tracking-[0.28em] text-orange-200/80 shadow-[0_0_22px_rgba(251,146,60,0.18)]">
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_10px_rgba(52,211,153,0.9)]" />
-            first-paint loader online
+            витрина готовится
           </div>
           <h2 className="font-orbitron text-3xl font-black uppercase tracking-wider text-orange-400 drop-shadow-[0_0_15px_rgba(251,191,36,0.5)] md:text-5xl">
-            RIDE LINK
+            МАРШРУТ
           </h2>
           
           {/* Animated Speed Bar */}
@@ -630,9 +638,9 @@ export function Loading({ variant = 'kinetic', text, className }: LoadingProps) 
           </p>
           
           <div className="flex justify-center gap-2 mt-4">
-            <TelemetryMetric label="RPM" value={`${Math.round(bikeTelemetry.rpm)}`} />
-            <TelemetryMetric label="KM/H" value={`${Math.round(bikeTelemetry.speed)}`} />
-            <TelemetryMetric label="GEAR" value={`${bikeTelemetry.gear}`} />
+            <TelemetryMetric label="ОБ/МИН" value={`${Math.round(bikeTelemetry.rpm)}`} />
+            <TelemetryMetric label="КМ/Ч" value={`${Math.round(bikeTelemetry.speed)}`} />
+            <TelemetryMetric label="ПЕР." value={`${bikeTelemetry.gear}`} />
           </div>
         </motion.div>
       </div>

--- a/components/map-riders/BeginnerRiderOnboardingQuiz.tsx
+++ b/components/map-riders/BeginnerRiderOnboardingQuiz.tsx
@@ -20,14 +20,14 @@ const EXPERIENCE_OPTIONS: Array<{ id: ExperienceLevel; label: string; helper: st
 ];
 
 const BIKE_OPTIONS: Array<{ id: BikeGoal; label: string; helper: string }> = [
-  { id: "rental", label: "Беру байк в аренду", helper: "Карта подпишет заезд как VIP rental и оставит видимость внутри экипажа." },
+  { id: "rental", label: "Беру байк в аренду", helper: "Карта подпишет заезд как аренда VIP и оставит видимость внутри экипажа." },
   { id: "personal", label: "На своём байке", helper: "Карта подготовит личный режим и короткий автостоп геошеринга." },
 ];
 
 const INTENT_OPTIONS: Array<{ id: RideIntent; label: string; helper: string }> = [
   { id: "learn", label: "Понять что делать", helper: "Сначала безопасный режим: экипаж, размытие дома, 15 минут." },
-  { id: "meetup", label: "Найти встречу", helper: "Фокус на meetup-точках: тап по карте и кнопка +." },
-  { id: "route", label: "Катнуть маршрут", helper: "Подготовим название заезда и публичный crew-сигнал." },
+  { id: "meetup", label: "Найти встречу", helper: "Фокус на точках встречи: тап по карте и кнопка +." },
+  { id: "route", label: "Катнуть маршрут", helper: "Подготовим название заезда и публичный сигнал экипажа." },
 ];
 
 function optionClass(isActive: boolean) {
@@ -46,8 +46,8 @@ export function BeginnerRiderOnboardingQuiz({ crew }: { crew: FranchizeCrewVM })
 
   const recommendation = useMemo(() => {
     const isNewbie = experience === "new" || intent === "learn";
-    const rideName = intent === "meetup" ? "Meetup с экипажем" : intent === "route" ? "Городской выезд" : "Первый безопасный выезд";
-    const vehicleLabel = bikeGoal === "rental" ? `${crew.header.brandName || "VIP BIKE"} rental` : "Личный байк";
+    const rideName = intent === "meetup" ? "Встреча с экипажем" : intent === "route" ? "Городской выезд" : "Первый безопасный выезд";
+    const vehicleLabel = bikeGoal === "rental" ? `${crew.header.brandName || "VIP BIKE"} · аренда` : "Личный байк";
     const visibilityMode = experience === "crew" && intent === "route" ? "public" : "crew";
     const autoExpireMinutes = isNewbie ? 15 : intent === "route" ? 60 : 5;
 
@@ -57,7 +57,7 @@ export function BeginnerRiderOnboardingQuiz({ crew }: { crew: FranchizeCrewVM })
       rideMode: bikeGoal,
       visibilityMode,
       autoExpireMinutes,
-      homeBlurLabel: isNewbie ? "Дом размыт, позиция только для экипажа" : visibilityMode === "public" ? "Публичный сигнал для маршрута" : "Короткий crew-сигнал",
+      homeBlurLabel: isNewbie ? "Дом размыт, позиция только для экипажа" : visibilityMode === "public" ? "Публичный сигнал для маршрута" : "Короткий сигнал экипажа",
     } as const;
   }, [bikeGoal, crew.header.brandName, experience, intent]);
 
@@ -74,7 +74,7 @@ export function BeginnerRiderOnboardingQuiz({ crew }: { crew: FranchizeCrewVM })
     <section className="overflow-hidden rounded-3xl border border-white/10 bg-black/35 p-4 text-white shadow-2xl shadow-black/25 backdrop-blur-xl md:p-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <Badge className="border border-[var(--mr-accent)]/45 bg-[var(--mr-accent)]/15 text-[var(--mr-accent)]">RENT-P1.1 • newbie gate</Badge>
+          <Badge className="border border-[var(--mr-accent)]/45 bg-[var(--mr-accent)]/15 text-[var(--mr-accent)]">Старт новичка</Badge>
           <h2 className="mt-3 font-orbitron text-2xl">Быстрый старт райдера</h2>
           <p className="mt-2 max-w-2xl text-sm text-white/65">
             Три вопроса — и MapRiders сам подготовит название заезда, тип байка, приватность и автостоп геошеринга для <span className="text-white">/{crewSlug}</span>.
@@ -123,7 +123,7 @@ export function BeginnerRiderOnboardingQuiz({ crew }: { crew: FranchizeCrewVM })
 
         <aside className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
           <div className="flex items-center gap-2 text-sm font-semibold text-white">
-            <VibeContentRenderer content="::FaShieldAlt::" /> Рекомендация
+            <VibeContentRenderer content="::FaShieldCat::" /> Рекомендация
           </div>
           <dl className="mt-4 space-y-3 text-sm">
             <div><dt className="text-white/45">Заезд</dt><dd>{recommendation.rideName}</dd></div>

--- a/components/user-info.tsx
+++ b/components/user-info.tsx
@@ -29,17 +29,22 @@ export function UserInfo() {
 
   if (error) {
     return (
-      <motion.div
-        initial={{ opacity: 0, scale: 0.8 }}
-        animate={{ opacity: 1, scale: 1 }}
-        className="flex flex-col items-center gap-1"
-      >
-        <div className="flex items-center gap-2 p-2 bg-destructive/80 text-destructive-foreground rounded-md border border-destructive shadow-lg animate-pulse">
-            <VibeContentRenderer content="::FaTriangleExclamation::" className="h-5 w-5" />
-            <span className="font-mono text-xs">Auth Error!</span>
-        </div>
-        <Button asChild variant="outline" size="sm" className="text-xs border-destructive/50 text-destructive-foreground/80 hover:bg-destructive/70 hover:text-destructive-foreground">
-            <a href={TELEGRAM_WEB_APP_URL} target="_blank" rel="noopener noreferrer">Открыть WebApp</a>
+      <motion.div initial={{ opacity: 0, scale: 0.9 }} animate={{ opacity: 1, scale: 1 }}>
+        <Button
+          asChild
+          variant="ghost"
+          className={cn(
+            "rounded-full px-3 py-2 transition-all",
+            "bg-gradient-to-br from-brand-purple/30 via-brand-pink/30 to-brand-orange/30",
+            "hover:from-brand-purple/50 hover:via-brand-pink/50 hover:to-brand-orange/50",
+            "text-light-text hover:text-white",
+            "shadow-[0_0_10px_rgba(var(--brand-pink-rgb),0.4)] hover:shadow-[0_0_15px_rgba(var(--brand-pink-rgb),0.6)]",
+          )}
+        >
+          <a href={TELEGRAM_WEB_APP_URL} target="_blank" rel="noopener noreferrer" aria-label="Открыть Telegram WebApp" className="inline-flex items-center gap-2">
+            <Send className="h-5 w-5" />
+            <span className="hidden text-xs font-semibold sm:inline">WebApp</span>
+          </a>
         </Button>
       </motion.div>
     );

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -52,11 +52,11 @@ This root file stays intentionally compact so operators and agents can load it q
 ## 3) Active ad-hoc task — `/vipbikerental` interactive landing
 
 - status: `ready_for_pr`
-- updated_at: `2026-05-06T23:45:00Z`
+- updated_at: `2026-05-07T00:00:00Z`
 - owner: `codex`
-- notes: `Self-reviewed and polished ConversionPilot into a more customer-facing route cockpit: score is now a compact operator signal, while the main surface recommends the next bike and three clear rent/buy/group-ride paths with better copy and accessibility labels.`
-- next_step: `Create PR and production-smoke /vipbikerental with real vip-bike catalog/map data.`
-- risks: `Local runtime can render fallback data when Supabase is unavailable; production QA should verify real vip-bike catalog/map records and active rental states.`
+- notes: `Polished /vipbikerental copy density, removed the duplicated partner-link audit block, improved hero-tab contrast over video, moved VIP Bike catalog hydration behind client-side skeleton cards, russified the newest loader/landing labels, brightened the MapRiders preview map, and replaced the invalid FaShieldAlt marker with FaShieldCat.`
+- next_step: `Production-smoke /vipbikerental and /franchize/vip-bike with real catalog latency; confirm skeleton-to-card transition on mobile Telegram WebApp.`
+- risks: `Catalog API still depends on server Supabase env; production QA should verify live item hydration and fallback behavior when Supabase is slow.`
 
 
 ### 2026-05-06 — SupaPlan franchize maintenance pair
@@ -80,6 +80,9 @@ This root file stays intentionally compact so operators and agents can load it q
 
 ## 4) Mini execution diary addendum
 
+- 2026-05-07 — UX cleanup for `/vipbikerental`: removed literal explanatory copy and duplicated partner-link section, changed active hero tabs to light-on-tinted styling, added a route-level VIP Bike loader plus client-side catalog skeleton hydration, and tuned the global bike loader wheel/wind animation. Next step: mobile smoke with live Supabase catalog latency.
+- 2026-05-07 — Self-review polish for the UX cleanup: reduced new English labels in loader/landing/onboarding surfaces, brightened the MapRiders preview into a lighter VibeMap-like card, and replaced the invalid `FaShieldAlt` VCR token with `FaShieldCat` for the production-history easter egg. Next step: mobile visual smoke once browser libraries are available.
+- 2026-05-07 — Franchize-wide text polish: reduced fresh English labels in create/admin/catalog/order/rental-document surfaces, russified launch/order helper chips, and kept technical field names only where operators need exact JSON/DB keys. Next step: spot-check `/franchize/vip-bike`, `/franchize/create`, and rental document flows in preview.
 - 2026-05-06 — Started `/vipbikerental` interactive enhancement stream from `app/vipbikerental/todo.md`; shipped the first Hero tabs slice with animated mode preview and MapRiders overview metrics. Next step: replace fallback rent/buy preview cards with real catalog item data.
 - 2026-05-06 — Continued `/vipbikerental` stream: split page into server wrapper + client runtime, hydrated real `vip-bike` catalog items, upgraded Hero rent/buy cards to catalog data, and replaced static Electro-Enduro cards with horizontal slider + quick preview configurator. Next step: MapRiders mini-map/social proof preview.
 - 2026-05-06 — Self-reviewed `/vipbikerental` refactor by comparing old/new section headings, then shipped lightweight MapRiders preview: static glowing route map, live rider dots, meetup labels, latest ride stats and SVG speed sparkline. Next step: interactive newbie stepper.


### PR DESCRIPTION
### Motivation

- Make the `/vipbikerental` landing more resilient and user-friendly by hydrating catalog data on the client and improving loading UX with skeletons. 
- Localize UI copy and minor tokens from English to Russian for a more consistent end-user experience. 
- Polish MapRiders preview, hero contrast, and several admin/rental flows to reduce confusing copy and improve accessibility.

### Description

- Added a server runtime API route `app/api/franchize/catalog/route.ts` that proxies `getFranchizeBySlug` for client-side catalog hydration. 
- Converted `/vipbikerental/page.tsx` to a client-driven entry that renders `VipBikeRentalClient` with an empty `items` prop and implemented client fetch/hydration inside `VipBikeRentalClient` (fetches `/api/franchize/catalog?slug=vip-bike`).
- Introduced skeleton components (`CatalogCardSkeleton`, `BikeCardSkeleton`) and a `vipbikerental` loader (`app/vipbikerental/loading.tsx`) to show progressive UI while catalog loads, and wired `isCatalogLoading` flags across several child components. 
- Wide UI/text polish and russification across franchize code: many labels, CTAs, helper texts and default strings updated in `actions-runtime.ts`, `CatalogClient.tsx`, admin/client components, onboarding quiz, order flow, rental documents, create form, and `Loading` component; replaced an invalid icon token `FaShieldAlt` → `FaShieldCat`. 
- Visual and interaction tweaks to MapRiders preview and several VIP Bike landing sections (brighter preview card, hero tab contrast, layout adjustments), plus small component API changes (e.g. `BikeSpeedster` now accepts `gear`).

### Testing

- Ran TypeScript type-check (`tsc --noEmit`) and local dev build smoke (dev server render of `/vipbikerental`) to validate imports and runtime hydration; no type errors reported. 
- No dedicated unit tests were added or run in this change set; visual/functional verification performed via local manual smoke.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb96f4bcc832499be9239055ce188)