### PR TITLE
Redesign franchize contacts page; add CopyAddressButton and improved contact links

### DIFF
--- a/app/franchize/[slug]/contacts/page.tsx
+++ b/app/franchize/[slug]/contacts/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
+import { MapPinned, MessageCircle, Navigation, Phone, ShieldCheck, Star } from "lucide-react";
 import { getFranchizeBySlug } from "../../actions";
 import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
+import { CopyAddressButton } from "../../components/CopyAddressButton";
 import { FranchizeFloatingCart } from "../../components/FranchizeFloatingCart";
 import { FranchizeHero } from "../../components/FranchizeHero";
 import { FranchizePageShell } from "../../components/FranchizePageShell";
@@ -29,11 +31,23 @@ export default async function FranchizeContactsPage({ params }: FranchizeContact
   const surface = crewPaletteForSurface(crew.theme);
   const resolvedSlug = crew.slug || slug;
   const activePath = `/franchize/${resolvedSlug}/contacts`;
-  const telegramHref = crew.contacts.telegram
+  const supportTelegramHref = "https://t.me/oneBikePlsBot";
+  const hasTelegram = Boolean(crew.contacts.telegram);
+  const telegramHref = hasTelegram
     ? crew.contacts.telegram.startsWith("http")
       ? crew.contacts.telegram
       : `https://t.me/${crew.contacts.telegram.replace(/^@/, "")}`
-    : `/franchize/${resolvedSlug}`;
+    : supportTelegramHref;
+  const primaryContactCta = hasTelegram
+    ? { label: "Написать в Telegram", href: telegramHref }
+    : { label: "Поддержка OneBikePls", href: supportTelegramHref };
+  const phoneHref = crew.contacts.phone ? `tel:${crew.contacts.phone.replace(/[^+\d]/g, "")}` : "";
+  const gps = crew.contacts.map.gps.trim();
+  const hasGps = /^-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?$/.test(gps);
+  const directionsTarget = hasGps ? gps : crew.contacts.address;
+  const directionsHref = directionsTarget
+    ? `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(directionsTarget)}`
+    : "";
 
   return (
     <main className="min-h-screen" style={surface.page}>
@@ -44,27 +58,121 @@ export default async function FranchizeContactsPage({ params }: FranchizeContact
           eyebrow={`/franchize/${resolvedSlug}/contacts · связь`}
           title="Контакты экипажа"
           subcopy="Быстрый операторский блок для связи, маршрута и проверки точки выдачи перед арендой или покупкой."
-          primaryCta={{ label: "Написать в Telegram", href: telegramHref }}
+          primaryCta={primaryContactCta}
           secondaryCta={{ label: "Открыть каталог", href: `/franchize/${resolvedSlug}` }}
         />
 
-        <div className="mt-6 rounded-2xl border p-4" style={surface.subtleCard}>
-          <div className="space-y-2 text-sm" style={surface.mutedText}>
-            <p>Адрес: {crew.contacts.address || "—"}</p>
-            <p>Телефон: {crew.contacts.phone || "—"}</p>
-            <p>Telegram: {crew.contacts.telegram || "—"}</p>
-            {crew.contacts.workingHours && <p>Часы работы: {crew.contacts.workingHours}</p>}
-          </div>
-          {crew.ratingSummary.count > 0 && (
-            <div className="mt-4 rounded-2xl border px-3 py-2 text-sm" style={surface.card}>
-              <span className="font-bold" style={{ color: crew.theme.palette.accentMain }}>★ {crew.ratingSummary.average.toFixed(1)}</span>
-              <span style={surface.mutedText}> · рейтинг экипажа по {crew.ratingSummary.count} отзывам</span>
-            </div>
-          )}
+        <section
+          className="mt-6 rounded-2xl border p-4 shadow-lg shadow-black/10"
+          style={{
+            ...surface.subtleCard,
+            ["--crew-accent" as string]: crew.theme.palette.accentMain,
+            ["--crew-accent-hover" as string]: crew.theme.palette.accentMainHover,
+            ["--crew-accent-contrast" as string]: "var(--franchize-shell-primary-contrast)",
+            ["--crew-border" as string]: crew.theme.palette.borderSoft,
+            ["--crew-card" as string]: crew.theme.palette.bgCard,
+            ["--crew-muted" as string]: crew.theme.palette.textSecondary,
+            ["--crew-text" as string]: crew.theme.palette.textPrimary,
+          }}
+        >
+          <div className="grid gap-4 lg:grid-cols-[1.4fr_0.8fr]">
+            <div>
+              <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-[var(--crew-accent)]">
+                <ShieldCheck className="h-4 w-4" />
+                Связь без лишних шагов
+              </div>
+              <h2 className="mt-3 text-2xl font-bold text-[var(--crew-text)]">Выберите быстрый канал</h2>
+              <p className="mt-2 max-w-2xl text-sm text-[var(--crew-muted)]">
+                Telegram — основной канал экипажа, телефон и маршрут помогают быстро подтвердить выдачу перед поездкой.
+              </p>
 
-          {crew.contacts.map.publicTransport && <p className="mt-3 text-xs" style={surface.mutedText}>Транспорт: {crew.contacts.map.publicTransport}</p>}
-          {crew.contacts.map.carDirections && <p className="mt-1 text-xs" style={surface.mutedText}>Как добраться: {crew.contacts.map.carDirections}</p>}
-        </div>
+              {crew.contacts.workingHours && (
+                <p className="mt-3 inline-flex rounded-full border border-[var(--crew-border)] bg-[var(--crew-card)] px-3 py-1 text-xs font-semibold text-[var(--crew-text)]">
+                  Open now / график: {crew.contacts.workingHours}
+                </p>
+              )}
+
+              <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                {hasTelegram ? (
+                  <a
+                    href={telegramHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[var(--crew-accent)] px-4 py-2 text-sm font-bold text-[var(--crew-accent-contrast)] transition hover:bg-[var(--crew-accent-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--crew-accent)]"
+                  >
+                    <MessageCircle className="h-4 w-4" />
+                    Написать в Telegram
+                  </a>
+                ) : (
+                  <a
+                    href={supportTelegramHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[var(--crew-accent)] px-4 py-2 text-sm font-bold text-[var(--crew-accent-contrast)] transition hover:bg-[var(--crew-accent-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--crew-accent)]"
+                  >
+                    <MessageCircle className="h-4 w-4" />
+                    Поддержка OneBikePls
+                  </a>
+                )}
+
+                {crew.contacts.phone && (
+                  <a
+                    href={phoneHref}
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-[var(--crew-border)] px-4 py-2 text-sm font-semibold text-[var(--crew-text)] transition hover:border-[var(--crew-accent)] hover:text-[var(--crew-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--crew-accent)]"
+                  >
+                    <Phone className="h-4 w-4" />
+                    Позвонить
+                  </a>
+                )}
+
+                {crew.contacts.address && <CopyAddressButton address={crew.contacts.address} />}
+
+                {directionsHref && (
+                  <a
+                    href={directionsHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-[var(--crew-border)] px-4 py-2 text-sm font-semibold text-[var(--crew-text)] transition hover:border-[var(--crew-accent)] hover:text-[var(--crew-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--crew-accent)]"
+                  >
+                    <Navigation className="h-4 w-4" />
+                    {hasGps ? "Маршрут по GPS" : "Маршрут по адресу"}
+                  </a>
+                )}
+              </div>
+            </div>
+
+            {crew.ratingSummary.count > 0 && (
+              <aside className="rounded-2xl border border-[var(--crew-border)] bg-[var(--crew-card)] p-4">
+                <div className="flex items-center gap-2 text-[var(--crew-accent)]">
+                  <Star className="h-5 w-5 fill-current" />
+                  <span className="text-3xl font-black">{crew.ratingSummary.average.toFixed(1)}</span>
+                </div>
+                <p className="mt-2 text-sm font-semibold text-[var(--crew-text)]">Проверенный экипаж</p>
+                <p className="mt-1 text-sm text-[var(--crew-muted)]">
+                  Рейтинг сформирован по {crew.ratingSummary.count} отзывам после аренд и сделок.
+                </p>
+              </aside>
+            )}
+          </div>
+
+          <dl className="mt-5 grid gap-3 text-sm md:grid-cols-3">
+            <div className="rounded-xl border border-[var(--crew-border)] bg-[var(--crew-card)] p-3">
+              <dt className="flex items-center gap-2 font-semibold text-[var(--crew-text)]"><MapPinned className="h-4 w-4" /> Адрес</dt>
+              <dd className="mt-1 text-[var(--crew-muted)]">{crew.contacts.address || "Адрес скоро добавим"}</dd>
+            </div>
+            <div className="rounded-xl border border-[var(--crew-border)] bg-[var(--crew-card)] p-3">
+              <dt className="flex items-center gap-2 font-semibold text-[var(--crew-text)]"><Phone className="h-4 w-4" /> Телефон</dt>
+              <dd className="mt-1 text-[var(--crew-muted)]">{crew.contacts.phone || "Телефон скоро добавим"}</dd>
+            </div>
+            <div className="rounded-xl border border-[var(--crew-border)] bg-[var(--crew-card)] p-3">
+              <dt className="flex items-center gap-2 font-semibold text-[var(--crew-text)]"><MessageCircle className="h-4 w-4" /> Telegram</dt>
+              <dd className="mt-1 text-[var(--crew-muted)]">{crew.contacts.telegram || "Используйте поддержку OneBikePls"}</dd>
+            </div>
+          </dl>
+
+          {crew.contacts.map.publicTransport && <p className="mt-3 text-xs text-[var(--crew-muted)]">Транспорт: {crew.contacts.map.publicTransport}</p>}
+          {crew.contacts.map.carDirections && <p className="mt-1 text-xs text-[var(--crew-muted)]">Как добраться: {crew.contacts.map.carDirections}</p>}
+        </section>
 
         <div className="mt-4">
           <FranchizeContactsMap

--- a/app/franchize/components/CopyAddressButton.tsx
+++ b/app/franchize/components/CopyAddressButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy, TriangleAlert } from "lucide-react";
+
+interface CopyAddressButtonProps {
+  address: string;
+}
+
+type CopyStatus = "idle" | "copied" | "error";
+
+function copyWithTextareaFallback(text: string) {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export function CopyAddressButton({ address }: CopyAddressButtonProps) {
+  const [status, setStatus] = useState<CopyStatus>("idle");
+
+  const handleCopy = async () => {
+    if (!address) {
+      return;
+    }
+
+    const clipboard = navigator.clipboard;
+    const copied = await Promise.resolve(
+      clipboard
+        ? clipboard.writeText(address).then(() => true, () => copyWithTextareaFallback(address))
+        : copyWithTextareaFallback(address),
+    ).catch(() => false);
+
+    setStatus(copied ? "copied" : "error");
+    window.setTimeout(() => setStatus("idle"), 1800);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-[var(--crew-border)] px-4 py-2 text-sm font-semibold text-[var(--crew-text)] transition hover:border-[var(--crew-accent)] hover:text-[var(--crew-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--crew-accent)]"
+      aria-live="polite"
+    >
+      {status === "copied" ? <Check className="h-4 w-4" /> : null}
+      {status === "error" ? <TriangleAlert className="h-4 w-4" /> : null}
+      {status === "idle" ? <Copy className="h-4 w-4" /> : null}
+      {status === "copied" ? "Адрес скопирован" : null}
+      {status === "error" ? "Скопируйте вручную" : null}
+      {status === "idle" ? "Скопировать адрес" : null}
+    </button>
+  );
+}


### PR DESCRIPTION
### Motivation
- Improve the contacts UI to provide clearer, faster contact actions (Telegram, phone, directions) and better fallbacks when data is missing.
- Add a client-side copy-to-clipboard control for the crew address to streamline sharing the pickup point.

### Description
- Reworked `app/franchize/[slug]/contacts/page.tsx` to replace the simple contact card with a richer `section` including action buttons, rating summary, and structured details, and switched `FranchizeHero` to use a computed primary CTA (`primaryContactCta`).
- Added robust contact link handling: compute `hasTelegram`, fall back to a OneBikePls support Telegram (`supportTelegramHref`), normalize `phoneHref`, validate `gps` coordinates, and build `directionsHref` that targets GPS or address accordingly.
- Introduced new client component `app/franchize/components/CopyAddressButton.tsx` that copies the address to clipboard with a `navigator.clipboard` attempt and a textarea fallback, exposing visual feedback states (`idle`, `copied`, `error`).
- Small UI and theming improvements: consistent CSS variables from the crew theme, icons from `lucide-react`, accessible focus/outlines, a rating aside, and enhanced layout for contact actions and details.

### Testing
- Performed a local type-check/build pass (`tsc` / Next build) which completed without errors.
- No automated unit/integration tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0ec12a3c83249efb17a6ded48da3)