### PR TITLE
Add pluggable franchize content blocks and integrate into community/onboarding/sales pages

### DIFF
--- a/app/franchize/[slug]/community/page.tsx
+++ b/app/franchize/[slug]/community/page.tsx
@@ -8,39 +8,6 @@ import { buildFranchizeIntentLinks } from "@/app/franchize/lib/section-links";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
-const cityEvents = [
-  {
-    title: "Вечерний сбор новичков",
-    time: "Пт • 19:30",
-    place: "Старт у базы экипажа",
-    text: "Короткий городской круг, проверка экипировки, объяснение жестов и правил колонны.",
-  },
-  {
-    title: "MapRiders city loop",
-    time: "Сб • 12:00",
-    place: "Маршрут через набережную и тихие улицы",
-    text: "Открываем live-карту, ставим meetup-пины и едем в темпе самого спокойного райдера.",
-  },
-  {
-    title: "Техно-час перед покатушкой",
-    time: "Вс • 11:00",
-    place: "Партнёрская сервис-зона",
-    text: "Давление, цепь, свет, тормоза и быстрый чек арендного или личного байка.",
-  },
-];
-
-const partnerCards = [
-  { name: "VIP BIKE сервис", role: "осмотр и подготовка", perk: "Экспресс-чек перед выездом для экипажа" },
-  { name: "Кофе-точка райдеров", role: "место встречи", perk: "Тёплый старт, зарядка телефона, быстрый брифинг" },
-  { name: "Экипировка рядом", role: "перчатки / дождевик / защита", perk: "Помощь новичку без лишнего пафоса" },
-];
-
-const cityTips = [
-  "Не стартуй один, если это первый выезд на незнакомом байке.",
-  "Включай MapRiders до старта: экипаж увидит скорость, stale-статус и точку встречи.",
-  "Для новичков держим видимость «только экипаж» и автостоп геошеринга.",
-  "Meetup-пин ставим long-press на карте или тапом по точке + кнопка «+».",
-];
 
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
@@ -60,6 +27,7 @@ export default async function FranchizeCommunityPage({ params }: { params: Promi
   const surface = crewPaletteForSurface(crew.theme);
   const brandName = crew.header.brandName || crew.name || "VIP BIKE";
   const telegramHref = crew.contacts.telegram ? `https://t.me/${crew.contacts.telegram.replace("@", "")}` : "https://t.me/oneBikePlsBot";
+  const { communityEvents, partnerCards, cityRiderTips } = crew.contentBlocks;
 
   return (
     <main className="min-h-screen" style={surface.page}>
@@ -108,7 +76,7 @@ export default async function FranchizeCommunityPage({ params }: { params: Promi
         </section>
 
         <section className="grid gap-4 md:grid-cols-3">
-          {cityEvents.map((event) => (
+          {communityEvents.map((event) => (
             <article key={event.title} className="rounded-3xl border border-white/10 bg-white/[0.04] p-5 backdrop-blur-xl">
               <CalendarDays className="h-6 w-6 text-[var(--community-accent)]" />
               <p className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-white/45">{event.time}</p>
@@ -126,10 +94,10 @@ export default async function FranchizeCommunityPage({ params }: { params: Promi
               <h2 className="font-orbitron text-2xl text-white">Городской riding-гайд</h2>
             </div>
             <ul className="mt-5 space-y-3 text-sm text-white/68">
-              {cityTips.map((tip) => (
-                <li key={tip} className="flex gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-3">
+              {cityRiderTips.map((tip) => (
+                <li key={tip.text} className="flex gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-3">
                   <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-[var(--community-accent)]" />
-                  <span>{tip}</span>
+                  <span>{tip.text}</span>
                 </li>
               ))}
             </ul>

--- a/app/franchize/[slug]/onboarding/page.tsx
+++ b/app/franchize/[slug]/onboarding/page.tsx
@@ -12,36 +12,23 @@ interface PartnerOnboardingPageProps {
   params: Promise<{ slug: string }>;
 }
 
-const checklist = [
-  {
-    title: "Заявка и контакт",
-    text: "Фиксируем Telegram/телефон, город, формат партнёрства и ожидаемый объём байков.",
-    icon: MessageCircle,
-  },
-  {
-    title: "Парк и роли",
-    text: "Описываем модели, статусы аренды/продажи, ответственных за выдачу, сервис и контент.",
-    icon: ClipboardCheck,
-  },
-  {
-    title: "Документы и правила",
-    text: "Согласуем договор, депозит, чеклист выдачи, ограничения по району и страховочные сценарии.",
-    icon: FileText,
-  },
-  {
-    title: "Пилотный запуск",
-    text: "Включаем витрину, тестовый заказ, MapRiders-сценарий и короткий smoke-check в Telegram WebApp.",
-    icon: ShieldCheck,
-  },
-];
+const checklistIcons = [MessageCircle, ClipboardCheck, FileText, ShieldCheck] as const;
 
-const readinessRows = [
-  ["Брендинг", "лого, цвета, оффер, адрес и рабочие часы"],
-  ["Каталог", "аренда, продажа, электробайки, аксессуары"],
-  ["Операции", "выдача, возврат, сервис, админ-доступы"],
-  ["Продажи", "новые/электро/б/у/trade-in лиды и тест-драйв"],
-  ["Комьюнити", "MapRiders, события, партнёры и Telegram-канал"],
-];
+const checklistIconByName = {
+  "message-circle": MessageCircle,
+  "clipboard-check": ClipboardCheck,
+  "file-text": FileText,
+  "shield-check": ShieldCheck,
+} as const;
+
+function getChecklistIcon(iconName: string | undefined, index: number) {
+  if (iconName && iconName in checklistIconByName) {
+    return checklistIconByName[iconName as keyof typeof checklistIconByName];
+  }
+
+  return checklistIcons[index % checklistIcons.length];
+}
+
 
 export async function generateMetadata({ params }: PartnerOnboardingPageProps): Promise<Metadata> {
   const { slug } = await params;
@@ -60,6 +47,7 @@ export default async function PartnerOnboardingPage({ params }: PartnerOnboardin
   const surface = crewPaletteForSurface(crew.theme);
   const brandName = crew.header.brandName || crew.name || "VIP BIKE";
   const telegramHref = crew.contacts.telegram ? `https://t.me/${crew.contacts.telegram.replace("@", "")}` : "https://t.me/oneBikePlsBot";
+  const { onboardingChecklist, onboardingReadinessRows } = crew.contentBlocks;
 
   return (
     <main className="min-h-screen" style={surface.page}>
@@ -96,10 +84,10 @@ export default async function PartnerOnboardingPage({ params }: PartnerOnboardin
                 <span className="text-sm font-semibold uppercase tracking-[0.16em]">Definition of ready</span>
               </div>
               <ul className="mt-4 space-y-3 text-sm opacity-75">
-                {readinessRows.map(([label, text]) => (
-                  <li key={label} className="grid gap-1 rounded-2xl border border-current/10 bg-white/[0.03] p-3">
-                    <span className="font-semibold opacity-100">{label}</span>
-                    <span>{text}</span>
+                {onboardingReadinessRows.map((row) => (
+                  <li key={row.label} className="grid gap-1 rounded-2xl border border-current/10 bg-white/[0.03] p-3">
+                    <span className="font-semibold opacity-100">{row.label}</span>
+                    <span>{row.text}</span>
                   </li>
                 ))}
               </ul>
@@ -108,8 +96,8 @@ export default async function PartnerOnboardingPage({ params }: PartnerOnboardin
         </section>
 
         <section className="grid gap-4 md:grid-cols-2">
-          {checklist.map((item, index) => {
-            const Icon = item.icon;
+          {onboardingChecklist.map((item, index) => {
+            const Icon = getChecklistIcon(item.icon, index);
             return (
               <article key={item.title} className="rounded-3xl border border-[var(--onboarding-border)] bg-[var(--onboarding-card)] p-5">
                 <div className="flex items-center justify-between gap-3">

--- a/app/franchize/[slug]/sales/page.tsx
+++ b/app/franchize/[slug]/sales/page.tsx
@@ -12,36 +12,6 @@ interface SalesPageProps {
   params: Promise<{ slug: string }>;
 }
 
-const verticals = [
-  {
-    id: "new",
-    title: "Новые байки",
-    icon: Sparkles,
-    pitch: "Витрина для моделей под заказ, предпродажного расчёта и тест-драйва.",
-    cta: "Заявка на новый",
-  },
-  {
-    id: "electric",
-    title: "Electro / custom",
-    icon: BatteryCharging,
-    pitch: "Электро-эндуро, батареи, мощность, подвеска и сборка под райдера.",
-    cta: "Собрать электро",
-  },
-  {
-    id: "used",
-    title: "Б/у и проверенные",
-    icon: Bike,
-    pitch: "Лиды на технику с историей аренды, диагностикой и прозрачным состоянием.",
-    cta: "Подобрать б/у",
-  },
-  {
-    id: "trade-in",
-    title: "Trade-in",
-    icon: RefreshCcw,
-    pitch: "Быстрый вход для оценки старого байка и обмена на аренду, новый или электро.",
-    cta: "Оценить байк",
-  },
-];
 
 const isTruthySpec = (value: unknown) => value === true || value === 1 || String(value).toLowerCase() === "true" || String(value).toLowerCase() === "1";
 
@@ -57,6 +27,17 @@ function itemMatchesVertical(item: CatalogItemVM, verticalId: string): boolean {
 function previewItems(items: CatalogItemVM[], verticalId: string): CatalogItemVM[] {
   const matches = items.filter((item) => itemMatchesVertical(item, verticalId));
   return (matches.length ? matches : items.filter((item) => item.saleAvailable)).slice(0, 3);
+}
+
+const verticalIconById = {
+  new: Sparkles,
+  electric: BatteryCharging,
+  used: Bike,
+  "trade-in": RefreshCcw,
+} as const;
+
+function getVerticalIcon(verticalId: string) {
+  return verticalIconById[verticalId as keyof typeof verticalIconById] ?? Sparkles;
 }
 
 export async function generateMetadata({ params }: SalesPageProps): Promise<Metadata> {
@@ -76,6 +57,7 @@ export default async function FranchizeSalesPage({ params }: SalesPageProps) {
   const surface = crewPaletteForSurface(crew.theme);
   const brandName = crew.header.brandName || crew.name || "VIP BIKE";
   const saleItems = items.filter((item) => item.saleAvailable || Number(item.salePrice || 0) > 0 || isTruthySpec(item.rawSpecs?.sale));
+  const salesVerticals = crew.contentBlocks.salesVerticals;
 
   return (
     <main className="min-h-screen" style={surface.page}>
@@ -118,7 +100,7 @@ export default async function FranchizeSalesPage({ params }: SalesPageProps) {
                 </div>
                 <div className="rounded-2xl border border-current/10 bg-white/[0.03] p-3">
                   <dt className="opacity-55">Вертикалей</dt>
-                  <dd className="mt-1 text-2xl font-semibold text-[var(--sales-accent)]">4</dd>
+                  <dd className="mt-1 text-2xl font-semibold text-[var(--sales-accent)]">{salesVerticals.length}</dd>
                 </div>
               </dl>
             </aside>
@@ -126,8 +108,8 @@ export default async function FranchizeSalesPage({ params }: SalesPageProps) {
         </section>
 
         <section className="grid gap-4 md:grid-cols-2">
-          {verticals.map((vertical) => {
-            const Icon = vertical.icon;
+          {salesVerticals.map((vertical) => {
+            const Icon = getVerticalIcon(vertical.id);
             const previews = previewItems(items, vertical.id);
             return (
               <article key={vertical.id} className="rounded-3xl border border-[var(--sales-border)] bg-[var(--sales-card)] p-5">

--- a/app/franchize/actions-runtime.ts
+++ b/app/franchize/actions-runtime.ts
@@ -9,6 +9,7 @@ import { readFile } from "fs/promises";
 import path from "path";
 import { getCrewSensitiveData, getUserSensitiveData, saveCrewSensitiveData } from "@/app/lib/private-secrets";
 import { buildFranchizeDocxFromTemplate } from "@/app/franchize/lib/docx-capability";
+import { cloneFranchizeContentBlocks, readFranchizeContentBlocks, type FranchizeContentBlocks } from "@/app/franchize/lib/content-blocks";
 import { resolveFranchizeTheme, resolvePaletteByMode } from "@/app/franchize/lib/theme-resolver";
 import { isTrustedTelegramBypassDeployment } from "@/lib/telegram-bypass-context";
 import { computeTelegramWebAppHash } from "@/lib/telegram-webapp-auth";
@@ -145,6 +146,7 @@ export interface FranchizeCrewVM {
     socialLinks: Array<{ label: string; href: string }>;
     textColor: string;
   };
+  contentBlocks: FranchizeContentBlocks;
 }
 
 export interface FranchizeBySlugResult {
@@ -520,6 +522,7 @@ const emptyCrew = (slug: string): FranchizeCrewVM => ({
     socialLinks: [],
     textColor: "#16130A",
   },
+  contentBlocks: cloneFranchizeContentBlocks(),
 });
 
 export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugResult> {
@@ -726,6 +729,7 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
         socialLinks: extractFooterSocialLinks(franchize, readPath(franchize, ["contacts", "telegram"], "")),
         textColor: readPath(franchize, ["footer", "textColor"], DEFAULT_FOOTER_TEXT_COLOR),
       },
+      contentBlocks: readFranchizeContentBlocks(franchize),
     };
 
     const items: CatalogItemVM[] = (cars ?? []).map((car) => {

--- a/app/franchize/lib/content-blocks.ts
+++ b/app/franchize/lib/content-blocks.ts
@@ -1,0 +1,298 @@
+export interface CommunityEventBlock {
+  title: string;
+  time: string;
+  place: string;
+  text: string;
+}
+
+export interface PartnerCardBlock {
+  name: string;
+  role: string;
+  perk: string;
+}
+
+export interface CityRiderTipBlock {
+  text: string;
+}
+
+export interface SalesVerticalCopyBlock {
+  id: string;
+  title: string;
+  pitch: string;
+  cta: string;
+}
+
+export interface OnboardingChecklistBlock {
+  title: string;
+  text: string;
+  icon?: string;
+}
+
+export interface OnboardingReadinessRowBlock {
+  label: string;
+  text: string;
+}
+
+export interface FranchizeContentBlocks {
+  communityEvents: CommunityEventBlock[];
+  partnerCards: PartnerCardBlock[];
+  cityRiderTips: CityRiderTipBlock[];
+  salesVerticals: SalesVerticalCopyBlock[];
+  onboardingChecklist: OnboardingChecklistBlock[];
+  onboardingReadinessRows: OnboardingReadinessRowBlock[];
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+export const DEFAULT_COMMUNITY_EVENTS: CommunityEventBlock[] = [
+  {
+    title: "Вечерний сбор новичков",
+    time: "Пт • 19:30",
+    place: "Старт у базы экипажа",
+    text: "Короткий городской круг, проверка экипировки, объяснение жестов и правил колонны.",
+  },
+  {
+    title: "MapRiders city loop",
+    time: "Сб • 12:00",
+    place: "Маршрут через набережную и тихие улицы",
+    text: "Открываем live-карту, ставим meetup-пины и едем в темпе самого спокойного райдера.",
+  },
+  {
+    title: "Техно-час перед покатушкой",
+    time: "Вс • 11:00",
+    place: "Партнёрская сервис-зона",
+    text: "Давление, цепь, свет, тормоза и быстрый чек арендного или личного байка.",
+  },
+];
+
+export const DEFAULT_PARTNER_CARDS: PartnerCardBlock[] = [
+  { name: "VIP BIKE сервис", role: "осмотр и подготовка", perk: "Экспресс-чек перед выездом для экипажа" },
+  { name: "Кофе-точка райдеров", role: "место встречи", perk: "Тёплый старт, зарядка телефона, быстрый брифинг" },
+  { name: "Экипировка рядом", role: "перчатки / дождевик / защита", perk: "Помощь новичку без лишнего пафоса" },
+];
+
+export const DEFAULT_CITY_RIDER_TIPS: CityRiderTipBlock[] = [
+  { text: "Не стартуй один, если это первый выезд на незнакомом байке." },
+  { text: "Включай MapRiders до старта: экипаж увидит скорость, stale-статус и точку встречи." },
+  { text: "Для новичков держим видимость «только экипаж» и автостоп геошеринга." },
+  { text: "Meetup-пин ставим long-press на карте или тапом по точке + кнопка «+»." },
+];
+
+export const DEFAULT_SALES_VERTICALS: SalesVerticalCopyBlock[] = [
+  {
+    id: "new",
+    title: "Новые байки",
+    pitch: "Витрина для моделей под заказ, предпродажного расчёта и тест-драйва.",
+    cta: "Заявка на новый",
+  },
+  {
+    id: "electric",
+    title: "Electro / custom",
+    pitch: "Электро-эндуро, батареи, мощность, подвеска и сборка под райдера.",
+    cta: "Собрать электро",
+  },
+  {
+    id: "used",
+    title: "Б/у и проверенные",
+    pitch: "Лиды на технику с историей аренды, диагностикой и прозрачным состоянием.",
+    cta: "Подобрать б/у",
+  },
+  {
+    id: "trade-in",
+    title: "Trade-in",
+    pitch: "Быстрый вход для оценки старого байка и обмена на аренду, новый или электро.",
+    cta: "Оценить байк",
+  },
+];
+
+export const DEFAULT_ONBOARDING_CHECKLIST: OnboardingChecklistBlock[] = [
+  {
+    title: "Заявка и контакт",
+    text: "Фиксируем Telegram/телефон, город, формат партнёрства и ожидаемый объём байков.",
+    icon: "message-circle",
+  },
+  {
+    title: "Парк и роли",
+    text: "Описываем модели, статусы аренды/продажи, ответственных за выдачу, сервис и контент.",
+    icon: "clipboard-check",
+  },
+  {
+    title: "Документы и правила",
+    text: "Согласуем договор, депозит, чеклист выдачи, ограничения по району и страховочные сценарии.",
+    icon: "file-text",
+  },
+  {
+    title: "Пилотный запуск",
+    text: "Включаем витрину, тестовый заказ, MapRiders-сценарий и короткий smoke-check в Telegram WebApp.",
+    icon: "shield-check",
+  },
+];
+
+export const DEFAULT_ONBOARDING_READINESS_ROWS: OnboardingReadinessRowBlock[] = [
+  { label: "Брендинг", text: "лого, цвета, оффер, адрес и рабочие часы" },
+  { label: "Каталог", text: "аренда, продажа, электробайки, аксессуары" },
+  { label: "Операции", text: "выдача, возврат, сервис, админ-доступы" },
+  { label: "Продажи", text: "новые/электро/б/у/trade-in лиды и тест-драйв" },
+  { label: "Комьюнити", text: "MapRiders, события, партнёры и Telegram-канал" },
+];
+
+export const DEFAULT_FRANCHIZE_CONTENT_BLOCKS: FranchizeContentBlocks = {
+  communityEvents: DEFAULT_COMMUNITY_EVENTS,
+  partnerCards: DEFAULT_PARTNER_CARDS,
+  cityRiderTips: DEFAULT_CITY_RIDER_TIPS,
+  salesVerticals: DEFAULT_SALES_VERTICALS,
+  onboardingChecklist: DEFAULT_ONBOARDING_CHECKLIST,
+  onboardingReadinessRows: DEFAULT_ONBOARDING_READINESS_ROWS,
+};
+
+export function cloneFranchizeContentBlocks(blocks: FranchizeContentBlocks = DEFAULT_FRANCHIZE_CONTENT_BLOCKS): FranchizeContentBlocks {
+  return {
+    communityEvents: blocks.communityEvents.map((item) => ({ ...item })),
+    partnerCards: blocks.partnerCards.map((item) => ({ ...item })),
+    cityRiderTips: blocks.cityRiderTips.map((item) => ({ ...item })),
+    salesVerticals: blocks.salesVerticals.map((item) => ({ ...item })),
+    onboardingChecklist: blocks.onboardingChecklist.map((item) => ({ ...item })),
+    onboardingReadinessRows: blocks.onboardingReadinessRows.map((item) => ({ ...item })),
+  };
+}
+
+const asRecord = (value: unknown): UnknownRecord => (
+  value && typeof value === "object" && !Array.isArray(value) ? (value as UnknownRecord) : {}
+);
+
+const readString = (record: UnknownRecord, keys: string[], fallback = "") => {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  }
+
+  return fallback;
+};
+
+const readArray = (source: UnknownRecord, paths: string[][]): unknown[] => {
+  for (const path of paths) {
+    let cursor: unknown = source;
+    for (const segment of path) {
+      cursor = asRecord(cursor)[segment];
+    }
+    if (Array.isArray(cursor) && cursor.length > 0) return cursor;
+  }
+
+  return [];
+};
+
+const readContentSource = (metadata: unknown): UnknownRecord => {
+  const source = asRecord(metadata);
+  const nested = asRecord(source.franchize);
+  const franchize = Object.keys(nested).length > 0 ? nested : source;
+  const contentBlocks = asRecord(franchize.contentBlocks);
+  const content = asRecord(franchize.content);
+
+  return {
+    ...franchize,
+    ...content,
+    ...contentBlocks,
+  };
+};
+
+const nonEmpty = <T extends object>(items: T[], fallback: T[]) => (items.length > 0 ? items : fallback.map((item) => ({ ...item })));
+
+const readCommunityEvents = (source: UnknownRecord): CommunityEventBlock[] => nonEmpty(
+  readArray(source, [["communityEvents"], ["community", "events"]])
+    .map((item) => {
+      const event = asRecord(item);
+      return {
+        title: readString(event, ["title", "name"]),
+        time: readString(event, ["time", "schedule", "date"]),
+        place: readString(event, ["place", "location", "address"]),
+        text: readString(event, ["text", "description", "body"]),
+      };
+    })
+    .filter((event) => event.title && event.text),
+  DEFAULT_COMMUNITY_EVENTS,
+);
+
+const readPartnerCards = (source: UnknownRecord): PartnerCardBlock[] => nonEmpty(
+  readArray(source, [["partnerCards"], ["community", "partnerCards"], ["community", "partners"]])
+    .map((item) => {
+      const partner = asRecord(item);
+      return {
+        name: readString(partner, ["name", "title"]),
+        role: readString(partner, ["role", "type", "badge"]),
+        perk: readString(partner, ["perk", "text", "description"]),
+      };
+    })
+    .filter((partner) => partner.name && partner.perk),
+  DEFAULT_PARTNER_CARDS,
+);
+
+const readCityRiderTips = (source: UnknownRecord): CityRiderTipBlock[] => nonEmpty(
+  readArray(source, [["cityRiderTips"], ["cityTips"], ["community", "cityRiderTips"], ["community", "cityTips"], ["community", "tips"]])
+    .map((item) => (typeof item === "string" ? { text: item.trim() } : { text: readString(asRecord(item), ["text", "tip", "title"]) }))
+    .filter((tip) => tip.text),
+  DEFAULT_CITY_RIDER_TIPS,
+);
+
+const readSalesVerticals = (source: UnknownRecord): SalesVerticalCopyBlock[] => nonEmpty(
+  readArray(source, [["salesVerticals"], ["sales", "verticals"], ["sales", "verticalCopy"]])
+    .map((item) => {
+      const vertical = asRecord(item);
+      const title = readString(vertical, ["title", "name"]);
+      return {
+        id: readString(vertical, ["id", "key", "slug"], title.toLowerCase().replace(/\s+/g, "-")),
+        title,
+        pitch: readString(vertical, ["pitch", "text", "description"]),
+        cta: readString(vertical, ["cta", "ctaLabel", "buttonLabel"], "Оставить заявку"),
+      };
+    })
+    .filter((vertical) => vertical.id && vertical.title && vertical.pitch),
+  DEFAULT_SALES_VERTICALS,
+);
+
+const readOnboardingChecklist = (source: UnknownRecord): OnboardingChecklistBlock[] => nonEmpty(
+  readArray(source, [["onboardingChecklist"], ["onboarding", "checklist"]])
+    .map((item) => {
+      const checklistItem = asRecord(item);
+      return {
+        title: readString(checklistItem, ["title", "label"]),
+        text: readString(checklistItem, ["text", "description", "body"]),
+        icon: readString(checklistItem, ["icon", "iconName"]),
+      };
+    })
+    .filter((item) => item.title && item.text),
+  DEFAULT_ONBOARDING_CHECKLIST,
+);
+
+const readReadinessRows = (source: UnknownRecord): OnboardingReadinessRowBlock[] => nonEmpty(
+  readArray(source, [["onboardingReadinessRows"], ["readinessRows"], ["onboarding", "readinessRows"], ["onboarding", "readiness"]])
+    .map((item) => {
+      if (Array.isArray(item)) {
+        return {
+          label: typeof item[0] === "string" ? item[0].trim() : "",
+          text: typeof item[1] === "string" ? item[1].trim() : "",
+        };
+      }
+
+      const row = asRecord(item);
+      return {
+        label: readString(row, ["label", "title", "name"]),
+        text: readString(row, ["text", "description", "body"]),
+      };
+    })
+    .filter((row) => row.label && row.text),
+  DEFAULT_ONBOARDING_READINESS_ROWS,
+);
+
+export function readFranchizeContentBlocks(metadata: unknown): FranchizeContentBlocks {
+  const source = readContentSource(metadata);
+
+  return {
+    communityEvents: readCommunityEvents(source),
+    partnerCards: readPartnerCards(source),
+    cityRiderTips: readCityRiderTips(source),
+    salesVerticals: readSalesVerticals(source),
+    onboardingChecklist: readOnboardingChecklist(source),
+    onboardingReadinessRows: readReadinessRows(source),
+  };
+}

--- a/docs/sql/sly13-franchize-test-hydration.sql
+++ b/docs/sql/sly13-franchize-test-hydration.sql
@@ -124,6 +124,43 @@ set
             'carDirections', 'Оффлайн встречи согласовываются заранее'
           )
         ),
+        'contentBlocks', jsonb_build_object(
+          'communityEvents', jsonb_build_array(
+            jsonb_build_object('title', 'CyberVIBE разбор недели', 'time', 'Ср • 20:00', 'place', 'Telegram / онлайн-комната', 'text', 'Разбираем идею, упаковку, контекст для AI и первый runnable шаг.'),
+            jsonb_build_object('title', 'Snowboard video review', 'time', 'Сб • 11:00', 'place', 'Онлайн + склон по договорённости', 'text', 'Короткий видеоразбор техники, ошибок стойки и плана следующей тренировки.'),
+            jsonb_build_object('title', 'Dota2 micro-coaching', 'time', 'Вс • 18:00', 'place', 'Discord / Telegram', 'text', 'Смотрим реплей, фиксируем 2-3 решения и домашку без токсичности.')
+          ),
+          'partnerCards', jsonb_build_array(
+            jsonb_build_object('name', 'oneSitePls', 'role', 'web runtime', 'perk', 'Быстрый путь от идеи до Telegram-first страницы'),
+            jsonb_build_object('name', 'CyberVIBE labs', 'role', 'AI-практика', 'perk', 'Промпты, контекст и чеклист запуска для оператора'),
+            jsonb_build_object('name', 'SLY13 coaching', 'role', 'спорт / игры', 'perk', 'Спокойный разбор навыка и понятный следующий шаг')
+          ),
+          'cityRiderTips', jsonb_build_array(
+            'Перед созвоном собери 3 ссылки, 1 цель и 1 главный страх.',
+            'Для AI-задачи сначала выгрузи контекст, потом проси правку.',
+            'Для спорта записывай короткое видео: без факта сложно улучшать технику.',
+            'После сессии фиксируй одно действие на 24 часа, а не бесконечный план.'
+          ),
+          'salesVerticals', jsonb_build_array(
+            jsonb_build_object('id', 'new', 'title', 'CyberVIBE запуск', 'pitch', 'Разбор идеи, оффера и первой страницы с AI-контекстом.', 'cta', 'Запустить разбор'),
+            jsonb_build_object('id', 'electric', 'title', 'AI workflow custom', 'pitch', 'Сборка личного процесса: контекст, промпты, проверки и PR-ритм.', 'cta', 'Собрать workflow'),
+            jsonb_build_object('id', 'used', 'title', 'Разбор текущего проекта', 'pitch', 'Аккуратная диагностика существующей страницы, воронки или Telegram-флоу.', 'cta', 'Разобрать проект'),
+            jsonb_build_object('id', 'trade-in', 'title', 'Trade-in хаоса', 'pitch', 'Меняем разрозненные заметки и чаты на понятную доску решений.', 'cta', 'Навести порядок')
+          ),
+          'onboardingChecklist', jsonb_build_array(
+            jsonb_build_object('title', 'Цель и канал', 'text', 'Фиксируем, что запускаем, кому это нужно и где будет первый контакт.', 'icon', 'message-circle'),
+            jsonb_build_object('title', 'Материалы и роли', 'text', 'Собираем ссылки, тексты, ограничения, доступы и ответственного за решения.', 'icon', 'clipboard-check'),
+            jsonb_build_object('title', 'Правила результата', 'text', 'Определяем формат выдачи, критерии готовности и безопасные границы.', 'icon', 'file-text'),
+            jsonb_build_object('title', 'Первый пилот', 'text', 'Делаем короткий запуск, проверяем на реальном пользователе и фиксируем следующий шаг.', 'icon', 'shield-check')
+          ),
+          'onboardingReadinessRows', jsonb_build_array(
+            jsonb_build_object('label', 'Оффер', 'text', 'что продаём, кому и каким первым сообщением'),
+            jsonb_build_object('label', 'Контекст', 'text', 'ссылки, материалы, ограничения и текущая боль'),
+            jsonb_build_object('label', 'Процесс', 'text', 'созвон/чат, домашка, сроки и формат результата'),
+            jsonb_build_object('label', 'Продажи', 'text', 'пакеты, цена, CTA и быстрый способ оплаты'),
+            jsonb_build_object('label', 'Комьюнити', 'text', 'канал обратной связи и место для следующих итераций')
+          )
+        ),
         'catalog', jsonb_build_object(
           'groupOrder', jsonb_build_array('CyberVIBE', 'Snowboard', 'Dota2', 'Labs'),
           'quickLinks', jsonb_build_array('CyberVIBE', 'Snowboard', 'Dota2', 'Labs'),

--- a/docs/sql/vip-bike-franchize-hydration.sql
+++ b/docs/sql/vip-bike-franchize-hydration.sql
@@ -195,6 +195,43 @@ set
             'carDirections', 'Подъезд к новой локации — см. указатели на месте'
           )
         ),
+        'contentBlocks', jsonb_build_object(
+          'communityEvents', jsonb_build_array(
+            jsonb_build_object('title', 'Вечерний сбор новичков VIP BIKE', 'time', 'Пт • 19:30', 'place', 'База на Комсомольской 2', 'text', 'Короткий городской круг, проверка экипировки, объяснение жестов и правил колонны.'),
+            jsonb_build_object('title', 'MapRiders city loop', 'time', 'Сб • 12:00', 'place', 'Набережная + тихие улицы Нижнего', 'text', 'Открываем live-карту, ставим meetup-пины и едем в темпе самого спокойного райдера.'),
+            jsonb_build_object('title', 'Техно-час перед покатушкой', 'time', 'Вс • 11:00', 'place', 'VIP BIKE сервис-зона', 'text', 'Давление, цепь, свет, тормоза и быстрый чек арендного или личного байка.')
+          ),
+          'partnerCards', jsonb_build_array(
+            jsonb_build_object('name', 'VIP BIKE сервис', 'role', 'осмотр и подготовка', 'perk', 'Экспресс-чек перед выездом для экипажа'),
+            jsonb_build_object('name', 'Кофе-точка райдеров', 'role', 'место встречи', 'perk', 'Тёплый старт, зарядка телефона, быстрый брифинг'),
+            jsonb_build_object('name', 'Экипировка рядом', 'role', 'перчатки / дождевик / защита', 'perk', 'Помощь новичку без лишнего пафоса')
+          ),
+          'cityRiderTips', jsonb_build_array(
+            'Не стартуй один, если это первый выезд на незнакомом байке.',
+            'Включай MapRiders до старта: экипаж увидит скорость, stale-статус и точку встречи.',
+            'Для новичков держим видимость «только экипаж» и автостоп геошеринга.',
+            'Meetup-пин ставим long-press на карте или тапом по точке + кнопка «+».'
+          ),
+          'salesVerticals', jsonb_build_array(
+            jsonb_build_object('id', 'new', 'title', 'Новые байки', 'pitch', 'Витрина для моделей под заказ, предпродажного расчёта и тест-драйва.', 'cta', 'Заявка на новый'),
+            jsonb_build_object('id', 'electric', 'title', 'Electro / custom', 'pitch', 'Электро-круизеры, батареи, подвеска и сборка под райдера.', 'cta', 'Собрать электро'),
+            jsonb_build_object('id', 'used', 'title', 'Б/у и проверенные', 'pitch', 'Лиды на технику с историей аренды, диагностикой и прозрачным состоянием.', 'cta', 'Подобрать б/у'),
+            jsonb_build_object('id', 'trade-in', 'title', 'Trade-in', 'pitch', 'Быстрый вход для оценки старого байка и обмена на аренду, новый или электро.', 'cta', 'Оценить байк')
+          ),
+          'onboardingChecklist', jsonb_build_array(
+            jsonb_build_object('title', 'Заявка и контакт', 'text', 'Фиксируем Telegram/телефон, город, формат партнёрства и ожидаемый объём байков.', 'icon', 'message-circle'),
+            jsonb_build_object('title', 'Парк и роли', 'text', 'Описываем модели, статусы аренды/продажи, ответственных за выдачу, сервис и контент.', 'icon', 'clipboard-check'),
+            jsonb_build_object('title', 'Документы и правила', 'text', 'Согласуем договор, депозит, чеклист выдачи, ограничения по району и страховочные сценарии.', 'icon', 'file-text'),
+            jsonb_build_object('title', 'Пилотный запуск', 'text', 'Включаем витрину, тестовый заказ, MapRiders-сценарий и короткий smoke-check в Telegram WebApp.', 'icon', 'shield-check')
+          ),
+          'onboardingReadinessRows', jsonb_build_array(
+            jsonb_build_object('label', 'Брендинг', 'text', 'лого, цвета, оффер, адрес и рабочие часы'),
+            jsonb_build_object('label', 'Каталог', 'text', 'аренда, продажа, электробайки, аксессуары'),
+            jsonb_build_object('label', 'Операции', 'text', 'выдача, возврат, сервис, админ-доступы'),
+            jsonb_build_object('label', 'Продажи', 'text', 'новые/электро/б/у/trade-in лиды и тест-драйв'),
+            jsonb_build_object('label', 'Комьюнити', 'text', 'MapRiders, события, партнёры и Telegram-канал')
+          )
+        ),
         'catalog', jsonb_build_object(
           'groupOrder', jsonb_build_array('Naked', 'Supersport', 'Enduro', 'Touring', 'Neo-retro', 'Power-cruiser'),
           'quickLinks', jsonb_build_array('23 февраля', 'Все по 549', 'Выгодное комбо', 'Cruiser week'),

--- a/docs/sql/vip-cross-franchize-hydration.sql
+++ b/docs/sql/vip-cross-franchize-hydration.sql
@@ -187,6 +187,43 @@ set
             'carDirections', 'Подъезд к локации — см. указатели на месте'
           )
         ),
+        'contentBlocks', jsonb_build_object(
+          'communityEvents', jsonb_build_array(
+            jsonb_build_object('title', 'Эндуро-брифинг новичков', 'time', 'Пт • 18:30', 'place', 'База VIP CROSS', 'text', 'Подбор защиты, посадка, базовые команды инструктора и правила группы.'),
+            jsonb_build_object('title', 'Лесной loop MapRiders', 'time', 'Сб • 10:30', 'place', 'Старт от Стригинского переулка 13Б', 'text', 'Едем оффроуд-маршрут с live-точками, паузами и темпом под самого спокойного райдера.'),
+            jsonb_build_object('title', 'Техчек эндуро-парка', 'time', 'Вс • 09:30', 'place', 'Сервис-зона VIP CROSS', 'text', 'Проверяем давление, рычаги, цепь, тормоза и защиту перед выездом на грунт.')
+          ),
+          'partnerCards', jsonb_build_array(
+            jsonb_build_object('name', 'VIP CROSS сервис', 'role', 'эндуро подготовка', 'perk', 'Осмотр мотоцикла и защиты перед маршрутом'),
+            jsonb_build_object('name', 'Инструктор маршрута', 'role', 'безопасный темп', 'perk', 'Помогает новичкам проходить сложные участки без давления'),
+            jsonb_build_object('name', 'Фото-точка оффроуд', 'role', 'контент', 'perk', 'Кадры с маршрута для команды и соцсетей')
+          ),
+          'cityRiderTips', jsonb_build_array(
+            'На грунте не едь один: держим группу и видимость инструктора.',
+            'Перед стартом включай MapRiders и проверь заряд телефона.',
+            'Если устал — говори сразу, группа подстроит темп и точку отдыха.',
+            'После маршрута отметь замечания по байку, чтобы сервис успел подготовить парк.'
+          ),
+          'salesVerticals', jsonb_build_array(
+            jsonb_build_object('id', 'new', 'title', 'Новые эндуро', 'pitch', 'Заявки на новые эндуро и кроссовые модели под заказ.', 'cta', 'Заявка на новый'),
+            jsonb_build_object('id', 'electric', 'title', 'Electro off-road', 'pitch', 'Электро-эндуро, батареи и настройки под тихий оффроуд.', 'cta', 'Собрать электро'),
+            jsonb_build_object('id', 'used', 'title', 'Проверенные б/у', 'pitch', 'Техника с понятной историей проката, диагностикой и сервисной подготовкой.', 'cta', 'Подобрать б/у'),
+            jsonb_build_object('id', 'trade-in', 'title', 'Trade-in эндуро', 'pitch', 'Оценка старого байка и обмен на аренду, новый или подготовленный б/у.', 'cta', 'Оценить байк')
+          ),
+          'onboardingChecklist', jsonb_build_array(
+            jsonb_build_object('title', 'Заявка и контакт', 'text', 'Фиксируем город, трассы, сезонность, ответственных и ожидаемый объём эндуро-парка.', 'icon', 'message-circle'),
+            jsonb_build_object('title', 'Парк и безопасность', 'text', 'Описываем модели, защиту, статусы аренды/продажи, инструкторов и сервис.', 'icon', 'clipboard-check'),
+            jsonb_build_object('title', 'Документы и правила', 'text', 'Согласуем договор, депозит, ограничения маршрутов, ответственность и чеклист выдачи.', 'icon', 'file-text'),
+            jsonb_build_object('title', 'Пилотный маршрут', 'text', 'Запускаем витрину, тестовую бронь, MapRiders-маршрут и проверку на телефоне.', 'icon', 'shield-check')
+          ),
+          'onboardingReadinessRows', jsonb_build_array(
+            jsonb_build_object('label', 'Брендинг', 'text', 'лого, цвета, оффер, адрес базы и сезонные часы'),
+            jsonb_build_object('label', 'Каталог', 'text', 'эндуро, кросс, питбайки, защита и инструкторские пакеты'),
+            jsonb_build_object('label', 'Операции', 'text', 'выдача, возврат, сервис, маршрутные ограничения'),
+            jsonb_build_object('label', 'Продажи', 'text', 'новые/электро/б/у/trade-in лиды и тест-драйв'),
+            jsonb_build_object('label', 'Комьюнити', 'text', 'MapRiders, события, инструкторы и Telegram-канал')
+          )
+        ),
         'catalog', jsonb_build_object(
           'groupOrder', jsonb_build_array('Enduro', 'Cross', 'Pitbike', 'Trial', 'Kids'),
           'quickLinks', jsonb_build_array('Эндуро выходного дня', 'Все по 449', 'Выгодное комбо', 'Trial week'),


### PR DESCRIPTION
### Motivation
- Move hardcoded UI copy/config for community, onboarding and sales into a reusable content-blocks structure so crews can provide custom copy via metadata. 
- Provide robust parsing and sensible defaults for multiple possible content shapes coming from DB/metadata. 
- Surface the content blocks through the existing franchize VM so pages can render dynamic content without inline arrays.

### Description
- Introduces a new module `app/franchize/lib/content-blocks.ts` that defines `FranchizeContentBlocks` types, default data constants, `readFranchizeContentBlocks`, and `cloneFranchizeContentBlocks` for safe defaults and parsing. 
- Wires the new content blocks into the runtime model by adding `contentBlocks: FranchizeContentBlocks` to `FranchizeCrewVM` and populating it with `readFranchizeContentBlocks` in `getFranchizeBySlug`, and using `cloneFranchizeContentBlocks()` in `emptyCrew`. 
- Replaces inline hardcoded arrays on the pages with dynamic data from `crew.contentBlocks` in `community/page.tsx`, `onboarding/page.tsx`, and `sales/page.tsx`, including: switching city events, partner cards, rider tips, onboarding checklist/readiness rows, and sales verticals to use the parsed content. 
- Adds small helpers for icon resolution: `getChecklistIcon` in onboarding and `getVerticalIcon` in sales to map content icon/vertical ids to lucide icons. 
- Updates SQL hydration fixtures in `docs/sql/*-hydration.sql` to include `contentBlocks` examples for sample franchises.

### Testing
- Ran a TypeScript type-check with `tsc --noEmit` which completed successfully. 
- Performed a local Next.js build with `next build` which completed without build-time errors. 
- Verified the updated pages render expected content using default fallbacks when `contentBlocks` are missing (manual smoke checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd153b0be08324bd81db182533f408)