### PR TITLE
fix: soften MapRiders demo rider display

### DIFF
--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -101,36 +101,41 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
   });
 
   // ── Build map points from state ──
-  const mapPoints = useMemo(() => {
-    const riderPoints = Array.from(state.liveRiders.values())
-      .filter((r) => r.status !== "evicted")
-      .map((rider) => {
-        const session = state.sessions.find((s) => s.user_id === rider.user_id);
-        const name = riderDisplayName(session?.users, rider.user_id);
-        const isStale = rider.status === "stale";
-        return {
-          id: `live-rider-${rider.user_id}`,
-          name: `${name} • ${Math.round(rider.speed_kmh)} км/ч`,
-          type: "point" as const,
-          icon: `image:https://placehold.co/56x56/${rider.isSelf ? "facc15" : isStale ? "4b5563" : "111827"}/ffffff?text=${encodeURIComponent(initialsFromName(name))}`,
-          color: rider.isSelf ? "#facc15" : isStale ? "#6b7280" : "#60a5fa",
-          coords: [[rider.lat, rider.lng]] as [number, number][],
-        };
-      });
+  const riderPoints = useMemo(
+    () =>
+      Array.from(state.liveRiders.values())
+        .filter((r) => r.status !== "evicted")
+        .map((rider) => {
+          const session = state.sessions.find((s) => s.user_id === rider.user_id);
+          const name = riderDisplayName(session?.users, rider.user_id);
+          const isStale = rider.status === "stale";
+          return {
+            id: `live-rider-${rider.user_id}`,
+            name: `${name} • ${Math.round(rider.speed_kmh)} км/ч`,
+            type: "point" as const,
+            icon: `image:https://placehold.co/56x56/${rider.isSelf ? "facc15" : isStale ? "4b5563" : "111827"}/ffffff?text=${encodeURIComponent(initialsFromName(name))}`,
+            color: rider.isSelf ? "#facc15" : isStale ? "#6b7280" : "#60a5fa",
+            coords: [[rider.lat, rider.lng]] as [number, number][],
+          };
+        }),
+    [state.liveRiders, state.sessions],
+  );
+  const showDemo = riderPoints.length === 0 && !state.shareEnabled;
 
-    const demoPoints =
-      riderPoints.length > 0
-        ? []
-        : [
-            {
-              id: "demo-rider-alpha",
-              name: "Demo Rider База • 14 км/ч",
-              type: "point" as const,
-              icon: "image:https://placehold.co/56x56/111827/ffffff?text=SB",
-              color: "#60a5fa",
-              coords: [HOME_BASE],
-            },
-          ];
+  const mapPoints = useMemo(() => {
+    const demoPoints = showDemo
+      ? [
+          {
+            id: "demo-rider-alpha",
+            name: "Demo Rider База • 14 км/ч",
+            type: "point" as const,
+            icon: "image:https://placehold.co/56x56/111827/ffffff?text=SB",
+            color: "#60a5fa",
+            coords: [HOME_BASE],
+            markerClassName: "animate-in fade-in duration-300",
+          },
+        ]
+      : [];
 
     const meetupPoints = state.meetups.map((m) => ({
       id: `meetup-${m.id}`,
@@ -162,7 +167,7 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
     });
 
     return [...sanitizedMapPoints, ...routePoints, ...riderPoints, ...demoPoints, ...meetupPoints];
-  }, [state.liveRiders, state.sessions, state.meetups, state.sessionDetail, mapData?.points]);
+  }, [riderPoints, showDemo, state.meetups, state.sessionDetail, mapData?.points]);
 
   const riderStatusCounts = useMemo(() => {
     const riders = Array.from(state.liveRiders.values());
@@ -358,7 +363,7 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
             {riderStatusCounts.stale ? <Badge className="border border-amber-300/45 bg-amber-500/20 text-amber-100">stale {riderStatusCounts.stale}</Badge> : null}
             {mapData?.routes?.length ? <Badge className="border border-sky-300/50 bg-sky-500/20 text-sky-100">{mapData.routes.length} маршрутов</Badge> : null}
             <Badge className="border border-white/20 bg-black/45 text-white/90">{shareModeLabel} • автостоп {nextAutoStopLabel}</Badge>
-            {state.liveRiders.size === 0 && state.sessions.length === 0 ? (
+            {showDemo ? (
               <Badge className="border border-emerald-300/40 bg-emerald-500/20 text-emerald-100">Демо-режим</Badge>
             ) : null}
           </div>

--- a/components/maps/RacingMap.tsx
+++ b/components/maps/RacingMap.tsx
@@ -132,7 +132,13 @@ export function RacingMap({
                 key={poi.id}
                 center={center}
                 radius={8}
-                pathOptions={{ color: poi.color, fillColor: poi.color, fillOpacity: 0.9, weight: 2 }}
+                pathOptions={{
+                  color: poi.color,
+                  fillColor: poi.color,
+                  fillOpacity: 0.9,
+                  weight: 2,
+                  className: poi.markerClassName,
+                }}
                 eventHandlers={{
                   click: () => onPointClick?.(poi),
                 }}

--- a/lib/map-utils.ts
+++ b/lib/map-utils.ts
@@ -55,6 +55,7 @@ export interface PointOfInterest {
     }>;
     properties?: Record<string, unknown>;
   };
+  markerClassName?: string;
   roadHighlight?: {
     weight?: number;
     glow?: boolean;


### PR DESCRIPTION
### Motivation
- Prevent a jarring demo rider flash when the global last rider goes offline while the current user is actively sharing.
- Make the demo marker entrance visually subtle to reduce perceived teleport/telemetry noise for watchers.

### Description
- Gate demo fallback with `const showDemo = riderPoints.length === 0 && !state.shareEnabled` so the demo rider only appears when there are no live riders and the current user is not sharing. (modified `components/map-riders/MapRidersClientRefactored.tsx`).
- Split live rider point construction into a `riderPoints` `useMemo` and conditionally include the demo point in `mapPoints` using `showDemo`, updating dependencies accordingly. (modified `components/map-riders/MapRidersClientRefactored.tsx`).
- Add `markerClassName` to the `PointOfInterest` type and pass it through to Leaflet `CircleMarker.pathOptions.className` to allow per-point CSS animation classes. (modified `lib/map-utils.ts` and `components/maps/RacingMap.tsx`).
- Apply a subtle Tailwind animation classes (`animate-in fade-in duration-300`) to the demo marker and reuse `showDemo` to control the floating "Демо-режим" badge so the badge hides when demo is not shown. (modified `components/map-riders/MapRidersClientRefactored.tsx`).

### Testing
- Ran `npm run typecheck:franchize` and it passed. 
- Ran `npm run qa:map-riders` (map page and split API smoke checks) and the smoke suite passed. 
- Ran `npx eslint --max-warnings=0 components/map-riders/MapRidersClientRefactored.tsx components/maps/RacingMap.tsx lib/map-utils.ts` and linter returned clean results. 
- Attempted `node scripts/capture-screenshot.mjs` to capture a visual proof, but Playwright/browser capture was blocked by missing system browser libraries in the runner (Playwright engines failed); this is an environment limitation, not a regression in the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fceabc6e3083249f16583007b08c58)