### PR TITLE
MapRiders: idle-tick stability, GPS warmup UX and duration/speed polish

### DIFF
--- a/app/vipbikerental/VipBikeRentalClient.tsx
+++ b/app/vipbikerental/VipBikeRentalClient.tsx
@@ -867,9 +867,13 @@ const normalizeMapPoint = (lat: number | undefined, lng: number | undefined, ind
 };
 
 const formatRideDuration = (seconds: number | undefined) => {
-  const safeSeconds = Math.max(0, Number(seconds || 0));
+  const safeSeconds = Number(seconds);
+  if (!Number.isFinite(safeSeconds)) return "—";
+  if (safeSeconds === 0) return "Только что начали!";
+  if (safeSeconds < 60) return "Меньше минуты";
+
   const minutes = Math.round(safeSeconds / 60);
-  if (minutes < 60) return `${minutes || 18} мин`;
+  if (minutes < 60) return `${minutes} мин`;
   return `${Math.floor(minutes / 60)} ч ${minutes % 60} мин`;
 };
 
@@ -880,6 +884,18 @@ function MapRidersLivePreview({ overview }: { overview: MapRidersOverview | null
   const activeRiders = formatCompactNumber(overview?.stats?.activeRiders, liveLocations.length);
   const meetupCount = formatCompactNumber(overview?.stats?.meetupCount, meetups.length);
   const weeklyDistance = formatCompactNumber(overview?.stats?.totalWeeklyDistanceKm, 127);
+  const isMapRidersWarmup = Boolean(
+    overview &&
+      !overview.liveLocations?.length &&
+      !overview.meetups?.length &&
+      !overview.latestCompleted?.length &&
+      Number(overview.stats?.activeRiders || 0) <= 0 &&
+      Number(overview.stats?.totalWeeklyDistanceKm || 0) <= 0,
+  );
+  const latestRideDistanceKm = Number(latestRide?.total_distance_km || 0);
+  const latestRideHint = latestRide
+    ? latestRideDistanceKm <= 0 ? "Последний заезд сохранён, дистанция ещё уточняется." : null
+    : "Ждём первый живой заезд — он появится здесь после старта MapRiders.";
   const speedPath = "M4 42 C18 34 24 18 38 28 C50 36 58 12 70 22 C82 30 88 18 96 10";
 
   return (
@@ -945,6 +961,9 @@ function MapRidersLivePreview({ overview }: { overview: MapRidersOverview | null
               <p className="text-xs uppercase tracking-[0.22em] text-emerald-900/70">превью маршрута</p>
               <h3 className="mt-2 font-orbitron text-2xl text-[#182016]">Райдеры на карте прямо сейчас</h3>
               <p className="mt-2 text-sm text-[#354131]">Откроется полная карта с геопозицией, встречами и рейтингом.</p>
+              {isMapRidersWarmup ? (
+                <p className="mt-2 text-xs font-medium text-emerald-950/70">Живые данные появятся после первого заезда — пока показываем демо-сцену.</p>
+              ) : null}
             </div>
             <div className="grid grid-cols-3 gap-2">
               {[
@@ -970,17 +989,18 @@ function MapRidersLivePreview({ overview }: { overview: MapRidersOverview | null
               <div className="grid grid-cols-3 gap-2 text-sm">
                 <div className="rounded-xl border border-border/60 bg-background/40 p-3">
                   <p className="text-xs text-muted-foreground">Райдер</p>
-                  <p className="mt-1 font-medium">{latestRide?.rider_name || "VIP rider"}</p>
+                  <p className="mt-1 font-medium">{latestRide?.rider_name || "Ждём первый заезд"}</p>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/40 p-3">
                   <p className="text-xs text-muted-foreground">Дистанция</p>
-                  <p className="mt-1 font-medium">{formatCompactNumber(latestRide?.total_distance_km, 24)} км</p>
+                  <p className="mt-1 font-medium">{latestRide ? `${formatCompactNumber(latestRide.total_distance_km, 0)} км` : "—"}</p>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/40 p-3">
                   <p className="text-xs text-muted-foreground">Время</p>
                   <p className="mt-1 font-medium">{formatRideDuration(latestRide?.duration_seconds)}</p>
                 </div>
               </div>
+              {latestRideHint ? <p className="text-xs text-muted-foreground">{latestRideHint}</p> : null}
               <svg viewBox="0 0 100 48" className="h-24 w-full rounded-2xl border border-border/60 bg-background/40 p-3" role="img" aria-label="Мини график скорости последней поездки">
                 <path d={speedPath} fill="none" stroke="currentColor" strokeWidth="3" className="text-primary drop-shadow-[0_0_8px_rgba(255,170,80,0.65)]" />
                 <path d="M4 42 L96 42" stroke="currentColor" strokeWidth="1" className="text-muted-foreground/40" />

--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -135,6 +135,14 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
   );
   const showDemo = riderPoints.length === 0 && !state.shareEnabled;
 
+  const staticMapPoints = useMemo(() => {
+    return (mapData?.points || []).filter((point) => {
+      const normalizedId = String(point.id || "").toLowerCase();
+      const normalizedName = String(point.name || "").toLowerCase();
+      return normalizedId !== "demo-rider-beta" && !normalizedName.includes("demo rider beta");
+    });
+  }, [mapData?.points, mapData?.bounds]);
+
   const mapPoints = useMemo(() => {
     const demoPoints = showDemo
       ? [
@@ -173,14 +181,8 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
           ]
         : [];
 
-    const sanitizedMapPoints = (mapData?.points || []).filter((point) => {
-      const normalizedId = String(point.id || "").toLowerCase();
-      const normalizedName = String(point.name || "").toLowerCase();
-      return normalizedId !== "demo-rider-beta" && !normalizedName.includes("demo rider beta");
-    });
-
-    return [...sanitizedMapPoints, ...routePoints, ...riderPoints, ...demoPoints, ...meetupPoints];
-  }, [riderPoints, showDemo, state.meetups, state.sessionDetail, mapData?.points]);
+    return [...staticMapPoints, ...routePoints, ...riderPoints, ...demoPoints, ...meetupPoints];
+  }, [staticMapPoints, riderPoints, showDemo, state.meetups, state.sessionDetail]);
 
   const riderStatusCounts = useMemo(() => {
     const riders = Array.from(state.liveRiders.values());

--- a/components/map-riders/RidersDrawer.tsx
+++ b/components/map-riders/RidersDrawer.tsx
@@ -54,6 +54,10 @@ export function RidersDrawer({ emptyStateCopy = DEFAULT_EMPTY_STATE_COPY }: Ride
   }, []);
 
   const drawerSnapPoints = useMemo(() => (prefersReducedMotion ? [1] : [0.64, 380 / 820, 640 / 820]), [prefersReducedMotion]);
+  const activeHistoryWarmupSessions = useMemo(
+    () => state.sessions.filter((session) => session.status === "active" && Number(session.total_distance_km || 0) <= 0),
+    [state.sessions],
+  );
 
   useEffect(() => {
     if (!isOpen) return;
@@ -216,6 +220,33 @@ export function RidersDrawer({ emptyStateCopy = DEFAULT_EMPTY_STATE_COPY }: Ride
             {/* ── History tab ── */}
             <TabsContent value="history" className="flex-1 overflow-auto p-4">
               <div className="space-y-2">
+                {activeHistoryWarmupSessions.map((session) => {
+                  const selectedSessionId = state.sessionDetail?.session?.id;
+                  const capturedRoutePoints = selectedSessionId === session.id ? state.sessionDetail?.points?.length || 0 : 0;
+                  const gpsWarmupHint = capturedRoutePoints > 0
+                    ? "Маршрут записывается, но дистанция еще не посчитана."
+                    : "⚠️ GPS прогревается, подожди секунду...";
+
+                  return (
+                    <div key={`active-warmup-${session.id}`} className="rounded-xl border border-white/10 bg-white/5 px-3 py-2.5">
+                      <button
+                        type="button"
+                        onClick={() => fetchSessionDetail(session.id)}
+                        className="flex w-full items-center justify-between text-left transition hover:text-emerald-100"
+                      >
+                        <div>
+                          <div className="text-sm font-medium text-white">{riderDisplayName(session.users, session.user_id)}</div>
+                          <div className="text-xs text-zinc-400">{session.ride_name || "Без названия"} • {formatRideDuration(0)}</div>
+                        </div>
+                        <div className="text-right text-sm text-emerald-200">
+                          <div>{Number(session.total_distance_km || 0).toFixed(1)} км</div>
+                          <div className="text-xs">{Number(session.latest_speed_kmh || 0).toFixed(0)} км/ч</div>
+                        </div>
+                      </button>
+                      <div className="mt-2 text-[11px] text-zinc-400">{gpsWarmupHint}</div>
+                    </div>
+                  );
+                })}
                 {state.recentCompleted.map((session) => (
                   <div key={session.id} className="rounded-xl border border-white/10 bg-white/5 px-3 py-2.5">
                     <button
@@ -246,7 +277,7 @@ export function RidersDrawer({ emptyStateCopy = DEFAULT_EMPTY_STATE_COPY }: Ride
                     </Button>
                   </div>
                 ))}
-                {!state.recentCompleted.length && (
+                {!state.recentCompleted.length && !activeHistoryWarmupSessions.length && (
                   <div className="rounded-xl border border-dashed border-white/25 p-4 text-center text-xs text-muted-foreground">
                     {emptyStateCopy.history}
                   </div>
@@ -285,7 +316,7 @@ function ReplayFullscreen({
 
   const replayGeometry = useMemo(() => {
     if (!points.length) {
-      return { path: "", playedPath: "", currentPoint: null as { x: number; y: number } | null, distanceKm: 0, durationLabel: "0 мин" };
+      return { path: "", playedPath: "", currentPoint: null as { x: number; y: number } | null, distanceKm: 0, durationLabel: formatRideDuration(0) };
     }
 
     const padding = 7;
@@ -393,8 +424,8 @@ function ReplayFullscreen({
         <div className="relative min-h-[46vh] overflow-hidden rounded-2xl border border-emerald-300/20 bg-[radial-gradient(circle_at_30%_20%,rgba(16,185,129,0.22),transparent_36%),linear-gradient(135deg,rgba(15,23,42,0.96),rgba(2,6,23,0.98))] p-3 shadow-2xl shadow-emerald-950/40">
           <div className="absolute inset-0 opacity-20 [background-image:linear-gradient(rgba(255,255,255,.08)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.08)_1px,transparent_1px)] [background-size:28px_28px]" />
           {!total ? (
-            <div className="relative z-10 flex h-full items-center justify-center rounded-xl border border-dashed border-white/20 text-sm text-zinc-400">
-              Нет точек маршрута для воспроизведения.
+            <div className="relative z-10 flex h-full items-center justify-center rounded-xl border border-dashed border-white/20 px-4 text-center text-sm text-zinc-400">
+              Нет точек маршрута для воспроизведения — GPS ещё прогревается или заезд только начался.
             </div>
           ) : (
             <svg className="relative z-10 h-full min-h-[46vh] w-full" viewBox="0 0 100 100" preserveAspectRatio="none" aria-label="Схема replay маршрута">

--- a/components/map-riders/StatusOverlay.tsx
+++ b/components/map-riders/StatusOverlay.tsx
@@ -37,8 +37,12 @@ export function StatusOverlay() {
   if (!state.shareEnabled) return null;
 
   const session = state.sessions.find((s) => s.id === state.sessionId);
-  const distance = Number(session?.total_distance_km || 0).toFixed(1);
-  const speed = Math.round(session?.latest_speed_kmh || 0);
+  const distanceKm = Number(session?.total_distance_km || 0);
+  const speedKmh = Number(session?.latest_speed_kmh || 0);
+  const hasDistance = distanceKm > 0;
+  const hasSpeed = speedKmh > 0;
+  const distance = hasDistance ? `${distanceKm.toFixed(1)} км` : "0 км";
+  const speed = hasSpeed ? `${Math.round(speedKmh)} км/ч` : "Ожидаем твою скорость...";
   const showSpeedLegend = Boolean(state.sessionDetail?.points?.length);
 
   return (
@@ -59,12 +63,13 @@ export function StatusOverlay() {
         <div className="h-4 w-px bg-white/20" />
         <div className="text-center">
           <div className="text-[10px] uppercase tracking-wider text-zinc-400">Дист.</div>
-          <div className="font-mono text-sm font-semibold">{distance} км</div>
+          <div className="font-mono text-sm font-semibold">{distance}</div>
+          {!hasDistance ? <div className="text-[10px] text-zinc-400">Жми, чтобы увидеть статистику 🏎</div> : null}
         </div>
         <div className="h-4 w-px bg-white/20" />
         <div className="text-center">
           <div className="text-[10px] uppercase tracking-wider text-zinc-400">Скор.</div>
-          <div className="font-mono text-sm font-semibold">{speed} км/ч</div>
+          <div className={`font-mono text-sm font-semibold ${hasSpeed ? "" : "animate-pulse"}`}>{speed}</div>
         </div>
       </div>
       {showSpeedLegend ? (

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -88,8 +88,18 @@ This root file stays intentionally compact so operators and agents can load it q
 - `next_step`: Preview-smoke `/franchize/vip-bike/map-riders` once Playwright host dependencies are available.
 - `risks`: Local screenshot capture was blocked by missing browser shared libraries in the runner; runtime visual QA still needs a browser-capable environment.
 
+### 2026-05-07 — MapRiders idle tick + dead-stat polish
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-07T00:00:00Z
+- `owner`: codex
+- `notes`: Kept idle eviction ticks referentially stable when no live rider changes are needed, split static map point sanitization away from dynamic rider/session/meetup points, softened just-started ride overlays/duration formatting for zero-distance and zero-speed states, added History-tab GPS warmup hints for active zero-distance rides, clarified empty replay warmup, and made `/vipbikerental` MapRiders preview honest when live ride data has not arrived yet.
+- `next_step`: Preview-smoke `/franchize/vip-bike/map-riders` and `/vipbikerental` with empty/just-started MapRiders data to confirm the surfaces explain GPS/data warmup without visual regressions or render noise.
+- `risks`: Runtime render-count validation still needs a browser/profiler session; this pass used code review and type/lint checks.
+
 ## 4) Mini execution diary addendum
 
+- 2026-05-07 — MapRiders idle/perceived-live polish: eviction ticks now clone the rider map only when stale/evicted status actually changes, static map points are memoized separately from moving riders/routes/meetups, the live overlay and drawer explain zero-distance GPS warmup, replay empty-state copy no longer looks broken, and `/vipbikerental` avoids fake/latest-ride dead stats while live data is warming up. Next step: profiler + mobile drawer/landing smoke on `/franchize/vip-bike/map-riders` and `/vipbikerental`.
 - 2026-05-07 — MapRiders drawer UX copy pass: parent state now prepares live-aware History/Meetups fallback copy, the drawer consumes those strings instead of hardcoded “go do it first” text, and genuinely empty tabs use a shorter playful fallback. Screenshot capture remains blocked until Playwright host libraries are installed.
 - 2026-05-07 — UX cleanup for `/vipbikerental`: removed literal explanatory copy and duplicated partner-link section, changed active hero tabs to light-on-tinted styling, added a route-level VIP Bike loader plus client-side catalog skeleton hydration, and tuned the global bike loader wheel/wind animation. Next step: mobile smoke with live Supabase catalog latency.
 - 2026-05-07 — Self-review polish for the UX cleanup: reduced new English labels in loader/landing/onboarding surfaces, brightened the MapRiders preview into a lighter VibeMap-like card, and replaced the invalid `FaShieldAlt` VCR token with `FaShieldCat` for the production-history easter egg. Next step: mobile visual smoke once browser libraries are available.

--- a/lib/map-riders-reducer.ts
+++ b/lib/map-riders-reducer.ts
@@ -307,20 +307,22 @@ export function mapRidersReducer(state: MapRidersState, action: MapRidersAction)
     case "eviction/tick": {
       const now = Date.now();
       let changed = false;
-      const nextRiders = new Map(state.liveRiders);
+      let nextRiders: Map<string, LiveRider> | null = null;
 
-      for (const [userId, rider] of nextRiders) {
+      for (const [userId, rider] of state.liveRiders) {
         if (isPinnedDemoRider(userId)) continue;
         const age = now - new Date(rider.updated_at).getTime();
         if (age > EVICT_MS) {
+          nextRiders = nextRiders ?? new Map(state.liveRiders);
           nextRiders.delete(userId);
           changed = true;
         } else if (age > STALE_MS && rider.status !== "stale") {
+          nextRiders = nextRiders ?? new Map(state.liveRiders);
           nextRiders.set(userId, { ...rider, status: "stale" });
           changed = true;
         }
       }
-      return changed ? { ...state, liveRiders: nextRiders } : state;
+      return changed && nextRiders ? { ...state, liveRiders: nextRiders } : state;
     }
 
     case "rider/evicted": {

--- a/lib/map-riders.ts
+++ b/lib/map-riders.ts
@@ -90,9 +90,13 @@ export function initialsFromName(name: string) {
 }
 
 export function formatRideDuration(seconds: number) {
+  if (seconds === 0) return "Только что начали!";
+  if (!Number.isFinite(seconds) || seconds < 0) return "Меньше минуты";
+
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   if (hours > 0) return `${hours} ч ${minutes} мин`;
+  if (minutes <= 0) return "Меньше минуты";
   return `${minutes} мин`;
 }
 

--- a/tests/franchize/map-riders-performance.spec.ts
+++ b/tests/franchize/map-riders-performance.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatRideDuration } from '@/lib/map-riders';
+import { initialMapRidersState, mapRidersReducer, type LiveRider, type MapRidersState } from '@/lib/map-riders-reducer';
+
+function rider(overrides: Partial<LiveRider> = {}): LiveRider {
+  return {
+    user_id: 'rider-1',
+    crew_slug: 'vip-bike',
+    lat: 56.204245,
+    lng: 43.798905,
+    speed_kmh: 0,
+    heading: null,
+    updated_at: new Date().toISOString(),
+    status: 'live',
+    isSelf: false,
+    ...overrides,
+  };
+}
+
+function stateWithRiders(liveRiders: Map<string, LiveRider>): MapRidersState {
+  return {
+    ...initialMapRidersState,
+    liveRiders,
+  };
+}
+
+describe('map riders eviction tick', () => {
+  it('keeps the same state and rider map reference when no rider changes', () => {
+    const liveRiders = new Map([['rider-1', rider()]]);
+    const state = stateWithRiders(liveRiders);
+
+    const nextState = mapRidersReducer(state, { type: 'eviction/tick' });
+
+    expect(nextState).toBe(state);
+    expect(nextState.liveRiders).toBe(liveRiders);
+  });
+
+  it('keeps empty rider maps stable on idle ticks', () => {
+    const state = stateWithRiders(new Map());
+
+    const nextState = mapRidersReducer(state, { type: 'eviction/tick' });
+
+    expect(nextState).toBe(state);
+    expect(nextState.liveRiders).toBe(state.liveRiders);
+  });
+
+  it('clones the rider map only when a rider becomes stale', () => {
+    const liveRiders = new Map([
+      [
+        'rider-1',
+        rider({
+          updated_at: new Date(Date.now() - 45_000).toISOString(),
+        }),
+      ],
+    ]);
+    const state = stateWithRiders(liveRiders);
+
+    const nextState = mapRidersReducer(state, { type: 'eviction/tick' });
+
+    expect(nextState).not.toBe(state);
+    expect(nextState.liveRiders).not.toBe(liveRiders);
+    expect(nextState.liveRiders.get('rider-1')?.status).toBe('stale');
+  });
+});
+
+describe('formatRideDuration', () => {
+  it('handles just-started and invalid durations without dead-looking zero minute labels', () => {
+    expect(formatRideDuration(0)).toBe('Только что начали!');
+    expect(formatRideDuration(Number.NaN)).toBe('Меньше минуты');
+    expect(formatRideDuration(-1)).toBe('Меньше минуты');
+    expect(formatRideDuration(30)).toBe('Меньше минуты');
+  });
+});


### PR DESCRIPTION
### Motivation

- Reduce unnecessary renders and make MapRiders UI honest when live GPS/data hasn't arrived yet. 
- Improve user-facing copy for just-started rides and GPS warmup states so zero-distance/speed doesn't look like broken data. 
- Keep static map points separate from frequently-updated live points to avoid extra memo churn.

### Description

- Make eviction tick referentially stable by only cloning `liveRiders` when a change is needed and returning original state otherwise in `map-riders-reducer`.
- Split and memoize static map points in `MapRidersClientRefactored` via `staticMapPoints` and filter out demo placeholder points there.
- Add warmup / explanatory UI and copy across several components: show a warmup hint in `MapRidersLivePreview` when no live data exists, clarify latest-ride distance/rider labels, and expose `latestRideHint` for context.
- Surface active zero-distance warmup sessions in `RidersDrawer` history with a GPS warmup hint and avoid showing a misleading empty-state when the parent knows about warmup sessions.
- Improve replay and overlay messaging by changing the empty-replay copy and formatting: `ReplayFullscreen` uses `formatRideDuration(0)` for empty runs; `StatusOverlay` shows friendly distance and speed placeholders and subtle animation when speed is not available.
- Centralized duration formatting in `lib/map-riders.ts` with `formatRideDuration` updated to handle `0`, non-finite and negative values gracefully.
- Update docs `THE_FRANCHEEZEPLAN.md` to document the UX and technical changes.

### Testing

- Added unit tests in `tests/franchize/map-riders-performance.spec.ts` covering `eviction/tick` idle stability and `formatRideDuration` edge cases and ran the suite with `vitest`, and the tests passed.
- Ran the existing test suite (Vitest) and type checks locally; the new tests for cloning behavior and duration formatting succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcee0b38c883248322a69b45e5ab91)