### PR TITLE
Propulsion-aware VS comparisons: add catalog-propulsion lib and UI labels

### DIFF
--- a/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
+++ b/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
@@ -6,6 +6,7 @@ import { CrewHeader } from "@/app/franchize/components/CrewHeader";
 import { FranchizeFloatingCart } from "@/app/franchize/components/FranchizeFloatingCart";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { SaleBikeLanding } from "@/app/franchize/components/SaleBikeLanding";
+import { isSameCatalogPropulsion } from "@/app/franchize/lib/catalog-propulsion";
 
 interface BuyBikePageProps {
   params: Promise<{ slug: string; bike_id: string }>;
@@ -54,7 +55,8 @@ export default async function BuyBikePage({
   const otherSaleBikes = items.filter(
     (candidate) =>
       candidate.id !== item.id &&
-      (candidate.saleAvailable || isSaleEnabled(candidate.rawSpecs?.sale)),
+      (candidate.saleAvailable || isSaleEnabled(candidate.rawSpecs?.sale)) &&
+      isSameCatalogPropulsion(item, candidate),
   );
   const vsItem = vs
     ? (otherSaleBikes.find((candidate) => candidate.id === vs) ?? null)

--- a/app/franchize/components/SaleBikeLandingClient.tsx
+++ b/app/franchize/components/SaleBikeLandingClient.tsx
@@ -41,6 +41,10 @@ import {
   VsSpecRow,
   getCatalogVsSpecValue,
 } from "@/components/franchize/VsSpecRow";
+import {
+  getCatalogPropulsionLabel,
+  getCatalogPropulsionSegment,
+} from "@/app/franchize/lib/catalog-propulsion";
 
 type SaleActionState = "idle" | "loading" | "success" | "error";
 type SaleBikeLandingClientProps = {
@@ -112,6 +116,11 @@ export function SaleBikeLandingClient({
   );
 
   const canShowConcretePrice = basePrice > 0;
+  const propulsionSegment = useMemo(
+    () => getCatalogPropulsionSegment(item),
+    [item],
+  );
+  const propulsionLabel = getCatalogPropulsionLabel(propulsionSegment);
 
   const trustStats = useMemo(
     () => ({
@@ -397,8 +406,11 @@ export function SaleBikeLandingClient({
                       className="pointer-events-none absolute right-0 top-full z-20 mt-2 w-64 rounded-2xl border p-2 opacity-0 shadow-2xl transition group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
                       style={surface.card}
                     >
-                      <p className="px-2 pb-2 text-xs opacity-70">
+                      <p className="px-2 pb-1 text-xs opacity-70">
                         Выберите байк для VS
+                      </p>
+                      <p className="px-2 pb-2 text-[11px] opacity-55">
+                        Показываем только {propulsionLabel}
                       </p>
                       {otherSaleBikes.slice(0, 5).map((bike) => (
                         <button
@@ -520,7 +532,12 @@ export function SaleBikeLandingClient({
               style={surface.subtleCard}
             >
               <div className="mb-3 grid grid-cols-[1fr_auto_1fr] items-center gap-2 text-center">
-                <p className="text-sm font-semibold">{item.title}</p>
+                <div>
+                  <p className="text-sm font-semibold">{item.title}</p>
+                  <p className="text-[10px] uppercase tracking-[0.12em] opacity-55">
+                    {propulsionLabel}
+                  </p>
+                </div>
                 <Swords
                   className="h-7 w-7"
                   style={{ color: crew.theme.palette.accentMain }}

--- a/app/franchize/lib/catalog-propulsion.ts
+++ b/app/franchize/lib/catalog-propulsion.ts
@@ -1,0 +1,100 @@
+export type CatalogPropulsionSegment = "electric" | "gas" | "unknown";
+
+export type CatalogPropulsionInput = {
+  title?: string;
+  subtitle?: string;
+  description?: string;
+  category?: string;
+  rawSpecs?: Record<string, unknown>;
+};
+
+const ELECTRIC_VALUE_RE =
+  /electric|electro|e-moto|emoto|электро|электроэн|эл\.?\s*мото|\bev\b/i;
+const GAS_VALUE_RE =
+  /gas|gasoline|petrol|fuel|\bice\b|бенз|двс|топлив|карбюратор|инжектор/i;
+const ELECTRIC_TEXT_RE =
+  /electric|electro|e-moto|emoto|электро|электроэн|эл\.?\s*мото|аккум|батар|заряд/i;
+const GAS_TEXT_RE =
+  /gas|gasoline|petrol|fuel|\bice\b|бенз|двс|топлив|куб|карбюратор|инжектор/i;
+
+const ELECTRIC_SPEC_KEYS = new Set([
+  "battery_options",
+  "battery_capacity",
+  "battery_capacity_kwh",
+  "battery_type",
+  "charge_time_h",
+  "charging_time_h",
+  "max_range_km",
+  "motor_kw",
+  "motor_peak_kw",
+  "power_kw",
+  "power_w",
+  "range_km",
+]);
+
+const GAS_SPEC_KEYS = new Set([
+  "displacement_cc",
+  "engine_cc",
+  "fuel_capacity_l",
+  "fuel_tank_l",
+  "horsepower",
+  "hp",
+  "torque_nm",
+]);
+
+const stringifySpecValue = (value: unknown) => {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value) ?? "";
+};
+
+const normalizeKey = (key: string) => key.toLowerCase().replace(/[^a-z0-9_]/g, "_");
+
+const scoreRawSpecs = (rawSpecs: Record<string, unknown> | undefined) => {
+  let electric = 0;
+  let gas = 0;
+
+  for (const [rawKey, rawValue] of Object.entries(rawSpecs ?? {})) {
+    const key = normalizeKey(rawKey);
+    const value = stringifySpecValue(rawValue);
+
+    if (ELECTRIC_SPEC_KEYS.has(key)) electric += 2;
+    if (GAS_SPEC_KEYS.has(key)) gas += 2;
+    if (ELECTRIC_VALUE_RE.test(value)) electric += 3;
+    if (GAS_VALUE_RE.test(value)) gas += 3;
+  }
+
+  return { electric, gas };
+};
+
+export const getCatalogPropulsionSegment = ({
+  title,
+  subtitle,
+  description,
+  category,
+  rawSpecs,
+}: CatalogPropulsionInput): CatalogPropulsionSegment => {
+  const score = scoreRawSpecs(rawSpecs);
+  const publicText = `${title ?? ""} ${subtitle ?? ""} ${description ?? ""} ${
+    category ?? ""
+  }`;
+
+  if (ELECTRIC_TEXT_RE.test(publicText)) score.electric += 1;
+  if (GAS_TEXT_RE.test(publicText)) score.gas += 1;
+
+  if (score.electric === score.gas) return "unknown";
+  return score.electric > score.gas ? "electric" : "gas";
+};
+
+export const getCatalogPropulsionLabel = (
+  segment: CatalogPropulsionSegment,
+) => {
+  if (segment === "electric") return "электро ↔ электро";
+  if (segment === "gas") return "бензин ↔ бензин";
+  return "один класс ↔ один класс";
+};
+
+export const isSameCatalogPropulsion = (
+  a: CatalogPropulsionInput,
+  b: CatalogPropulsionInput,
+) => getCatalogPropulsionSegment(a) === getCatalogPropulsionSegment(b);

--- a/app/franchize/modals/Item.tsx
+++ b/app/franchize/modals/Item.tsx
@@ -9,6 +9,11 @@ import {
   VsSpecRow,
   getCatalogVsSpecValue,
 } from "@/components/franchize/VsSpecRow";
+import {
+  getCatalogPropulsionLabel,
+  getCatalogPropulsionSegment,
+  isSameCatalogPropulsion,
+} from "@/app/franchize/lib/catalog-propulsion";
 import { ItemGallery } from "../components/ItemGallery";
 import { crewPaletteForSurface } from "../lib/theme";
 
@@ -216,13 +221,20 @@ export function ItemModal({
     [gallery.length],
   );
 
+  const propulsionSegment = useMemo(
+    () => (item ? getCatalogPropulsionSegment(item) : "unknown"),
+    [item],
+  );
+  const propulsionLabel = getCatalogPropulsionLabel(propulsionSegment);
+
   const comparableBikes = useMemo(() => {
     if (!item) return [];
     return items
       .filter(
         (candidate) =>
           candidate.id !== item.id &&
-          candidate.availabilityStatus === "available",
+          candidate.availabilityStatus === "available" &&
+          isSameCatalogPropulsion(item, candidate),
       )
       .slice(0, 6);
   }, [item, items]);
@@ -415,6 +427,9 @@ export function ItemModal({
               >
                 <summary className="cursor-pointer list-none text-sm font-semibold">
                   Сравнить с другой моделью
+                  <span className="ml-2 text-xs font-normal opacity-60">
+                    {propulsionLabel}
+                  </span>
                 </summary>
                 <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
                   {comparableBikes.map((bike) => (
@@ -439,7 +454,12 @@ export function ItemModal({
                     style={surface.subtleCard}
                   >
                     <div className="mb-3 grid grid-cols-[1fr_auto_1fr] items-center gap-2 text-center text-xs font-semibold">
-                      <span>{item.title}</span>
+                      <span>
+                        {item.title}
+                        <span className="mt-0.5 block text-[10px] uppercase tracking-[0.12em] opacity-55">
+                          {propulsionLabel}
+                        </span>
+                      </span>
                       <Swords className="h-5 w-5 text-[var(--item-accent)]" />
                       <span>{vsBike.title}</span>
                     </div>

--- a/components/franchize/VsSpecRow.tsx
+++ b/components/franchize/VsSpecRow.tsx
@@ -8,6 +8,13 @@ type VsSpecRowProps = {
   lowerIsBetter?: boolean;
 };
 
+export {
+  getCatalogPropulsionLabel,
+  getCatalogPropulsionSegment,
+  isSameCatalogPropulsion,
+  type CatalogPropulsionSegment,
+} from "@/app/franchize/lib/catalog-propulsion";
+
 export type CatalogVsSpec = {
   label: string;
   keys: string[];

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -49,6 +49,15 @@ This root file stays intentionally compact so operators and agents can load it q
 
 - 2026-05-04 — Added support for metadata-driven franchize header logo routing via `header.logoHref` with default fallback to `/franchize/{slug}`; seeded `vip-bike` to land on `/vipbikerental` instead of catalog. Next step: expose `header.logoHref` in admin configurator UI for non-SQL operators.
 
+### 2026-05-07 — VS same-propulsion micropolish
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-07T00:00:00Z
+- `owner`: codex
+- `notes`: Tightened franchize bike VS comparisons so electric bikes compare only with electric bikes, gas bikes compare only with gas bikes, and both sale-buy + rental modal surfaces explain the active comparison class. Self-review moved propulsion inference into a focused lib with score-based structured-spec detection and regression coverage for gas bikes that mention a support battery.
+- `next_step`: Smoke `/franchize/vip-bike` catalog modal and `/franchize/vip-bike/market/<bike_id>/buy` with mixed electric/gas catalog data.
+- `risks`: Propulsion is inferred from existing free-text category/spec metadata until catalog rows get a structured propulsion field.
+
 ## 3) Active ad-hoc task — `/vipbikerental` interactive landing
 
 - status: `ready_for_pr`

--- a/tests/franchize/lib.spec.ts
+++ b/tests/franchize/lib.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { catalogCardVariantStyles, crewPaletteForSurface, floatingCartOverlayBackground } from '@/app/franchize/lib/theme';
 import { resolveFranchizeTheme, resolvePaletteByMode } from '@/app/franchize/lib/theme-resolver';
 import { isExternalHref, toCategoryId } from '@/app/franchize/lib/navigation';
+import { getCatalogPropulsionSegment, isSameCatalogPropulsion } from '@/app/franchize/lib/catalog-propulsion';
 import { DEFAULT_FRANCHIZE_THEME } from '@/lib/franchize-config';
 import type { FranchizeTheme } from '@/app/franchize/actions';
 
@@ -32,6 +33,36 @@ describe('franchize navigation helpers', () => {
     expect(isExternalHref('http://example.com')).toBe(true);
     expect(isExternalHref('/franchize/vip-bike')).toBe(false);
     expect(isExternalHref('tg://resolve?domain=oneBikePlsBot')).toBe(false);
+  });
+});
+
+
+describe('franchize catalog propulsion helpers', () => {
+  it('keeps electric and gas bikes in separate VS lanes', () => {
+    const electricBike = {
+      title: 'Y-VOLT Surge V',
+      category: 'Electro-Enduro',
+      rawSpecs: { type: 'Electric', power_kw: '15+', range_km: '120' },
+    };
+    const gasBike = {
+      title: 'Kawasaki Ninja H2',
+      category: 'Hypersport',
+      rawSpecs: { engine_cc: 998, horsepower: 231, fuel_tank_l: 17 },
+    };
+
+    expect(getCatalogPropulsionSegment(electricBike)).toBe('electric');
+    expect(getCatalogPropulsionSegment(gasBike)).toBe('gas');
+    expect(isSameCatalogPropulsion(electricBike, gasBike)).toBe(false);
+  });
+
+  it('does not classify a gas bike as electric just because support text mentions a battery', () => {
+    const gasBikeWithBatteryNote = {
+      title: 'Yamaha MT-09 SP',
+      description: 'Бензиновый нейкед, обслужена 12V battery перед выдачей.',
+      rawSpecs: { engine_cc: 890, horsepower: 119 },
+    };
+
+    expect(getCatalogPropulsionSegment(gasBikeWithBatteryNote)).toBe('gas');
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prevent mixing electric and gas bikes in side-by-side (VS) comparisons by detecting propulsion from catalog metadata.
- Surface the inferred propulsion class in buy and modal UIs so users understand why some bikes are shown/hidden.

### Description
- Added a new propulsion inference library in `app/franchize/lib/catalog-propulsion.ts` that scores `rawSpecs` and public text and exposes `getCatalogPropulsionSegment`, `getCatalogPropulsionLabel`, and `isSameCatalogPropulsion`.
- Restricted VS candidate lists to the same propulsion class by applying `isSameCatalogPropulsion` in the buy page `app/franchize/[slug]/market/[bike_id]/buy/page.tsx` and the modal `app/franchize/modals/Item.tsx`.
- Re-exported propulsion helpers from `components/franchize/VsSpecRow.tsx` and updated `app/franchize/components/SaleBikeLandingClient.tsx` to show the propulsion label in the compare dropdown and VS header.
- Minor copy/UI adjustments to explain that only the same propulsion class is shown during comparisons.
- Documented the change in `docs/THE_FRANCHEEZEPLAN.md`.

### Testing
- Added unit tests in `tests/franchize/lib.spec.ts` for propulsion inference and `isSameCatalogPropulsion` and ran the test suite with `vitest` targeting `tests/franchize/lib.spec.ts`.
- `vitest` unit tests for the new propulsion helpers passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfc4e361c8324a14f328b9584ffbf)