### PR TITLE
Add franchize intent section links and integrate into CrewHeader rail

### DIFF
--- a/app/franchize/[slug]/about/page.tsx
+++ b/app/franchize/[slug]/about/page.tsx
@@ -5,6 +5,7 @@ import { CrewHeader } from "../../components/CrewHeader";
 import { FranchizeFloatingCart } from "../../components/FranchizeFloatingCart";
 import { FranchizeHero } from "../../components/FranchizeHero";
 import { FranchizePageShell } from "../../components/FranchizePageShell";
+import { buildFranchizeIntentLinks } from "../../lib/section-links";
 import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
@@ -26,10 +27,11 @@ export default async function FranchizeAboutPage({ params }: FranchizeAboutPageP
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
   const resolvedSlug = crew.slug || slug;
+  const activePath = `/franchize/${resolvedSlug}/about`;
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${resolvedSlug}/about`} groupLinks={items.map((item) => item.category)} />
+      <CrewHeader crew={crew} activePath={activePath} groupLinks={items.map((item) => item.category)} sectionLinks={buildFranchizeIntentLinks(resolvedSlug, activePath)} />
       <FranchizePageShell theme={crew.theme}>
         <FranchizeHero
           eyebrow={`/franchize/${resolvedSlug}/about · экипаж`}

--- a/app/franchize/[slug]/community/page.tsx
+++ b/app/franchize/[slug]/community/page.tsx
@@ -4,6 +4,7 @@ import { CalendarDays, Handshake, MapPinned, ShieldCheck, UsersRound } from "luc
 import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
+import { buildFranchizeIntentLinks } from "@/app/franchize/lib/section-links";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
@@ -55,13 +56,14 @@ export default async function FranchizeCommunityPage({ params }: { params: Promi
   const { slug } = await params;
   const { crew } = await getFranchizeBySlug(slug);
   const crewSlug = crew.slug || slug;
+  const activePath = `/franchize/${crewSlug}/community`;
   const surface = crewPaletteForSurface(crew.theme);
   const brandName = crew.header.brandName || crew.name || "VIP BIKE";
   const telegramHref = crew.contacts.telegram ? `https://t.me/${crew.contacts.telegram.replace("@", "")}` : "https://t.me/oneBikePlsBot";
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${crewSlug}/community`} />
+      <CrewHeader crew={crew} activePath={activePath} sectionLinks={buildFranchizeIntentLinks(crewSlug, activePath)} />
 
       <div
         className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-16 pt-20 text-white md:pt-24"

--- a/app/franchize/[slug]/contacts/page.tsx
+++ b/app/franchize/[slug]/contacts/page.tsx
@@ -6,6 +6,7 @@ import { FranchizeFloatingCart } from "../../components/FranchizeFloatingCart";
 import { FranchizeHero } from "../../components/FranchizeHero";
 import { FranchizePageShell } from "../../components/FranchizePageShell";
 import { FranchizeContactsMap } from "../../components/FranchizeContactsMap";
+import { buildFranchizeIntentLinks } from "../../lib/section-links";
 import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
@@ -27,6 +28,7 @@ export default async function FranchizeContactsPage({ params }: FranchizeContact
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
   const resolvedSlug = crew.slug || slug;
+  const activePath = `/franchize/${resolvedSlug}/contacts`;
   const telegramHref = crew.contacts.telegram
     ? crew.contacts.telegram.startsWith("http")
       ? crew.contacts.telegram
@@ -35,7 +37,7 @@ export default async function FranchizeContactsPage({ params }: FranchizeContact
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${resolvedSlug}/contacts`} groupLinks={items.map((item) => item.category)} />
+      <CrewHeader crew={crew} activePath={activePath} groupLinks={items.map((item) => item.category)} sectionLinks={buildFranchizeIntentLinks(resolvedSlug, activePath)} />
 
       <FranchizePageShell theme={crew.theme}>
         <FranchizeHero

--- a/app/franchize/[slug]/map-riders/page.tsx
+++ b/app/franchize/[slug]/map-riders/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
+import { buildFranchizeIntentLinks } from "@/app/franchize/lib/section-links";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import dynamic from "next/dynamic";
 import { buildFranchizeSectionMetadata } from "../metadata";
@@ -24,12 +25,14 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 export default async function MapRidersPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const { crew } = await getFranchizeBySlug(slug);
+  const crewSlug = crew.slug || slug;
+  const activePath = `/franchize/${crewSlug}/map-riders`;
   const surface = crewPaletteForSurface(crew.theme);
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/map-riders`} />
-      <MapRidersClient crew={crew} slug={crew.slug || slug} />
+      <CrewHeader crew={crew} activePath={activePath} sectionLinks={buildFranchizeIntentLinks(crewSlug, activePath)} />
+      <MapRidersClient crew={crew} slug={crewSlug} />
       <CrewFooter crew={crew} />
     </main>
   );

--- a/app/franchize/[slug]/onboarding/page.tsx
+++ b/app/franchize/[slug]/onboarding/page.tsx
@@ -4,6 +4,7 @@ import { CheckCircle2, ClipboardCheck, FileText, Handshake, MessageCircle, Shiel
 import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
+import { buildFranchizeIntentLinks } from "@/app/franchize/lib/section-links";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
@@ -55,13 +56,14 @@ export default async function PartnerOnboardingPage({ params }: PartnerOnboardin
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const crewSlug = crew.slug || slug;
+  const activePath = `/franchize/${crewSlug}/onboarding`;
   const surface = crewPaletteForSurface(crew.theme);
   const brandName = crew.header.brandName || crew.name || "VIP BIKE";
   const telegramHref = crew.contacts.telegram ? `https://t.me/${crew.contacts.telegram.replace("@", "")}` : "https://t.me/oneBikePlsBot";
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${crewSlug}/onboarding`} groupLinks={items.map((item) => item.category)} />
+      <CrewHeader crew={crew} activePath={activePath} groupLinks={items.map((item) => item.category)} sectionLinks={buildFranchizeIntentLinks(crewSlug, activePath)} />
       <div
         className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-16 pt-20 md:pt-24"
         style={{

--- a/app/franchize/[slug]/rentals/page.tsx
+++ b/app/franchize/[slug]/rentals/page.tsx
@@ -6,6 +6,7 @@ import { FranchizeHero } from "../../components/FranchizeHero";
 import { FranchizePageShell } from "../../components/FranchizePageShell";
 import { FranchizeRentalsBridge } from "../../components/FranchizeRentalsBridge";
 import { FranchizeErrorBoundary } from "../../components/ErrorBoundary";
+import { buildFranchizeIntentLinks } from "../../lib/section-links";
 import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
@@ -26,11 +27,12 @@ export default async function FranchizeRentalsPage({ params }: FranchizeRentalsP
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const resolvedSlug = crew.slug || slug;
+  const activePath = `/franchize/${resolvedSlug}/rentals`;
   const surface = crewPaletteForSurface(crew.theme);
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${resolvedSlug}/rentals`} groupLinks={items.map((item) => item.category)} />
+      <CrewHeader crew={crew} activePath={activePath} groupLinks={items.map((item) => item.category)} sectionLinks={buildFranchizeIntentLinks(resolvedSlug, activePath)} />
       <FranchizePageShell theme={crew.theme} contentClassName="space-y-6">
         <FranchizeHero
           eyebrow={`/franchize/${resolvedSlug}/rentals · control-center`}

--- a/app/franchize/[slug]/sales/page.tsx
+++ b/app/franchize/[slug]/sales/page.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, BatteryCharging, Bike, ClipboardList, RefreshCcw, Sparkles 
 import { getFranchizeBySlug, type CatalogItemVM } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
+import { buildFranchizeIntentLinks } from "@/app/franchize/lib/section-links";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
@@ -71,13 +72,14 @@ export default async function FranchizeSalesPage({ params }: SalesPageProps) {
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const crewSlug = crew.slug || slug;
+  const activePath = `/franchize/${crewSlug}/sales`;
   const surface = crewPaletteForSurface(crew.theme);
   const brandName = crew.header.brandName || crew.name || "VIP BIKE";
   const saleItems = items.filter((item) => item.saleAvailable || Number(item.salePrice || 0) > 0 || isTruthySpec(item.rawSpecs?.sale));
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${crewSlug}/sales`} groupLinks={items.map((item) => item.category)} />
+      <CrewHeader crew={crew} activePath={activePath} groupLinks={items.map((item) => item.category)} sectionLinks={buildFranchizeIntentLinks(crewSlug, activePath)} />
       <div
         className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-16 pt-20 md:pt-24"
         style={{

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -10,14 +10,16 @@ import type { FranchizeCrewVM } from "../actions";
 import { HeaderMenu } from "../modals/HeaderMenu";
 import { FranchizeProfileButton } from "./FranchizeProfileButton";
 import { toCategoryId } from "../lib/navigation";
+import type { FranchizeSectionLink } from "../lib/section-links";
 
 interface CrewHeaderProps {
   crew: FranchizeCrewVM;
   activePath: string;
   groupLinks?: string[];
+  sectionLinks?: FranchizeSectionLink[];
 }
 
-export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProps) {
+export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [] }: CrewHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [catalogLinks, setCatalogLinks] = useState<string[]>([]);
@@ -46,9 +48,25 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
   );
 
   const visibleRailLinks = useMemo(() => {
-    if (pathname === mainCatalogPath && catalogLinks.length > 0) return catalogLinks;
-    return defaultGroupLinks;
-  }, [catalogLinks, defaultGroupLinks, mainCatalogPath, pathname]);
+    if (pathname === mainCatalogPath && catalogLinks.length > 0) {
+      return catalogLinks.map((label) => ({ label, href: `#${toCategoryId(label)}`, active: activeCategory === label, categoryLabel: label }));
+    }
+
+    if (pathname !== mainCatalogPath && sectionLinks.length > 0) {
+      const normalizedSectionLinks = sectionLinks
+        .filter((link) => link.label.trim() && link.href.trim())
+        .map((link) => ({ ...link, categoryLabel: link.label }));
+
+      if (normalizedSectionLinks.length > 0) return normalizedSectionLinks;
+    }
+
+    return defaultGroupLinks.map((label) => ({
+      label,
+      href: pathname === mainCatalogPath ? `#${toCategoryId(label)}` : `${mainCatalogPath}#${toCategoryId(label)}`,
+      active: activeCategory === label,
+      categoryLabel: label,
+    }));
+  }, [activeCategory, catalogLinks, defaultGroupLinks, mainCatalogPath, pathname, sectionLinks]);
 
   // --- FIXED: Hysteresis Scroll Listener ---
   useEffect(() => {
@@ -120,23 +138,26 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
 
   // --- NEW: Плавный скролл активного бейджа (pill) в центр экрана ---
   useEffect(() => {
-    if (activeCategory && railRef.current) {
-      // Экранируем кавычки на случай нестандартных названий категорий
-      const safeCategory = activeCategory.replace(/"/g, '\\"');
-      const activeEl = railRef.current.querySelector(`[data-category-pill="${safeCategory}"]`) as HTMLElement;
-      
-      if (activeEl) {
-        const container = railRef.current;
-        // Вычисляем нужный сдвиг (позиция элемента относительно контейнера - половина контейнера + половина элемента)
-        const scrollLeft = activeEl.offsetLeft - container.clientWidth / 2 + activeEl.clientWidth / 2;
-        
-        container.scrollTo({
-          left: scrollLeft,
-          behavior: "smooth",
-        });
-      }
+    const activeRailLink = visibleRailLinks.find(
+      (link) => link.active || (!link.href.startsWith("#") && (pathname === link.href || activePath === link.href)),
+    );
+    if (!activeRailLink || !railRef.current) return;
+
+    const activeEl = Array.from(railRef.current.querySelectorAll<HTMLElement>("[data-category-pill]")).find(
+      (element) => element.dataset.categoryPill === activeRailLink.categoryLabel,
+    );
+
+    if (activeEl) {
+      const container = railRef.current;
+      // Вычисляем нужный сдвиг (позиция элемента относительно контейнера - половина контейнера + половина элемента)
+      const scrollLeft = activeEl.offsetLeft - container.clientWidth / 2 + activeEl.clientWidth / 2;
+
+      container.scrollTo({
+        left: scrollLeft,
+        behavior: "smooth",
+      });
     }
-  }, [activeCategory]);
+  }, [activePath, pathname, visibleRailLinks]);
   // ------------------------------------------------------------------
 
   return (
@@ -228,24 +249,22 @@ export function CrewHeader({ crew, activePath, groupLinks = [] }: CrewHeaderProp
             ref={railRef}
             className="relative mx-auto flex w-full max-w-7xl gap-2 overflow-x-auto no-scrollbar pb-1 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden snap-x snap-mandatory"
           >
-            {visibleRailLinks.map((linkLabel) => {
-              const targetId = toCategoryId(linkLabel);
-              const href = pathname === mainCatalogPath ? `#${targetId}` : `${mainCatalogPath}#${targetId}`;
-              const isActive = activeCategory === linkLabel;
+            {visibleRailLinks.map((link) => {
+              const isActive = link.active || (!link.href.startsWith("#") && (pathname === link.href || activePath === link.href));
               return (
                 <Link
-                  key={linkLabel}
-                  href={href}
-                  data-category-pill={linkLabel}
+                  key={`${link.label}-${link.href}`}
+                  href={link.href}
+                  data-category-pill={link.categoryLabel}
                   aria-current={isActive ? "location" : undefined}
-                  aria-label={`Перейти к разделу ${linkLabel}`}
+                  aria-label={`Перейти к разделу ${link.label}`}
                   className="shrink-0 snap-start rounded-full bg-[var(--pill-bg)] px-4 py-2 text-xs font-medium tracking-wide text-[var(--pill-text)] transition-colors pointer-events-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
                   style={{
                     ["--pill-bg" as string]: isActive ? crew.theme.palette.accentMain : crew.theme.palette.bgCard,
                     ["--pill-text" as string]: isActive ? "#000000" : crew.theme.palette.textPrimary,
                   }}
                 >
-                  {linkLabel}
+                  {link.label}
                 </Link>
               );
             })}

--- a/app/franchize/lib/section-links.ts
+++ b/app/franchize/lib/section-links.ts
@@ -1,0 +1,29 @@
+export interface FranchizeSectionLink {
+  label: string;
+  href: string;
+  active?: boolean;
+}
+
+const FRANCHIZE_INTENT_LINKS: Array<{ label: string; path: string }> = [
+  { label: "Каталог", path: "" },
+  { label: "Продажи", path: "/sales" },
+  { label: "Аренды", path: "/rentals" },
+  { label: "Карта", path: "/map-riders" },
+  { label: "Сообщество", path: "/community" },
+  { label: "Партнёрам", path: "/onboarding" },
+  { label: "О нас", path: "/about" },
+  { label: "Контакты", path: "/contacts" },
+];
+
+export function buildFranchizeIntentLinks(slug: string, activePath: string): FranchizeSectionLink[] {
+  const basePath = `/franchize/${slug}`;
+
+  return FRANCHIZE_INTENT_LINKS.map((link) => {
+    const href = `${basePath}${link.path}`;
+    return {
+      label: link.label,
+      href,
+      active: activePath === href,
+    };
+  });
+}

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -49,6 +49,15 @@ This root file stays intentionally compact so operators and agents can load it q
 
 - 2026-05-04 — Added support for metadata-driven franchize header logo routing via `header.logoHref` with default fallback to `/franchize/{slug}`; seeded `vip-bike` to land on `/vipbikerental` instead of catalog. Next step: expose `header.logoHref` in admin configurator UI for non-SQL operators.
 
+### 2026-05-07 — Franchize intent rail navigation
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-07T00:00:00Z
+- `owner`: codex
+- `notes`: Added optional CrewHeader section intent links for non-catalog franchize routes while preserving catalog category rail behavior and SPA Next.js Link navigation. Applied shared intent rails to about, contacts, sales, onboarding, community, MapRiders, and rentals.
+- `next_step`: Visual-smoke `/franchize/vip-bike/about`, `/contacts`, `/sales`, `/onboarding`, `/community`, `/map-riders`, and `/rentals` on mobile width to confirm active pill visibility/touch comfort.
+- `risks`: Runtime screenshot not captured in this non-browser code pass; route hydration still depends on crew/catalog data availability.
+
 ### 2026-05-07 — VS same-propulsion micropolish
 
 - `status`: ready_for_pr


### PR DESCRIPTION
### Motivation

- Provide a consistent intent-driven rail for franchize subroutes (about, contacts, sales, rentals, map-riders, community, onboarding) so non-catalog pages can show a navigable header pill strip with active state.
- Preserve existing catalog category behavior while enabling section-level links and improving touch/scroll UX for mobile.

### Description

- Added a new helper `buildFranchizeIntentLinks` and `FranchizeSectionLink` in `app/franchize/lib/section-links.ts` that builds canonical section links for a franchise slug and marks the active item based on `activePath`.
- Updated multiple franchize pages (`about`, `community`, `contacts`, `map-riders`, `onboarding`, `rentals`, `sales`) to compute an `activePath` and supply `sectionLinks={buildFranchizeIntentLinks(...)}` to `CrewHeader` where appropriate.
- Extended `CrewHeader` to accept an optional `sectionLinks` prop, normalize rail entries into a unified `visibleRailLinks` shape, render mixed section/categor y pills, and update the smooth-scroll and active-pill detection logic to account for section links and SPA navigation.
- Added an entry documenting the change in `docs/THE_FRANCHEEZEPLAN.md` under the progress diary.

### Testing

- Ran TypeScript type checking with `tsc --noEmit` which completed successfully.
- Performed a production build with `next build` that succeeded without build-time errors.
- Ran linting (`eslint`) as part of the preflight checks which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0b1f191c83249e633b2025544aba)