### PR TITLE
Franchize: add route metadata, metadata helper, and profile client

### DIFF
--- a/app/franchize/[slug]/admin/page.tsx
+++ b/app/franchize/[slug]/admin/page.tsx
@@ -1,8 +1,20 @@
+import type { Metadata } from "next";
 import { FranchizeAdminClient } from "@/app/franchize/components/FranchizeAdminClient";
+import { buildFranchizeSectionMetadata } from "../metadata";
 
 interface FranchizeSlugAdminPageProps {
   params: Promise<{ slug: string }>;
   searchParams: Promise<{ edit?: string }>;
+}
+
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Админ-панель экипажа",
+    sectionDescription: "Операторская панель настройки франшизной витрины, каталога, заказов и отзывов.",
+    pathSuffix: "/admin",
+  });
 }
 
 export default async function FranchizeSlugAdminPage({ params, searchParams }: FranchizeSlugAdminPageProps) {

--- a/app/franchize/[slug]/cart/page.tsx
+++ b/app/franchize/[slug]/cart/page.tsx
@@ -1,12 +1,24 @@
+import type { Metadata } from "next";
 import { getFranchizeBySlug } from "../../actions";
 import { CartPageClient } from "../../components/CartPageClient";
 import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
 import { FranchizeFloatingCart } from "../../components/FranchizeFloatingCart";
 import { crewPaletteForSurface } from "../../lib/theme";
+import { buildFranchizeSectionMetadata } from "../metadata";
 
 interface FranchizeCartPageProps {
   params: Promise<{ slug: string }>;
+}
+
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Корзина аренды и покупки",
+    sectionDescription: "Корзина экипажа с выбранными байками, аксессуарами и быстрым переходом к оформлению.",
+    pathSuffix: "/cart",
+  });
 }
 
 export default async function FranchizeCartPage({ params }: FranchizeCartPageProps) {

--- a/app/franchize/[slug]/community/page.tsx
+++ b/app/franchize/[slug]/community/page.tsx
@@ -1,9 +1,11 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { CalendarDays, Handshake, MapPinned, ShieldCheck, UsersRound } from "lucide-react";
 import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { buildFranchizeSectionMetadata } from "../metadata";
 
 const cityEvents = [
   {
@@ -38,6 +40,16 @@ const cityTips = [
   "Для новичков держим видимость «только экипаж» и автостоп геошеринга.",
   "Meetup-пин ставим long-press на карте или тапом по точке + кнопка «+».",
 ];
+
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Сообщество и поездки",
+    sectionDescription: "События, партнёры и городские маршруты экипажа для совместных выездов.",
+    pathSuffix: "/community",
+  });
+}
 
 export default async function FranchizeCommunityPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;

--- a/app/franchize/[slug]/configurator/page.tsx
+++ b/app/franchize/[slug]/configurator/page.tsx
@@ -1,11 +1,23 @@
+import type { Metadata } from "next";
 import { getFranchizeBySlug } from "../../actions";
 import { CrewHeader } from "../../components/CrewHeader";
 import { crewPaletteForSurface } from "../../lib/theme";
 import { ConfiguratorClient } from "./ConfiguratorClient";
 import Link from "next/link";
+import { buildFranchizeSectionMetadata } from "../metadata";
 
 interface ConfiguratorPageProps {
   params: Promise<{ slug: string }>;
+}
+
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Конфигуратор электробайка",
+    sectionDescription: "Сборка электромотоцикла под райдера: сценарий, комплектация и заявка экипажу.",
+    pathSuffix: "/configurator",
+  });
 }
 
 export default async function ConfiguratorPage({

--- a/app/franchize/[slug]/electro-enduro/page.tsx
+++ b/app/franchize/[slug]/electro-enduro/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
 import { CatalogClient } from "../../components/CatalogClient";
@@ -5,6 +6,7 @@ import { type CatalogItemVM, getFranchizeBySlug } from "../../actions";
 import { crewPaletteForSurface } from "../../lib/theme";
 import Link from "next/link";
 import { fallbackBikes } from "../configurator/fallback-catalog";
+import { buildFranchizeSectionMetadata } from "../metadata";
 
 interface ElectroEnduroPageProps {
   params: Promise<{ slug: string }>;
@@ -77,6 +79,18 @@ const configuratorFallbackItems = (): CatalogItemVM[] =>
       { label: "tier", value: String(bike.specs.tier ?? "standard") },
     ],
   }));
+
+
+export async function generateMetadata({ params }: ElectroEnduroPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Электро-эндуро",
+    sectionDescription: "Электро-эндуро витрина экипажа: аренда, тест-драйв, покупка и сборка кастомного байка.",
+    pathSuffix: "/electro-enduro",
+    image: ({ items }) => items.find((item) => item.imageUrl && (item.category.toLowerCase().includes("electro") || item.title.toLowerCase().includes("electro") || item.title.toLowerCase().includes("электро")))?.imageUrl,
+    imageAlt: ({ crew }) => `${crew.header.brandName} electro-enduro preview`,
+  });
+}
 
 export default async function ElectroEnduroPage({
   params,

--- a/app/franchize/[slug]/layout.tsx
+++ b/app/franchize/[slug]/layout.tsx
@@ -1,34 +1,22 @@
 import type { ReactNode } from "react";
 import type { Metadata } from "next";
 import { getFranchizeBySlug } from "../actions";
+import { resolveFranchizeSiteUrl, toAbsoluteFranchizeUrl } from "./metadata";
 
 interface FranchizeSlugLayoutProps {
   children: ReactNode;
   params: Promise<{ slug: string }>;
 }
 
-const DEFAULT_SITE_URL = "https://v0-car-test.vercel.app";
-
-function resolveSiteUrl() {
-  const raw = process.env.NEXT_PUBLIC_SITE_URL || process.env.VERCEL_PROJECT_PRODUCTION_URL || DEFAULT_SITE_URL;
-  return raw.startsWith("http://") || raw.startsWith("https://") ? raw : `https://${raw}`;
-}
-
-function toAbsoluteUrl(siteUrl: string, maybeRelativeUrl: string) {
-  if (!maybeRelativeUrl) return `${siteUrl}/icon0.svg`;
-  if (maybeRelativeUrl.startsWith("http://") || maybeRelativeUrl.startsWith("https://")) return maybeRelativeUrl;
-  return new URL(maybeRelativeUrl, siteUrl).toString();
-}
-
 export async function generateMetadata({ params }: Omit<FranchizeSlugLayoutProps, "children">): Promise<Metadata> {
   const { slug } = await params;
-  const siteUrl = resolveSiteUrl();
+  const siteUrl = resolveFranchizeSiteUrl();
 
   try {
     const { crew, items } = await getFranchizeBySlug(slug);
     const title = `${crew.header.brandName} | oneSitePls`;
     const description = crew.header.subtitle?.trim() || `Каталог, аренда и покупка техники экипажа ${crew.header.brandName}.`;
-    const image = toAbsoluteUrl(siteUrl, crew.header.logoUrl || items.find((item) => item.imageUrl)?.imageUrl || "/icon0.svg");
+    const image = toAbsoluteFranchizeUrl(siteUrl, crew.header.logoUrl || items.find((item) => item.imageUrl)?.imageUrl || "/icon0.svg");
     const path = `/franchize/${crew.slug || slug}`;
     const keywords = [
       crew.header.brandName,

--- a/app/franchize/[slug]/map-riders/page.tsx
+++ b/app/franchize/[slug]/map-riders/page.tsx
@@ -1,13 +1,25 @@
+import type { Metadata } from "next";
 import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import dynamic from "next/dynamic";
+import { buildFranchizeSectionMetadata } from "../metadata";
 
 const MapRidersClient = dynamic(
   () => import("@/app/franchize/components/MapRidersClient").then((mod) => mod.MapRidersClient),
   { ssr: false },
 );
+
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Карта райдеров",
+    sectionDescription: "Live-карта экипажа: райдеры рядом, meetup-точки, статусы поездки и безопасные сборы.",
+    pathSuffix: "/map-riders",
+  });
+}
 
 export default async function MapRidersPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;

--- a/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
+++ b/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getFranchizeBySlug } from "@/app/franchize/actions";
@@ -10,6 +11,7 @@ import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { SaleBikeLanding } from "@/app/franchize/components/SaleBikeLanding";
 import { isSameCatalogPropulsion } from "@/app/franchize/lib/catalog-propulsion";
 import { buildSaleBuySectionId } from "@/app/franchize/lib/sale-anchors";
+import { buildFranchizeSectionMetadata, findCatalogItemImage } from "../../../metadata";
 
 interface BuyBikePageProps {
   params: Promise<{ slug: string; bike_id: string }>;
@@ -21,6 +23,36 @@ const isSaleEnabled = (value: unknown) =>
   value === true ||
   String(value).toLowerCase() === "1" ||
   String(value).toLowerCase() === "true";
+
+
+export async function generateMetadata({ params }: BuyBikePageProps): Promise<Metadata> {
+  const { slug, bike_id } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: ({ items }) => {
+      const item = items.find((candidate) => candidate.id === bike_id);
+      return item ? `Покупка · ${item.title}` : "Покупка байка";
+    },
+    sectionDescription: ({ items }) => {
+      const item = items.find((candidate) => candidate.id === bike_id);
+      return item
+        ? `Покупка ${item.title}: характеристики, сравнение, тест-драйв и заявка экипажу.`
+        : "Страница покупки выбранного байка: характеристики, сравнение, тест-драйв и заявка экипажу.";
+    },
+    pathSuffix: `/market/${bike_id}/buy`,
+    ogTitle: ({ items, crew }) => {
+      const item = items.find((candidate) => candidate.id === bike_id);
+      return item ? `Купить ${item.title} · ${crew.header.brandName}` : "Покупка байка в экипаже oneSitePls";
+    },
+    ogDescription: ({ items }) => {
+      const item = items.find((candidate) => candidate.id === bike_id);
+      return item
+        ? `Открой карточку ${item.title}, сравни комплектацию и отправь заявку на покупку.`
+        : "Открой карточку выбранного байка, сравни комплектацию и отправь заявку на покупку.";
+    },
+    image: ({ items }) => findCatalogItemImage(items, bike_id),
+    imageAlt: ({ items, crew }) => items.find((item) => item.id === bike_id)?.title || `${crew.header.brandName} bike preview`,
+  });
+}
 
 export default async function BuyBikePage({
   params,

--- a/app/franchize/[slug]/metadata.ts
+++ b/app/franchize/[slug]/metadata.ts
@@ -1,54 +1,179 @@
 import type { Metadata } from "next";
-import { getFranchizeBySlug } from "../actions";
+import { getFranchizeBySlug, type CatalogItemVM, type FranchizeCrewVM } from "../actions";
+
+const DEFAULT_SITE_URL = "https://v0-car-test.vercel.app";
+const CREW_LOGO_FALLBACK = "/icon0.svg";
+
+type FranchizeMetadataContext = {
+  crew: FranchizeCrewVM;
+  items: CatalogItemVM[];
+  slug: string;
+  resolvedSlug: string;
+};
+
+type MetadataTextOption = string | ((context: FranchizeMetadataContext) => string | undefined | null);
+type SocialCard = "summary" | "summary_large_image";
 
 interface MetadataOptions {
-  sectionTitle: string;
-  sectionDescription: string;
+  sectionTitle: MetadataTextOption;
+  sectionDescription: MetadataTextOption;
   pathSuffix: string;
+  ogTitle?: MetadataTextOption;
+  ogDescription?: MetadataTextOption;
+  image?: string | ((context: FranchizeMetadataContext) => string | undefined | null);
+  imageAlt?: string | ((context: FranchizeMetadataContext) => string | undefined | null);
+  socialCard?: SocialCard;
+  twitterCard?: SocialCard;
+}
+
+export function resolveFranchizeSiteUrl() {
+  const raw = process.env.NEXT_PUBLIC_SITE_URL || process.env.VERCEL_PROJECT_PRODUCTION_URL || DEFAULT_SITE_URL;
+  return raw.startsWith("http://") || raw.startsWith("https://") ? raw : `https://${raw}`;
+}
+
+export function toAbsoluteFranchizeUrl(siteUrl: string, maybeRelativeUrl: string) {
+  if (!maybeRelativeUrl) return new URL(CREW_LOGO_FALLBACK, siteUrl).toString();
+  if (maybeRelativeUrl.startsWith("http://") || maybeRelativeUrl.startsWith("https://")) return maybeRelativeUrl;
+  return new URL(maybeRelativeUrl, siteUrl).toString();
+}
+
+function defaultCrewImage({ crew }: FranchizeMetadataContext) {
+  return crew.header.logoUrl || crew.logoUrl || CREW_LOGO_FALLBACK;
+}
+
+function resolveTextOption(option: MetadataTextOption, context: FranchizeMetadataContext) {
+  return (typeof option === "function" ? option(context) : option) || "Franchize";
+}
+
+function resolveOptionalTextOption(option: MetadataTextOption | undefined, context: FranchizeMetadataContext) {
+  if (!option) return undefined;
+  return typeof option === "function" ? option(context) || undefined : option;
+}
+
+function fallbackTextOption(option: MetadataTextOption, fallback: string) {
+  return typeof option === "string" ? option : fallback;
+}
+
+function buildVkMeta({
+  title,
+  description,
+  image,
+  url,
+}: {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+}) {
+  return {
+    "vk:title": title,
+    "vk:description": description,
+    "vk:image": image,
+    "vk:url": url,
+  };
+}
+
+function resolveRouteImage(context: FranchizeMetadataContext, options: MetadataOptions) {
+  if (typeof options.image === "function") return options.image(context) || defaultCrewImage(context);
+  return options.image || defaultCrewImage(context);
+}
+
+function resolveRouteImageAlt(context: FranchizeMetadataContext, options: MetadataOptions) {
+  if (typeof options.imageAlt === "function") return options.imageAlt(context) || `${context.crew.header.brandName} preview`;
+  return options.imageAlt || `${context.crew.header.brandName} preview`;
+}
+
+function buildMetadata({
+  title,
+  description,
+  canonicalPath,
+  ogTitle,
+  ogDescription,
+  image,
+  imageAlt,
+  socialCard = "summary_large_image",
+}: {
+  title: string;
+  description: string;
+  canonicalPath: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  image: string;
+  imageAlt: string;
+  socialCard?: SocialCard;
+}): Metadata {
+  const siteUrl = resolveFranchizeSiteUrl();
+  const absoluteImage = toAbsoluteFranchizeUrl(siteUrl, image);
+  const resolvedOgTitle = ogTitle || title;
+  const resolvedOgDescription = ogDescription || description;
+
+  return {
+    metadataBase: new URL(siteUrl),
+    title,
+    description,
+    alternates: { canonical: canonicalPath },
+    openGraph: {
+      siteName: "oneSitePls",
+      title: resolvedOgTitle,
+      description: resolvedOgDescription,
+      url: canonicalPath,
+      type: "website",
+      locale: "ru_RU",
+      images: [{ url: absoluteImage, alt: imageAlt }],
+    },
+    // Next.js exposes this bucket as `twitter`; Telegram/VK still receive OpenGraph plus VK hints below.
+    twitter: {
+      card: socialCard,
+      title: resolvedOgTitle,
+      description: resolvedOgDescription,
+      images: [absoluteImage],
+    },
+    other: buildVkMeta({
+      title: resolvedOgTitle,
+      description: resolvedOgDescription,
+      image: absoluteImage,
+      url: canonicalPath,
+    }),
+  };
 }
 
 export async function buildFranchizeSectionMetadata(slug: string, options: MetadataOptions): Promise<Metadata> {
   try {
-    const { crew } = await getFranchizeBySlug(slug);
+    const { crew, items } = await getFranchizeBySlug(slug);
     const resolvedSlug = crew.slug || slug;
-    const title = `${options.sectionTitle} · ${crew.header.brandName} | oneSitePls`;
-    const description = options.sectionDescription;
+    const context = { crew, items, slug, resolvedSlug };
+    const sectionTitle = resolveTextOption(options.sectionTitle, context);
+    const description = resolveTextOption(options.sectionDescription, context);
+    const title = `${sectionTitle} · ${crew.header.brandName} | oneSitePls`;
     const canonicalPath = `/franchize/${resolvedSlug}${options.pathSuffix}`;
 
-    return {
+    return buildMetadata({
       title,
       description,
-      alternates: { canonical: canonicalPath },
-      openGraph: {
-        title,
-        description,
-        url: canonicalPath,
-        type: "website",
-      },
-      twitter: {
-        card: "summary",
-        title,
-        description,
-      },
-    };
+      canonicalPath,
+      ogTitle: resolveOptionalTextOption(options.ogTitle, context) || title,
+      ogDescription: resolveOptionalTextOption(options.ogDescription, context) || description,
+      image: resolveRouteImage(context, options),
+      imageAlt: resolveRouteImageAlt(context, options),
+      socialCard: options.socialCard || options.twitterCard,
+    });
   } catch {
-    const fallbackTitle = `${options.sectionTitle} · Franchize ${slug} | oneSitePls`;
+    const fallbackTitle = `${fallbackTextOption(options.sectionTitle, "Franchize")} · Franchize ${slug} | oneSitePls`;
     const fallbackPath = `/franchize/${slug}${options.pathSuffix}`;
-    return {
+    return buildMetadata({
       title: fallbackTitle,
-      description: options.sectionDescription,
-      alternates: { canonical: fallbackPath },
-      openGraph: {
-        title: fallbackTitle,
-        description: options.sectionDescription,
-        url: fallbackPath,
-        type: "website",
-      },
-      twitter: {
-        card: "summary",
-        title: fallbackTitle,
-        description: options.sectionDescription,
-      },
-    };
+      description: fallbackTextOption(options.sectionDescription, `Витрина franchize ${slug}.`),
+      canonicalPath: fallbackPath,
+      ogTitle: fallbackTextOption(options.ogTitle || options.sectionTitle, fallbackTitle),
+      ogDescription: fallbackTextOption(options.ogDescription || options.sectionDescription, `Витрина franchize ${slug}.`),
+      image: CREW_LOGO_FALLBACK,
+      imageAlt: `Franchize ${slug} preview`,
+      socialCard: options.socialCard || options.twitterCard || "summary",
+    });
   }
+}
+
+export function findCatalogItemImage(items: CatalogItemVM[], itemId?: string) {
+  const item = itemId ? items.find((candidate) => candidate.id === itemId) : undefined;
+  return item?.imageUrl || item?.mediaUrls?.find(Boolean) || undefined;
 }

--- a/app/franchize/[slug]/order/[id]/page.tsx
+++ b/app/franchize/[slug]/order/[id]/page.tsx
@@ -1,12 +1,24 @@
+import type { Metadata } from "next";
 import { getFranchizeBySlug } from "../../../actions";
 import { CrewFooter } from "../../../components/CrewFooter";
 import { CrewHeader } from "../../../components/CrewHeader";
 import { FranchizeFloatingCart } from "../../../components/FranchizeFloatingCart";
 import { OrderPageClient } from "../../../components/OrderPageClient";
 import { crewPaletteForSurface } from "../../../lib/theme";
+import { buildFranchizeSectionMetadata } from "../../metadata";
 
 interface FranchizeOrderPageProps {
   params: Promise<{ slug: string; id: string }>;
+}
+
+
+export async function generateMetadata({ params }: FranchizeOrderPageProps): Promise<Metadata> {
+  const { slug, id } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Оформление заказа",
+    sectionDescription: "Оформление заказа экипажа: контакты, выбранная техника, условия аренды или покупки и следующий шаг оплаты.",
+    pathSuffix: `/order/${id}`,
+  });
 }
 
 export default async function FranchizeOrderPage({ params }: FranchizeOrderPageProps) {

--- a/app/franchize/[slug]/profile/ProfileClient.tsx
+++ b/app/franchize/[slug]/profile/ProfileClient.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import VibeContentRenderer from "@/components/VibeContentRenderer";
+import { useAppContext } from "@/contexts/AppContext";
+import {
+  getFranchizeCapabilityContractAction,
+  getFranchizeProfileBySlugAction,
+  grantFranchizeAchievementAction,
+  type FranchizeAchievementDefinition,
+  type FranchizeProfileState,
+  type FranchizeActivityDigest,
+  type FranchizeFormPrefill,
+  getFranchizeActivityDigestAction,
+  getFranchizeFormPrefillAction,
+  saveFranchizeFormPrefillAction,
+} from "@/app/franchize/profile-actions";
+
+export function FranchizeProfileClient() {
+  const { dbUser } = useAppContext();
+  const params = useParams<{ slug: string }>();
+  const slug = params?.slug || "vip-bike";
+  const [catalog, setCatalog] = useState<FranchizeAchievementDefinition[]>([]);
+  const [profile, setProfile] = useState<FranchizeProfileState | null>(null);
+  const [capabilityContract, setCapabilityContract] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [digest, setDigest] = useState<FranchizeActivityDigest | null>(null);
+  const [prefill, setPrefill] = useState<FranchizeFormPrefill>({ fullName: "", phone: "", preferredTime: "", deliveryMode: "pickup", comment: "" });
+
+  useEffect(() => {
+    const run = async () => {
+      if (!dbUser?.user_id) return;
+      const result = await getFranchizeProfileBySlugAction({ slug, userId: dbUser.user_id });
+      if (!result.success || !result.data) {
+        setError(result.error || "Не удалось загрузить франшизный профиль.");
+        return;
+      }
+      setProfile(result.data);
+      setCatalog(result.catalog || []);
+      const capabilities = await getFranchizeCapabilityContractAction();
+      setCapabilityContract(capabilities);
+      const [digestRes, prefillRes] = await Promise.all([
+        getFranchizeActivityDigestAction({ slug, userId: dbUser.user_id }),
+        getFranchizeFormPrefillAction({ slug, userId: dbUser.user_id }),
+      ]);
+      if (digestRes.success && digestRes.data) setDigest(digestRes.data);
+      if (prefillRes.success && prefillRes.data) setPrefill(prefillRes.data);
+      await grantFranchizeAchievementAction({
+        slug,
+        userId: dbUser.user_id,
+        achievementId: "franchize_profile_opened",
+        source: "web:franchize_profile",
+        context: { path: `/franchize/${slug}/profile` },
+        incrementCounters: { profileOpenCount: 1 },
+      });
+    };
+    run();
+  }, [dbUser?.user_id, slug]);
+
+  const unlockedSet = useMemo(() => new Set(Object.keys(profile?.achievements || {})), [profile?.achievements]);
+  const unlockedCount = catalog.filter((item) => unlockedSet.has(item.id)).length;
+  const handlePrefillSave = async () => {
+    if (!dbUser?.user_id) return;
+    const res = await saveFranchizeFormPrefillAction({ slug, userId: dbUser.user_id, prefill });
+    if (!res.success) setError(res.error || "Не удалось сохранить поля.");
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-dark-bg via-black to-dark-card text-light-text p-4 pb-16">
+      <div className="container mx-auto max-w-4xl space-y-4">
+        <Card className="border-brand-cyan/40 bg-dark-card/80">
+          <CardHeader>
+            <CardTitle className="font-orbitron text-brand-cyan flex items-center gap-2">
+              <VibeContentRenderer content="::FaIdBadge::" /> Franchize Identity — {profile?.crewName || slug}
+            </CardTitle>
+            <CardDescription className="font-mono text-xs">
+              Персональная страница достижений франшизы: slug-фильтр, capability-треки и интеграционные триггеры.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <div className="rounded-lg border border-brand-green/30 bg-black/20 p-3">
+              <p className="font-orbitron text-brand-green text-sm">Разблокировано</p>
+              <p className="font-mono text-xs text-muted-foreground mt-1">{unlockedCount}/{catalog.length} достижений для slug `{slug}`</p>
+            </div>
+            <div className="rounded-lg border border-brand-purple/30 bg-black/20 p-3">
+              <p className="font-orbitron text-brand-purple text-sm">Счётчики</p>
+              <p className="font-mono text-xs text-muted-foreground mt-1">Открытий профиля: {profile?.counters?.profileOpenCount || 0}</p>
+            </div>
+            <div className="rounded-lg border border-brand-yellow/30 bg-black/20 p-3">
+              <p className="font-orbitron text-brand-yellow text-sm">Последняя активность</p>
+              <p className="font-mono text-xs text-muted-foreground mt-1">{profile?.lastActivityAt || "—"}</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-brand-pink/30 bg-dark-card/70">
+          <CardHeader>
+            <CardTitle className="font-orbitron text-brand-pink flex items-center gap-2">
+              <VibeContentRenderer content="::FaUserSecret::" /> Достижения франшизы (filtered by slug)
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {catalog.map((achievement) => {
+              const unlocked = unlockedSet.has(achievement.id);
+              return (
+                <div key={achievement.id} className={`rounded-lg border bg-black/20 p-3 ${unlocked ? "border-brand-green/40" : "border-brand-pink/20"}`}>
+                  <p className={`font-orbitron text-sm ${unlocked ? "text-brand-green" : "text-brand-pink"}`}>{achievement.title}</p>
+                  <p className="font-mono text-xs text-muted-foreground mt-1">{achievement.description}</p>
+                  <p className="font-mono text-2xs text-brand-yellow mt-1">Источник: {achievement.triggerSources.join(", ")}</p>
+                  <p className="font-mono text-2xs mt-1">{unlocked ? "✅ Разблокировано" : "🔒 Заблокировано"}</p>
+                </div>
+              );
+            })}
+            {!!error && <p className="text-xs font-mono text-red-400">{error}</p>}
+          </CardContent>
+        </Card>
+
+        <Card className="border-brand-cyan/20 bg-dark-card/60">
+          <CardHeader>
+            <CardTitle className="font-orbitron text-brand-cyan text-base">Capability contract (для интеграций)</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            {Object.entries(capabilityContract).map(([key, value]) => (
+              <p key={key} className="font-mono text-xs text-muted-foreground">
+                <span className="text-brand-cyan">{key}:</span> {value}
+              </p>
+            ))}
+          </CardContent>
+        </Card>
+        <Card className="border-brand-green/30 bg-dark-card/70">
+          <CardHeader><CardTitle className="font-orbitron text-brand-green text-base">Префилл данных для аренды/покупки</CardTitle></CardHeader>
+          <CardContent className="grid grid-cols-1 gap-2 md:grid-cols-2">
+            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="ФИО" value={prefill.fullName} onChange={(e) => setPrefill((p) => ({ ...p, fullName: e.target.value }))} />
+            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="Телефон" value={prefill.phone} onChange={(e) => setPrefill((p) => ({ ...p, phone: e.target.value }))} />
+            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="Удобное время" value={prefill.preferredTime} onChange={(e) => setPrefill((p) => ({ ...p, preferredTime: e.target.value }))} />
+            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="Комментарий по умолчанию" value={prefill.comment} onChange={(e) => setPrefill((p) => ({ ...p, comment: e.target.value }))} />
+            <Button className="md:col-span-2" onClick={handlePrefillSave}>Сохранить профильные поля</Button>
+          </CardContent>
+        </Card>
+        <Card className="border-brand-yellow/30 bg-dark-card/70">
+          <CardHeader><CardTitle className="font-orbitron text-brand-yellow text-base">Аренды и покупки</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-xs text-muted-foreground">Текущие аренды</p>
+            {(digest?.rentals || []).slice(0, 5).map((r) => (
+              <Link key={r.rentalId} href={r.docLink} className="block rounded border p-2 text-sm">
+                <span className="font-semibold">{r.vehicleLabel}</span> · <span className="opacity-80">{r.status}</span>
+              </Link>
+            ))}
+            <p className="pt-2 text-xs text-muted-foreground">Планируемые покупки (sale)</p>
+            {(digest?.buyOrders || []).slice(0, 5).map((o) => (
+              <Link key={o.orderId} href={o.docLink} className="block rounded border p-2 text-sm">
+                Заказ #{o.orderId} · {o.status} · {o.vehicleIds.join(", ")}
+                {o.docFileName ? <span className="mt-1 block text-xs text-muted-foreground">Документ: {o.docFileName}</span> : null}
+              </Link>
+            ))}
+          </CardContent>
+        </Card>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <Button asChild className="bg-brand-cyan text-black hover:bg-brand-cyan/80 font-orbitron">
+            <Link href={`/franchize/${slug}/map-riders`}>
+              Открыть Map Riders
+            </Link>
+          </Button>
+          <Button asChild variant="outline" className="border-brand-yellow text-brand-yellow hover:bg-brand-yellow/10">
+            <Link href="/profile">
+              Вернуться в главный профиль
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/franchize/[slug]/profile/page.tsx
+++ b/app/franchize/[slug]/profile/page.tsx
@@ -1,178 +1,20 @@
-"use client";
+import type { Metadata } from "next";
+import { buildFranchizeSectionMetadata } from "../metadata";
+import { FranchizeProfileClient } from "./ProfileClient";
 
-import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import VibeContentRenderer from "@/components/VibeContentRenderer";
-import { useAppContext } from "@/contexts/AppContext";
-import {
-  getFranchizeCapabilityContractAction,
-  getFranchizeProfileBySlugAction,
-  grantFranchizeAchievementAction,
-  type FranchizeAchievementDefinition,
-  type FranchizeProfileState,
-  type FranchizeActivityDigest,
-  type FranchizeFormPrefill,
-  getFranchizeActivityDigestAction,
-  getFranchizeFormPrefillAction,
-  saveFranchizeFormPrefillAction,
-} from "@/app/franchize/profile-actions";
+interface FranchizeProfilePageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: FranchizeProfilePageProps): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Профиль райдера",
+    sectionDescription: "Персональный профиль франшизы: достижения, активность, сохранённые данные и быстрые переходы к арендам.",
+    pathSuffix: "/profile",
+  });
+}
 
 export default function FranchizeProfilePage() {
-  const { dbUser } = useAppContext();
-  const params = useParams<{ slug: string }>();
-  const slug = params?.slug || "vip-bike";
-  const [catalog, setCatalog] = useState<FranchizeAchievementDefinition[]>([]);
-  const [profile, setProfile] = useState<FranchizeProfileState | null>(null);
-  const [capabilityContract, setCapabilityContract] = useState<Record<string, string>>({});
-  const [error, setError] = useState<string | null>(null);
-  const [digest, setDigest] = useState<FranchizeActivityDigest | null>(null);
-  const [prefill, setPrefill] = useState<FranchizeFormPrefill>({ fullName: "", phone: "", preferredTime: "", deliveryMode: "pickup", comment: "" });
-
-  useEffect(() => {
-    const run = async () => {
-      if (!dbUser?.user_id) return;
-      const result = await getFranchizeProfileBySlugAction({ slug, userId: dbUser.user_id });
-      if (!result.success || !result.data) {
-        setError(result.error || "Не удалось загрузить франшизный профиль.");
-        return;
-      }
-      setProfile(result.data);
-      setCatalog(result.catalog || []);
-      const capabilities = await getFranchizeCapabilityContractAction();
-      setCapabilityContract(capabilities);
-      const [digestRes, prefillRes] = await Promise.all([
-        getFranchizeActivityDigestAction({ slug, userId: dbUser.user_id }),
-        getFranchizeFormPrefillAction({ slug, userId: dbUser.user_id }),
-      ]);
-      if (digestRes.success && digestRes.data) setDigest(digestRes.data);
-      if (prefillRes.success && prefillRes.data) setPrefill(prefillRes.data);
-      await grantFranchizeAchievementAction({
-        slug,
-        userId: dbUser.user_id,
-        achievementId: "franchize_profile_opened",
-        source: "web:franchize_profile",
-        context: { path: `/franchize/${slug}/profile` },
-        incrementCounters: { profileOpenCount: 1 },
-      });
-    };
-    run();
-  }, [dbUser?.user_id, slug]);
-
-  const unlockedSet = useMemo(() => new Set(Object.keys(profile?.achievements || {})), [profile?.achievements]);
-  const unlockedCount = catalog.filter((item) => unlockedSet.has(item.id)).length;
-  const handlePrefillSave = async () => {
-    if (!dbUser?.user_id) return;
-    const res = await saveFranchizeFormPrefillAction({ slug, userId: dbUser.user_id, prefill });
-    if (!res.success) setError(res.error || "Не удалось сохранить поля.");
-  };
-
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-dark-bg via-black to-dark-card text-light-text p-4 pb-16">
-      <div className="container mx-auto max-w-4xl space-y-4">
-        <Card className="border-brand-cyan/40 bg-dark-card/80">
-          <CardHeader>
-            <CardTitle className="font-orbitron text-brand-cyan flex items-center gap-2">
-              <VibeContentRenderer content="::FaIdBadge::" /> Franchize Identity — {profile?.crewName || slug}
-            </CardTitle>
-            <CardDescription className="font-mono text-xs">
-              Персональная страница достижений франшизы: slug-фильтр, capability-треки и интеграционные триггеры.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <div className="rounded-lg border border-brand-green/30 bg-black/20 p-3">
-              <p className="font-orbitron text-brand-green text-sm">Разблокировано</p>
-              <p className="font-mono text-xs text-muted-foreground mt-1">{unlockedCount}/{catalog.length} достижений для slug `{slug}`</p>
-            </div>
-            <div className="rounded-lg border border-brand-purple/30 bg-black/20 p-3">
-              <p className="font-orbitron text-brand-purple text-sm">Счётчики</p>
-              <p className="font-mono text-xs text-muted-foreground mt-1">Открытий профиля: {profile?.counters?.profileOpenCount || 0}</p>
-            </div>
-            <div className="rounded-lg border border-brand-yellow/30 bg-black/20 p-3">
-              <p className="font-orbitron text-brand-yellow text-sm">Последняя активность</p>
-              <p className="font-mono text-xs text-muted-foreground mt-1">{profile?.lastActivityAt || "—"}</p>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="border-brand-pink/30 bg-dark-card/70">
-          <CardHeader>
-            <CardTitle className="font-orbitron text-brand-pink flex items-center gap-2">
-              <VibeContentRenderer content="::FaUserSecret::" /> Достижения франшизы (filtered by slug)
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            {catalog.map((achievement) => {
-              const unlocked = unlockedSet.has(achievement.id);
-              return (
-                <div key={achievement.id} className={`rounded-lg border bg-black/20 p-3 ${unlocked ? "border-brand-green/40" : "border-brand-pink/20"}`}>
-                  <p className={`font-orbitron text-sm ${unlocked ? "text-brand-green" : "text-brand-pink"}`}>{achievement.title}</p>
-                  <p className="font-mono text-xs text-muted-foreground mt-1">{achievement.description}</p>
-                  <p className="font-mono text-2xs text-brand-yellow mt-1">Источник: {achievement.triggerSources.join(", ")}</p>
-                  <p className="font-mono text-2xs mt-1">{unlocked ? "✅ Разблокировано" : "🔒 Заблокировано"}</p>
-                </div>
-              );
-            })}
-            {!!error && <p className="text-xs font-mono text-red-400">{error}</p>}
-          </CardContent>
-        </Card>
-
-        <Card className="border-brand-cyan/20 bg-dark-card/60">
-          <CardHeader>
-            <CardTitle className="font-orbitron text-brand-cyan text-base">Capability contract (для интеграций)</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-1">
-            {Object.entries(capabilityContract).map(([key, value]) => (
-              <p key={key} className="font-mono text-xs text-muted-foreground">
-                <span className="text-brand-cyan">{key}:</span> {value}
-              </p>
-            ))}
-          </CardContent>
-        </Card>
-        <Card className="border-brand-green/30 bg-dark-card/70">
-          <CardHeader><CardTitle className="font-orbitron text-brand-green text-base">Префилл данных для аренды/покупки</CardTitle></CardHeader>
-          <CardContent className="grid grid-cols-1 gap-2 md:grid-cols-2">
-            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="ФИО" value={prefill.fullName} onChange={(e) => setPrefill((p) => ({ ...p, fullName: e.target.value }))} />
-            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="Телефон" value={prefill.phone} onChange={(e) => setPrefill((p) => ({ ...p, phone: e.target.value }))} />
-            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="Удобное время" value={prefill.preferredTime} onChange={(e) => setPrefill((p) => ({ ...p, preferredTime: e.target.value }))} />
-            <input className="rounded border bg-black/20 p-2 text-sm" placeholder="Комментарий по умолчанию" value={prefill.comment} onChange={(e) => setPrefill((p) => ({ ...p, comment: e.target.value }))} />
-            <Button className="md:col-span-2" onClick={handlePrefillSave}>Сохранить профильные поля</Button>
-          </CardContent>
-        </Card>
-        <Card className="border-brand-yellow/30 bg-dark-card/70">
-          <CardHeader><CardTitle className="font-orbitron text-brand-yellow text-base">Аренды и покупки</CardTitle></CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-xs text-muted-foreground">Текущие аренды</p>
-            {(digest?.rentals || []).slice(0, 5).map((r) => (
-              <Link key={r.rentalId} href={r.docLink} className="block rounded border p-2 text-sm">
-                <span className="font-semibold">{r.vehicleLabel}</span> · <span className="opacity-80">{r.status}</span>
-              </Link>
-            ))}
-            <p className="pt-2 text-xs text-muted-foreground">Планируемые покупки (sale)</p>
-            {(digest?.buyOrders || []).slice(0, 5).map((o) => (
-              <Link key={o.orderId} href={o.docLink} className="block rounded border p-2 text-sm">
-                Заказ #{o.orderId} · {o.status} · {o.vehicleIds.join(", ")}
-                {o.docFileName ? <span className="mt-1 block text-xs text-muted-foreground">Документ: {o.docFileName}</span> : null}
-              </Link>
-            ))}
-          </CardContent>
-        </Card>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <Button asChild className="bg-brand-cyan text-black hover:bg-brand-cyan/80 font-orbitron">
-            <Link href={`/franchize/${slug}/map-riders`}>
-              Открыть Map Riders
-            </Link>
-          </Button>
-          <Button asChild variant="outline" className="border-brand-yellow text-brand-yellow hover:bg-brand-yellow/10">
-            <Link href="/profile">
-              Вернуться в главный профиль
-            </Link>
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
+  return <FranchizeProfileClient />;
 }

--- a/app/franchize/[slug]/rental/[id]/page.tsx
+++ b/app/franchize/[slug]/rental/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { ExternalLink, Info, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { getFranchizeBySlug, getFranchizeRentalCard } from "../../../actions";
@@ -8,6 +9,7 @@ import { FranchizeHero } from "../../../components/FranchizeHero";
 import { FranchizePageShell } from "../../../components/FranchizePageShell";
 import { FranchizeRentalDocumentsPanel } from "../../../components/FranchizeRentalDocumentsPanel";
 import { crewPaletteForSurface } from "../../../lib/theme";
+import { buildFranchizeSectionMetadata } from "../../metadata";
 
 interface FranchizeRentalPageProps {
   params: Promise<{ slug: string; id: string }>;
@@ -20,6 +22,16 @@ const statusLabel: Record<string, string> = {
   completed: "Завершена",
   cancelled: "Отменена",
 };
+
+
+export async function generateMetadata({ params }: FranchizeRentalPageProps): Promise<Metadata> {
+  const { slug, id } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Карточка аренды",
+    sectionDescription: "Карточка аренды экипажа: статус сделки, документы, проверка контракта и дальнейшие действия.",
+    pathSuffix: `/rental/${id}`,
+  });
+}
 
 export default async function FranchizeRentalPage({ params }: FranchizeRentalPageProps) {
   const { slug, id } = await params;

--- a/app/franchize/[slug]/review/[rentalId]/page.tsx
+++ b/app/franchize/[slug]/review/[rentalId]/page.tsx
@@ -1,11 +1,23 @@
+import type { Metadata } from "next";
 import { getFranchizeBySlug, getRentalReviewContext } from "../../../actions";
 import { CrewHeader } from "../../../components/CrewHeader";
 import { CrewFooter } from "../../../components/CrewFooter";
 import { crewPaletteForSurface } from "../../../lib/theme";
 import { ReviewForm } from "./ReviewForm";
+import { buildFranchizeSectionMetadata } from "../../metadata";
 
 interface RentalReviewPageProps {
   params: Promise<{ slug: string; rentalId: string }>;
+}
+
+
+export async function generateMetadata({ params }: RentalReviewPageProps): Promise<Metadata> {
+  const { slug, rentalId } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Отзыв об аренде",
+    sectionDescription: "Страница отзыва после аренды: оценка байка, впечатления райдера и обратная связь экипажу.",
+    pathSuffix: `/review/${rentalId}`,
+  });
 }
 
 export default async function RentalReviewPage({ params }: RentalReviewPageProps) {

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -68,6 +68,16 @@ This root file stays intentionally compact so operators and agents can load it q
 - `next_step`: Visual-smoke `/franchize/vip-bike/about`, `/contacts`, `/rentals`, a rental card, and a sale-buy route in a browser-capable environment; next polish task should focus route-specific metadata coverage.
 - `risks`: Local screenshot capture remains blocked by missing Playwright host libraries; curl smoke reached the about route after fallback crew loading.
 
+
+### 2026-05-07 — Franchize route metadata coverage
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-07T00:00:00Z
+- `owner`: codex
+- `notes`: Added route-specific `generateMetadata` coverage for franchize community, electro-enduro, configurator, cart, profile, admin, MapRiders, sale-buy, order, rental, and review routes via the shared `[slug]/metadata.ts` helper with canonical paths, OpenGraph/Twitter-compatible social cards, VK meta hints, and route-aware item imagery when available; self-review tightened sale-buy title/description to include the selected bike when hydrated.
+- `next_step`: Production-smoke `/franchize/vip-bike/community`, `/electro-enduro`, `/configurator`, `/cart`, `/profile`, `/admin`, `/map-riders`, and one dynamic buy/order/rental/review route to confirm crawlers/VK/Telegram receive expected tags.
+- `risks`: Dynamic order/rental/review metadata intentionally uses crew/logo fallback imagery unless the page has an item-specific image source in route params or hydrated catalog data.
+
 ## 3) Active ad-hoc task — `/vipbikerental` interactive landing
 
 - status: `ready_for_pr`


### PR DESCRIPTION
### Motivation
- Provide consistent, route-aware metadata for franchize pages so crawlers and social cards receive canonical, localized OpenGraph/Twitter/VK tags and route-specific images where available.
- Centralize site URL and image resolution logic to avoid duplicated URL handling across franchize routes.
- Move the franchize profile UI to a dedicated client component to simplify the server page and enable richer client-side behavior.

### Description
- Introduced `app/franchize/[slug]/metadata.ts` with `buildFranchizeSectionMetadata`, `resolveFranchizeSiteUrl`, `toAbsoluteFranchizeUrl`, and helpers for resolving text, images, OpenGraph/Twitter/VK fields, and `findCatalogItemImage` for item-specific imagery.
- Added `generateMetadata` implementations to multiple franchize routes including `admin`, `cart`, `community`, `configurator`, `electro-enduro`, `map-riders`, dynamic `market/[bike_id]/buy`, `order/[id]`, `rental/[id]`, `review/[rentalId]`, and `profile` to emit route-aware metadata via the shared helper.
- Updated franchize `layout.tsx` to use `resolveFranchizeSiteUrl` and `toAbsoluteFranchizeUrl` for canonical/base URLs and image resolution.
- Enhanced sale-buy metadata to include item-aware `sectionTitle`, `sectionDescription`, `ogTitle`, `ogDescription`, and item image selection via `findCatalogItemImage` when `bike_id` is present.
- Split the profile page into a client component by adding `ProfileClient.tsx` and replaced the previous server-side implementation to render `FranchizeProfileClient` from `page.tsx`.
- Minor documentation update in `docs/THE_FRANCHEEZEPLAN.md` documenting the new metadata coverage.

### Testing
- Performed a TypeScript build of the codebase to validate types and imports, which completed successfully.
- Ran the existing unit test suite with `vitest`, and all tests passed locally.
- Manually inspected a few routes in dev mode to ensure `generateMetadata` returns without runtime errors for hydrated and fallback crews.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd059a4904832490797e742818e8bb)