### PR TITLE
Add FranchizePageShell & FranchizeHero and apply themed shell across franchize pages

### DIFF
--- a/app/franchize/[slug]/about/page.tsx
+++ b/app/franchize/[slug]/about/page.tsx
@@ -3,6 +3,8 @@ import { getFranchizeBySlug } from "../../actions";
 import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
 import { FranchizeFloatingCart } from "../../components/FranchizeFloatingCart";
+import { FranchizeHero } from "../../components/FranchizeHero";
+import { FranchizePageShell } from "../../components/FranchizePageShell";
 import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
@@ -23,30 +25,31 @@ export default async function FranchizeAboutPage({ params }: FranchizeAboutPageP
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
+  const resolvedSlug = crew.slug || slug;
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/about`} groupLinks={items.map((item) => item.category)} />
-      <section className="mx-auto w-full max-w-4xl px-4 py-6">
-        <p className="text-xs uppercase tracking-[0.2em]" style={{ color: crew.theme.palette.accentMain }}>
-          /franchize/{crew.slug || slug}/about
-        </p>
-        <h1 className="mt-2 text-2xl font-semibold">О нас</h1>
-        <p className="mt-2 max-w-2xl text-sm" style={surface.mutedText}>
-          {crew.description ||
-            "Раздел в процессе наполнения. Подробный текст, преимущества и FAQ подгрузятся из метаданных франшизы."}
-        </p>
-        {crew.ratingSummary.count > 0 && (
-          <div className="mt-4 inline-flex items-center gap-2 rounded-2xl border px-3 py-2 text-sm" style={surface.card}>
-            <span className="font-bold" style={{ color: crew.theme.palette.accentMain }}>★ {crew.ratingSummary.average.toFixed(1)}</span>
-            <span style={surface.mutedText}>общий рейтинг экипажа · {crew.ratingSummary.count} отзывов</span>
-          </div>
-        )}
-      </section>
+      <CrewHeader crew={crew} activePath={`/franchize/${resolvedSlug}/about`} groupLinks={items.map((item) => item.category)} />
+      <FranchizePageShell theme={crew.theme}>
+        <FranchizeHero
+          eyebrow={`/franchize/${resolvedSlug}/about · экипаж`}
+          title="О нас"
+          subcopy={crew.description || "Операторская страница экипажа: ценности, формат работы и доверие перед первой заявкой. Подробности подтянутся из метаданных франшизы."}
+          primaryCta={{ label: "Смотреть каталог", href: `/franchize/${resolvedSlug}` }}
+          secondaryCta={{ label: "Связаться", href: `/franchize/${resolvedSlug}/contacts` }}
+        >
+          {crew.ratingSummary.count > 0 ? (
+            <div className="rounded-2xl border px-4 py-3 text-sm" style={surface.subtleCard}>
+              <span className="font-bold" style={{ color: crew.theme.palette.accentMain }}>★ {crew.ratingSummary.average.toFixed(1)}</span>
+              <span style={surface.mutedText}> · {crew.ratingSummary.count} отзывов экипажа</span>
+            </div>
+          ) : null}
+        </FranchizeHero>
+      </FranchizePageShell>
       <CrewFooter crew={crew} />
       <FranchizeFloatingCart
-        slug={crew.slug || slug}
-        href={`/franchize/${crew.slug || slug}/cart`}
+        slug={resolvedSlug}
+        href={`/franchize/${resolvedSlug}/cart`}
         items={items}
         accentColor={crew.theme.palette.accentMain}
         textColor={crew.theme.palette.textPrimary}

--- a/app/franchize/[slug]/contacts/page.tsx
+++ b/app/franchize/[slug]/contacts/page.tsx
@@ -3,6 +3,8 @@ import { getFranchizeBySlug } from "../../actions";
 import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
 import { FranchizeFloatingCart } from "../../components/FranchizeFloatingCart";
+import { FranchizeHero } from "../../components/FranchizeHero";
+import { FranchizePageShell } from "../../components/FranchizePageShell";
 import { FranchizeContactsMap } from "../../components/FranchizeContactsMap";
 import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
@@ -24,15 +26,27 @@ export default async function FranchizeContactsPage({ params }: FranchizeContact
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
+  const resolvedSlug = crew.slug || slug;
+  const telegramHref = crew.contacts.telegram
+    ? crew.contacts.telegram.startsWith("http")
+      ? crew.contacts.telegram
+      : `https://t.me/${crew.contacts.telegram.replace(/^@/, "")}`
+    : `/franchize/${resolvedSlug}`;
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/contacts`} groupLinks={items.map((item) => item.category)} />
+      <CrewHeader crew={crew} activePath={`/franchize/${resolvedSlug}/contacts`} groupLinks={items.map((item) => item.category)} />
 
-      <section className="mx-auto w-full max-w-4xl px-4 py-6">
-        <h1 className="text-2xl font-semibold">Контакты</h1>
+      <FranchizePageShell theme={crew.theme}>
+        <FranchizeHero
+          eyebrow={`/franchize/${resolvedSlug}/contacts · связь`}
+          title="Контакты экипажа"
+          subcopy="Быстрый операторский блок для связи, маршрута и проверки точки выдачи перед арендой или покупкой."
+          primaryCta={{ label: "Написать в Telegram", href: telegramHref }}
+          secondaryCta={{ label: "Открыть каталог", href: `/franchize/${resolvedSlug}` }}
+        />
 
-        <div className="mt-4 rounded-2xl border p-4" style={surface.card}>
+        <div className="mt-6 rounded-2xl border p-4" style={surface.subtleCard}>
           <div className="space-y-2 text-sm" style={surface.mutedText}>
             <p>Адрес: {crew.contacts.address || "—"}</p>
             <p>Телефон: {crew.contacts.phone || "—"}</p>
@@ -40,7 +54,7 @@ export default async function FranchizeContactsPage({ params }: FranchizeContact
             {crew.contacts.workingHours && <p>Часы работы: {crew.contacts.workingHours}</p>}
           </div>
           {crew.ratingSummary.count > 0 && (
-            <div className="mt-4 rounded-2xl border px-3 py-2 text-sm" style={surface.subtleCard}>
+            <div className="mt-4 rounded-2xl border px-3 py-2 text-sm" style={surface.card}>
               <span className="font-bold" style={{ color: crew.theme.palette.accentMain }}>★ {crew.ratingSummary.average.toFixed(1)}</span>
               <span style={surface.mutedText}> · рейтинг экипажа по {crew.ratingSummary.count} отзывам</span>
             </div>
@@ -59,12 +73,12 @@ export default async function FranchizeContactsPage({ params }: FranchizeContact
             theme={crew.theme}
           />
         </div>
-      </section>
+      </FranchizePageShell>
 
       <CrewFooter crew={crew} />
       <FranchizeFloatingCart
-        slug={crew.slug || slug}
-        href={`/franchize/${crew.slug || slug}/cart`}
+        slug={resolvedSlug}
+        href={`/franchize/${resolvedSlug}/cart`}
         items={items}
         accentColor={crew.theme.palette.accentMain}
         textColor={crew.theme.palette.textPrimary}

--- a/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
+++ b/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
@@ -4,9 +4,12 @@ import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
 import { FranchizeFloatingCart } from "@/app/franchize/components/FranchizeFloatingCart";
+import { FranchizeHero } from "@/app/franchize/components/FranchizeHero";
+import { FranchizePageShell } from "@/app/franchize/components/FranchizePageShell";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { SaleBikeLanding } from "@/app/franchize/components/SaleBikeLanding";
 import { isSameCatalogPropulsion } from "@/app/franchize/lib/catalog-propulsion";
+import { buildSaleBuySectionId } from "@/app/franchize/lib/sale-anchors";
 
 interface BuyBikePageProps {
   params: Promise<{ slug: string; bike_id: string }>;
@@ -26,14 +29,17 @@ export default async function BuyBikePage({
   const { slug, bike_id } = await params;
   const { vs } = (await searchParams) ?? {};
   const { crew, items } = await getFranchizeBySlug(slug);
+  const resolvedSlug = crew.slug || slug;
+  const surface = crewPaletteForSurface(crew.theme);
   const item = items.find((candidate) => candidate.id === bike_id);
 
   if (!item) notFound();
+  const buySectionId = buildSaleBuySectionId(item.id);
   if (!item.saleAvailable && !isSaleEnabled(item.rawSpecs?.sale)) {
     return (
       <main
         className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center gap-4 p-6 text-center"
-        style={crewPaletteForSurface(crew.theme).page}
+        style={surface.page}
       >
         <h1 className="text-2xl font-semibold">
           Этот байк не помечен как продажа
@@ -42,7 +48,7 @@ export default async function BuyBikePage({
           Откройте карточку через маркет и выберите аренду.
         </p>
         <Link
-          href={`/franchize/${slug}?vehicle=${encodeURIComponent(bike_id)}&flow=rent`}
+          href={`/franchize/${resolvedSlug}?vehicle=${encodeURIComponent(bike_id)}&flow=rent`}
           className="rounded-xl border px-4 py-2 text-sm font-semibold"
         >
           Вернуться в маркет
@@ -51,7 +57,6 @@ export default async function BuyBikePage({
     );
   }
 
-  const resolvedSlug = crew.slug || slug;
   const otherSaleBikes = items.filter(
     (candidate) =>
       candidate.id !== item.id &&
@@ -65,13 +70,22 @@ export default async function BuyBikePage({
   return (
     <main
       className="min-h-screen"
-      style={crewPaletteForSurface(crew.theme).page}
+      style={surface.page}
     >
       <CrewHeader
         crew={crew}
         activePath={`/franchize/${resolvedSlug}/market/${bike_id}/buy`}
         groupLinks={items.map((candidate) => candidate.category)}
       />
+      <FranchizePageShell theme={crew.theme} contentClassName="space-y-6">
+        <FranchizeHero
+          eyebrow={`/franchize/${resolvedSlug}/market/${bike_id}/buy · sale`}
+          title={`Покупка · ${item.title}`}
+          subcopy="Операторская витрина продажи: сравнение, конфигурация, тест-драйв и быстрый возврат в маркет без потери бренда экипажа."
+          primaryCta={{ label: "Настроить покупку", href: `#${buySectionId}` }}
+          secondaryCta={{ label: "Вернуться в маркет", href: `/franchize/${resolvedSlug}?vehicle=${encodeURIComponent(bike_id)}` }}
+        />
+      </FranchizePageShell>
       <SaleBikeLanding
         crew={crew}
         item={item}

--- a/app/franchize/[slug]/rental/[id]/page.tsx
+++ b/app/franchize/[slug]/rental/[id]/page.tsx
@@ -4,7 +4,10 @@ import { getFranchizeBySlug, getFranchizeRentalCard } from "../../../actions";
 import { CrewHeader } from "../../../components/CrewHeader";
 import { CrewFooter } from "../../../components/CrewFooter";
 import { FranchizeRentalLifecycleActions } from "../../../components/FranchizeRentalLifecycleActions";
+import { FranchizeHero } from "../../../components/FranchizeHero";
+import { FranchizePageShell } from "../../../components/FranchizePageShell";
 import { FranchizeRentalDocumentsPanel } from "../../../components/FranchizeRentalDocumentsPanel";
+import { crewPaletteForSurface } from "../../../lib/theme";
 
 interface FranchizeRentalPageProps {
   params: Promise<{ slug: string; id: string }>;
@@ -21,6 +24,8 @@ const statusLabel: Record<string, string> = {
 export default async function FranchizeRentalPage({ params }: FranchizeRentalPageProps) {
   const { slug, id } = await params;
   const [{ crew, items }, rental] = await Promise.all([getFranchizeBySlug(slug), getFranchizeRentalCard(slug, id)]);
+  const resolvedSlug = crew.slug || slug;
+  const surface = crewPaletteForSurface(crew.theme);
   const dealStarted = rental.found || rental.paymentStatus === "interest_paid";
   const verificationText =
     rental.contractVerificationStatus === "verified"
@@ -36,19 +41,19 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
         : crew.theme.palette.textSecondary;
 
   return (
-    <main className="min-h-screen" style={{ backgroundColor: crew.theme.palette.bgBase, color: crew.theme.palette.textPrimary }}>
-      <CrewHeader crew={crew} activePath={`/franchize/${slug}/rental/${id}`} groupLinks={items.map((item) => item.category)} />
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader crew={crew} activePath={`/franchize/${resolvedSlug}/rental/${id}`} groupLinks={items.map((item) => item.category)} />
 
-      <section className="mx-auto w-full max-w-4xl px-4 pb-8 pt-10">
-        <p className="text-xs uppercase tracking-[0.2em]" style={{ color: crew.theme.palette.accentMain }}>
-          /franchize/{slug}/rental/{id}
-        </p>
-        <h1 className="mt-2 text-2xl font-semibold">Franchize rental card</h1>
-        <p className="mt-2 text-sm" style={{ color: crew.theme.palette.textSecondary }}>
-          {rental.found
+      <FranchizePageShell theme={crew.theme} contentClassName="space-y-6">
+        <FranchizeHero
+          eyebrow={`/franchize/${resolvedSlug}/rental/${id} · сделка`}
+          title="Карточка аренды"
+          subcopy={rental.found
             ? "Сделка активирована. Управляй следующим шагом аренды из Telegram WebApp или через runtime-карточку."
             : "Сделка пока не найдена. Проверь ссылку и дождись синхронизации после оплаты XTR."}
-        </p>
+          primaryCta={{ label: "Продолжить оформление", href: `/franchize/${resolvedSlug}/order/demo-order` }}
+          secondaryCta={{ label: "К каталогу", href: `/franchize/${resolvedSlug}` }}
+        />
 
         {dealStarted && (
           <div
@@ -60,7 +65,7 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
           </div>
         )}
 
-        <section className="mt-6 rounded-3xl border p-4 shadow-[0_18px_30px_rgba(0,0,0,0.35)]" style={{ borderColor: crew.theme.palette.borderSoft, backgroundColor: crew.theme.palette.bgCard }}>
+        <section className="rounded-3xl border p-4" style={surface.subtleCard}>
           <div className="mb-4 flex flex-wrap items-center gap-2">
             <span className="text-xs" style={{ color: crew.theme.palette.textSecondary }}>Проверка контракта:</span>
             <span className="rounded-full border px-3 py-1 text-xs font-semibold" style={{ borderColor: verificationColor, color: verificationColor }}>
@@ -99,15 +104,15 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
 
           <div className="mt-5 grid gap-2 sm:grid-cols-2">
             <Link
-              href={`/franchize/${slug}/order/demo-order`}
+              href={`/franchize/${resolvedSlug}/order/demo-order`}
               className="inline-flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold"
-              style={{ backgroundColor: crew.theme.palette.accentMain, color: "#16130A" }}
+              style={{ backgroundColor: crew.theme.palette.accentMain, color: crew.theme.palette.bgBase }}
             >
               <Sparkles className="h-4 w-4" />
               Продолжить оформление
             </Link>
             <Link
-              href={`/franchize/${slug}`}
+              href={`/franchize/${resolvedSlug}`}
               className="inline-flex justify-center rounded-xl border px-4 py-3 text-sm"
               style={{ borderColor: crew.theme.palette.borderSoft, color: crew.theme.palette.textPrimary }}
             >
@@ -151,7 +156,7 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
             </a>
           </div>
         </section>
-      </section>
+      </FranchizePageShell>
 
       <CrewFooter crew={crew} />
     </main>

--- a/app/franchize/[slug]/rentals/page.tsx
+++ b/app/franchize/[slug]/rentals/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { getFranchizeBySlug } from "../../actions";
 import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
+import { FranchizeHero } from "../../components/FranchizeHero";
+import { FranchizePageShell } from "../../components/FranchizePageShell";
 import { FranchizeRentalsBridge } from "../../components/FranchizeRentalsBridge";
 import { FranchizeErrorBoundary } from "../../components/ErrorBoundary";
+import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
 interface FranchizeRentalsPageProps {
@@ -23,37 +25,31 @@ export async function generateMetadata({ params }: FranchizeRentalsPageProps): P
 export default async function FranchizeRentalsPage({ params }: FranchizeRentalsPageProps) {
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
+  const resolvedSlug = crew.slug || slug;
+  const surface = crewPaletteForSurface(crew.theme);
 
   return (
-    <>
-      <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/rentals`} groupLinks={items.map((item) => item.category)} />
-      <section className="mx-auto w-full max-w-4xl px-4 pt-6">
-        <p className="text-xs uppercase tracking-[0.2em]" style={{ color: crew.theme.palette.accentMain }}>
-          /franchize/{slug}/rentals
-        </p>
-        <h1 className="mt-2 text-2xl font-semibold">Мои аренды · Franchize shell</h1>
-        <p className="mt-2 text-sm" style={{ color: crew.theme.palette.textSecondary }}>
-          Полноценный rentals control-center в franchize оболочке: используем существующий движок, но сохраняем бренд и навигацию экипажа.
-        </p>
-        <div className="mt-3 flex flex-wrap gap-3 text-sm">
-          <Link href={`/franchize/${crew.slug || slug}`} className="underline underline-offset-4" style={{ color: crew.theme.palette.accentMain }}>
-            ← Вернуться в каталог
-          </Link>
-          <Link href="/rentals" className="underline underline-offset-4" style={{ color: crew.theme.palette.accentMain }}>
-            Открыть классический /rentals
-          </Link>
-        </div>
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader crew={crew} activePath={`/franchize/${resolvedSlug}/rentals`} groupLinks={items.map((item) => item.category)} />
+      <FranchizePageShell theme={crew.theme} contentClassName="space-y-6">
+        <FranchizeHero
+          eyebrow={`/franchize/${resolvedSlug}/rentals · control-center`}
+          title="Мои аренды"
+          subcopy="Операторская оболочка для текущих, завершённых и ожидающих аренд: оставляем рабочий движок, но держим бренд экипажа и быстрые возвраты."
+          primaryCta={{ label: "Вернуться в каталог", href: `/franchize/${resolvedSlug}` }}
+          secondaryCta={{ label: "Классический /rentals", href: "/rentals" }}
+        />
 
         <FranchizeErrorBoundary
           resetKey={slug}
           fallbackTitle="Раздел аренд временно недоступен"
-          fallbackHref={`/franchize/${crew.slug || slug}/rentals`}
+          fallbackHref={`/franchize/${resolvedSlug}/rentals`}
           fallbackLinkLabel="Остаться в арендном разделе"
         >
           <FranchizeRentalsBridge />
         </FranchizeErrorBoundary>
-      </section>
+      </FranchizePageShell>
       <CrewFooter crew={crew} />
-    </>
+    </main>
   );
 }

--- a/app/franchize/components/FranchizeHero.tsx
+++ b/app/franchize/components/FranchizeHero.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+type FranchizeHeroCta = {
+  label: string;
+  href: string;
+};
+
+type FranchizeHeroProps = {
+  eyebrow: string;
+  title: string;
+  subcopy: string;
+  primaryCta: FranchizeHeroCta;
+  secondaryCta: FranchizeHeroCta;
+  children?: ReactNode;
+};
+
+export function FranchizeHero({
+  eyebrow,
+  title,
+  subcopy,
+  primaryCta,
+  secondaryCta,
+  children,
+}: FranchizeHeroProps) {
+  return (
+    <header className="relative z-10 grid gap-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+      <div className="min-w-0">
+        <p
+          className="inline-flex max-w-full rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em]"
+          style={{
+            backgroundColor:
+              "color-mix(in srgb, var(--franchize-shell-accent) 12%, transparent)",
+            borderColor:
+              "color-mix(in srgb, var(--franchize-shell-accent) 42%, var(--franchize-shell-border))",
+            color: "var(--franchize-shell-accent)",
+          }}
+        >
+          <span className="truncate">{eyebrow}</span>
+        </p>
+        <h1 className="mt-4 max-w-3xl text-3xl font-semibold tracking-tight sm:text-4xl lg:text-5xl">
+          {title}
+        </h1>
+        <p
+          className="mt-3 max-w-2xl text-sm leading-6 sm:text-base"
+          style={{ color: "var(--franchize-shell-muted)" }}
+        >
+          {subcopy}
+        </p>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          <Link
+            href={primaryCta.href}
+            className="inline-flex min-h-11 items-center justify-center rounded-2xl border px-5 py-3 text-sm font-semibold transition hover:opacity-90 focus:outline-none focus:ring-2"
+            style={{
+              backgroundColor: "var(--franchize-shell-accent)",
+              borderColor: "var(--franchize-shell-accent)",
+              color: "var(--franchize-shell-primary-contrast)",
+              boxShadow:
+                "0 12px 30px color-mix(in srgb, var(--franchize-shell-accent) 24%, transparent)",
+            }}
+          >
+            {primaryCta.label}
+          </Link>
+          <Link
+            href={secondaryCta.href}
+            className="inline-flex min-h-11 items-center justify-center rounded-2xl border px-5 py-3 text-sm font-semibold transition hover:opacity-80 focus:outline-none focus:ring-2"
+            style={{
+              backgroundColor:
+                "color-mix(in srgb, var(--franchize-shell-card) 58%, transparent)",
+              borderColor: "var(--franchize-shell-border)",
+              color: "var(--franchize-shell-text)",
+            }}
+          >
+            {secondaryCta.label}
+          </Link>
+        </div>
+      </div>
+      {children ? <div className="md:max-w-xs">{children}</div> : null}
+    </header>
+  );
+}

--- a/app/franchize/components/FranchizePageShell.tsx
+++ b/app/franchize/components/FranchizePageShell.tsx
@@ -1,0 +1,112 @@
+import type { CSSProperties, ReactNode } from "react";
+import type { FranchizeTheme } from "../actions";
+
+type FranchizePageShellProps = {
+  theme: FranchizeTheme;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  width?: "content" | "wide";
+};
+
+type FranchizeShellVars = CSSProperties & {
+  "--franchize-shell-bg": string;
+  "--franchize-shell-card": string;
+  "--franchize-shell-border": string;
+  "--franchize-shell-text": string;
+  "--franchize-shell-muted": string;
+  "--franchize-shell-accent": string;
+  "--franchize-shell-primary-contrast": string;
+  "--franchize-shell-ring": string;
+};
+
+const hexToRgb = (hex: string) => {
+  const normalized = hex.replace("#", "").trim();
+  const base =
+    normalized.length === 3
+      ? normalized
+          .split("")
+          .map((char) => `${char}${char}`)
+          .join("")
+      : normalized;
+
+  if (!/^[0-9A-Fa-f]{6}$/.test(base)) return null;
+
+  return {
+    r: Number.parseInt(base.slice(0, 2), 16),
+    g: Number.parseInt(base.slice(2, 4), 16),
+    b: Number.parseInt(base.slice(4, 6), 16),
+  };
+};
+
+const relativeLuminance = (hex: string) => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return 0;
+
+  const channels = [rgb.r, rgb.g, rgb.b].map((channel) => {
+    const value = channel / 255;
+    return value <= 0.03928
+      ? value / 12.92
+      : ((value + 0.055) / 1.055) ** 2.4;
+  });
+
+  return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+};
+
+const contrastRatio = (foreground: string, background: string) => {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+const pickBestAccentText = (palette: FranchizeTheme["palette"]) =>
+  [palette.textPrimary, palette.bgBase, palette.bgCard].sort(
+    (left, right) =>
+      contrastRatio(right, palette.accentMain) -
+      contrastRatio(left, palette.accentMain),
+  )[0];
+
+export function FranchizePageShell({
+  theme,
+  children,
+  className = "",
+  contentClassName = "",
+  width = "content",
+}: FranchizePageShellProps) {
+  const palette = theme.palette;
+  const shellVars: FranchizeShellVars = {
+    "--franchize-shell-bg": palette.bgBase,
+    "--franchize-shell-card": palette.bgCard,
+    "--franchize-shell-border": palette.borderSoft,
+    "--franchize-shell-text": palette.textPrimary,
+    "--franchize-shell-muted": palette.textSecondary,
+    "--franchize-shell-accent": palette.accentMain,
+    "--franchize-shell-primary-contrast": pickBestAccentText(palette),
+    "--franchize-shell-ring": palette.accentMain,
+  };
+  const maxWidthClass = width === "wide" ? "max-w-6xl" : "max-w-5xl";
+
+  return (
+    <section
+      className={`mx-auto w-full ${maxWidthClass} px-3 py-5 sm:px-4 sm:py-8 ${className}`}
+      style={shellVars}
+    >
+      <div
+        className={`relative overflow-hidden rounded-[2rem] border p-4 backdrop-blur sm:p-6 ${contentClassName}`}
+        style={{
+          background:
+            "radial-gradient(circle at top right, color-mix(in srgb, var(--franchize-shell-accent) 15%, transparent), transparent 34rem), color-mix(in srgb, var(--franchize-shell-card) 90%, transparent)",
+          borderColor: "var(--franchize-shell-border)",
+          color: "var(--franchize-shell-text)",
+          boxShadow:
+            "0 24px 70px color-mix(in srgb, var(--franchize-shell-accent) 14%, transparent)",
+        }}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/app/franchize/components/SaleBikeLanding.tsx
+++ b/app/franchize/components/SaleBikeLanding.tsx
@@ -1,5 +1,6 @@
 import type { CatalogItemVM, FranchizeCrewVM } from "@/app/franchize/actions";
 import { SaleBikeLandingClient } from "@/app/franchize/components/SaleBikeLandingClient";
+import { buildSaleBuySectionId } from "@/app/franchize/lib/sale-anchors";
 
 export function SaleBikeLanding({
   crew,
@@ -13,8 +14,10 @@ export function SaleBikeLanding({
   otherSaleBikes?: CatalogItemVM[];
 }) {
   return (
-    <section className="min-h-screen pb-28 pt-3 sm:pt-6">
-      <h1 className="sr-only">{item.title}</h1>
+    <section
+      id={buildSaleBuySectionId(item.id)}
+      className="min-h-screen scroll-mt-24 pb-28 pt-3 sm:pt-6"
+    >
       <SaleBikeLandingClient
         crew={crew}
         item={item}

--- a/app/franchize/lib/sale-anchors.ts
+++ b/app/franchize/lib/sale-anchors.ts
@@ -1,0 +1,10 @@
+const safeDomIdPart = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "bike";
+
+export function buildSaleBuySectionId(itemId: string) {
+  return `buy-${safeDomIdPart(itemId)}`;
+}

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -58,6 +58,16 @@ This root file stays intentionally compact so operators and agents can load it q
 - `next_step`: Smoke `/franchize/vip-bike` catalog modal and `/franchize/vip-bike/market/<bike_id>/buy` with mixed electric/gas catalog data.
 - `risks`: Propulsion is inferred from existing free-text category/spec metadata until catalog rows get a structured propulsion field.
 
+
+### 2026-05-07 — Franchize reusable content shell
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-07T21:22:00Z
+- `owner`: codex
+- `notes`: Added reusable `FranchizePageShell` + `FranchizeHero` components and applied the themed content hero/card shell to about, contacts, rentals, rental detail, and sale-buy franchize pages. Self-review tightened the shell toward agency polish: contrast-safe accent CTA text, richer badge/card treatment, sanitized sale anchors, and removal of the duplicate sale-page H1.
+- `next_step`: Visual-smoke `/franchize/vip-bike/about`, `/contacts`, `/rentals`, a rental card, and a sale-buy route in a browser-capable environment; next polish task should focus route-specific metadata coverage.
+- `risks`: Local screenshot capture remains blocked by missing Playwright host libraries; curl smoke reached the about route after fallback crew loading.
+
 ## 3) Active ad-hoc task — `/vipbikerental` interactive landing
 
 - status: `ready_for_pr`


### PR DESCRIPTION
### Motivation

- Introduce a reusable, theme-aware content shell and hero to unify franchize pages UX and preserve crew branding while reusing existing rental/sale engines.
- Improve accessibility and visual polish by deriving contrast-safe accent text and consolidating per-page hero/card treatments, plus sanitize sale anchors and normalize resolved slugs for routing.

### Description

- Added `FranchizePageShell` (themed shell with CSS variables, contrast helpers, and layout container) and `FranchizeHero` (eyebrow, title, subcopy, primary/secondary CTAs) components under `app/franchize/components`.
- Reworked pages `about`, `contacts`, `rentals`, rental detail (`rental/[id]`), and sale-buy (`market/[bike_id]/buy`) to use `FranchizePageShell`/`FranchizeHero`, introduced `resolvedSlug = crew.slug || slug` and improved surface/theme usage via `crewPaletteForSurface`.
- Added `buildSaleBuySectionId` helper in `lib/sale-anchors.ts`, applied it to `SaleBikeLanding` and sale buy page to create safe DOM anchors, and removed a duplicate sale H1 in favor of the hero.
- Normalized Telegram links on contacts page into `telegramHref` and adjusted rating/card treatments and minor layout spacing and style updates; updated docs `docs/THE_FRANCHEEZEPLAN.md` with the new shell entry.

### Testing

- Ran TypeScript type check with `tsc --noEmit` and a local Next build with `next build`, both completed successfully.
- No new unit tests were added in this change set and existing automated test suites were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd00cfab908324a1594f5c7bda3a66)