### PR TITLE
Telegram WebApp fallbacks and operator-support UI for franchize flows

### DIFF
--- a/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
+++ b/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
@@ -7,11 +7,18 @@ import { CrewHeader } from "@/app/franchize/components/CrewHeader";
 import { FranchizeFloatingCart } from "@/app/franchize/components/FranchizeFloatingCart";
 import { FranchizeHero } from "@/app/franchize/components/FranchizeHero";
 import { FranchizePageShell } from "@/app/franchize/components/FranchizePageShell";
+import {
+  getTelegramHandleHref,
+  getTelegramWebAppFallbackHref,
+} from "@/app/franchize/lib/telegram-links";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { SaleBikeLanding } from "@/app/franchize/components/SaleBikeLanding";
 import { isSameCatalogPropulsion } from "@/app/franchize/lib/catalog-propulsion";
 import { buildSaleBuySectionId } from "@/app/franchize/lib/sale-anchors";
-import { buildFranchizeSectionMetadata, findCatalogItemImage } from "../../../metadata";
+import {
+  buildFranchizeSectionMetadata,
+  findCatalogItemImage,
+} from "../../../metadata";
 
 interface BuyBikePageProps {
   params: Promise<{ slug: string; bike_id: string }>;
@@ -24,8 +31,9 @@ const isSaleEnabled = (value: unknown) =>
   String(value).toLowerCase() === "1" ||
   String(value).toLowerCase() === "true";
 
-
-export async function generateMetadata({ params }: BuyBikePageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: BuyBikePageProps): Promise<Metadata> {
   const { slug, bike_id } = await params;
   return buildFranchizeSectionMetadata(slug, {
     sectionTitle: ({ items }) => {
@@ -41,7 +49,9 @@ export async function generateMetadata({ params }: BuyBikePageProps): Promise<Me
     pathSuffix: `/market/${bike_id}/buy`,
     ogTitle: ({ items, crew }) => {
       const item = items.find((candidate) => candidate.id === bike_id);
-      return item ? `Купить ${item.title} · ${crew.header.brandName}` : "Покупка байка в экипаже oneSitePls";
+      return item
+        ? `Купить ${item.title} · ${crew.header.brandName}`
+        : "Покупка байка в экипаже oneSitePls";
     },
     ogDescription: ({ items }) => {
       const item = items.find((candidate) => candidate.id === bike_id);
@@ -50,7 +60,9 @@ export async function generateMetadata({ params }: BuyBikePageProps): Promise<Me
         : "Открой карточку выбранного байка, сравни комплектацию и отправь заявку на покупку.";
     },
     image: ({ items }) => findCatalogItemImage(items, bike_id),
-    imageAlt: ({ items, crew }) => items.find((item) => item.id === bike_id)?.title || `${crew.header.brandName} bike preview`,
+    imageAlt: ({ items, crew }) =>
+      items.find((item) => item.id === bike_id)?.title ||
+      `${crew.header.brandName} bike preview`,
   });
 }
 
@@ -64,6 +76,11 @@ export default async function BuyBikePage({
   const resolvedSlug = crew.slug || slug;
   const surface = crewPaletteForSurface(crew.theme);
   const item = items.find((candidate) => candidate.id === bike_id);
+  const contactHref = `/franchize/${resolvedSlug}/contacts`;
+  const catalogHref = `/franchize/${resolvedSlug}`;
+  const profileHref = `/franchize/${resolvedSlug}/profile`;
+  const telegramHref = getTelegramHandleHref(crew.contacts.telegram);
+  const telegramFallbackHref = getTelegramWebAppFallbackHref("sale", bike_id, crew.contacts.telegramBotUsername);
 
   if (!item) notFound();
   const buySectionId = buildSaleBuySectionId(item.id);
@@ -74,17 +91,44 @@ export default async function BuyBikePage({
         style={surface.page}
       >
         <h1 className="text-2xl font-semibold">
-          Этот байк не помечен как продажа
+          Этот байк сейчас не продаётся
         </h1>
         <p className="text-sm opacity-80">
-          Откройте карточку через маркет и выберите аренду.
+          Продажная карточка недоступна: позиция могла остаться только для
+          аренды или временно уйти на проверку документов.
         </p>
-        <Link
-          href={`/franchize/${resolvedSlug}?vehicle=${encodeURIComponent(bike_id)}&flow=rent`}
-          className="rounded-xl border px-4 py-2 text-sm font-semibold"
-        >
-          Вернуться в маркет
-        </Link>
+        <div className="grid w-full gap-2 sm:grid-cols-2">
+          <Link
+            href={`/franchize/${resolvedSlug}?vehicle=${encodeURIComponent(bike_id)}&flow=rent`}
+            className="rounded-xl border px-4 py-2 text-sm font-semibold"
+          >
+            Вернуться в каталог
+          </Link>
+          <Link
+            href={profileHref}
+            className="rounded-xl border px-4 py-2 text-sm font-semibold"
+          >
+            В профиль
+          </Link>
+          <a
+            href={telegramHref}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-xl border px-4 py-2 text-sm font-semibold"
+          >
+            Написать в Telegram
+          </a>
+          <Link
+            href={contactHref}
+            className="rounded-xl border px-4 py-2 text-sm font-semibold"
+          >
+            Поддержка / контакты
+          </Link>
+        </div>
+        <p className="text-xs opacity-70">
+          Оплата и договор не запускаются, пока оператор не подтвердит продажный
+          статус байка.
+        </p>
       </main>
     );
   }
@@ -100,10 +144,7 @@ export default async function BuyBikePage({
     : null;
 
   return (
-    <main
-      className="min-h-screen"
-      style={surface.page}
-    >
+    <main className="min-h-screen" style={surface.page}>
       <CrewHeader
         crew={crew}
         activePath={`/franchize/${resolvedSlug}/market/${bike_id}/buy`}
@@ -115,8 +156,106 @@ export default async function BuyBikePage({
           title={`Покупка · ${item.title}`}
           subcopy="Операторская витрина продажи: сравнение, конфигурация, тест-драйв и быстрый возврат в маркет без потери бренда экипажа."
           primaryCta={{ label: "Настроить покупку", href: `#${buySectionId}` }}
-          secondaryCta={{ label: "Вернуться в маркет", href: `/franchize/${resolvedSlug}?vehicle=${encodeURIComponent(bike_id)}` }}
+          secondaryCta={{
+            label: "Вернуться в маркет",
+            href: `/franchize/${resolvedSlug}?vehicle=${encodeURIComponent(bike_id)}`,
+          }}
         />
+        <section className="rounded-3xl border p-4" style={surface.subtleCard}>
+          <div className="grid gap-4 lg:grid-cols-[1.25fr_0.75fr]">
+            <div>
+              <p
+                className="text-xs font-semibold uppercase tracking-[0.16em]"
+                style={{ color: crew.theme.palette.accentMain }}
+              >
+                Что будет дальше
+              </p>
+              <ol className="mt-3 space-y-2 text-sm">
+                {[
+                  `Сравните комплектацию ${item.title} и выберите конфигурацию покупки.`,
+                  "Передайте заявку в Telegram: оператор закрепит тест-драйв, цену и резерв.",
+                  "Договор, предоплата и передача байка подтверждаются только после ручной проверки документов.",
+                ].map((step, index) => (
+                  <li key={step} className="flex gap-2">
+                    <span
+                      className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold"
+                      style={{
+                        backgroundColor: `${crew.theme.palette.accentMain}24`,
+                        color: crew.theme.palette.accentMain,
+                      }}
+                    >
+                      {index + 1}
+                    </span>
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ol>
+              <p
+                className="mt-3 rounded-2xl border p-3 text-xs"
+                style={{
+                  ...surface.card,
+                  borderColor: crew.theme.palette.borderSoft,
+                }}
+              >
+                Безопасность сделки: маркет не списывает деньги сам по себе,
+                договор и платёж подтверждаются оператором, а спорные правки
+                фиксируются в Telegram-переписке.
+              </p>
+            </div>
+            <div className="space-y-2 text-sm">
+              <a
+                href={telegramHref}
+                target="_blank"
+                rel="noreferrer"
+                className="flex justify-center rounded-xl px-4 py-3 font-semibold"
+                style={{
+                  backgroundColor: crew.theme.palette.accentMain,
+                  color: crew.theme.palette.accentTextOn,
+                }}
+              >
+                Написать оператору в Telegram
+              </a>
+              <a
+                href={telegramFallbackHref}
+                target="_blank"
+                rel="noreferrer"
+                className="flex justify-center rounded-xl border px-4 py-3"
+                style={{
+                  borderColor: crew.theme.palette.borderSoft,
+                  color: crew.theme.palette.textPrimary,
+                }}
+              >
+                Открыть WebApp fallback
+              </a>
+              <Link
+                href={contactHref}
+                className="flex justify-center rounded-xl border px-4 py-3"
+                style={{
+                  borderColor: crew.theme.palette.borderSoft,
+                  color: crew.theme.palette.textPrimary,
+                }}
+              >
+                Поддержка / контакты
+              </Link>
+              <div className="grid grid-cols-2 gap-2">
+                <Link
+                  href={catalogHref}
+                  className="rounded-xl border px-3 py-2 text-center text-xs"
+                  style={{ borderColor: crew.theme.palette.borderSoft }}
+                >
+                  Каталог
+                </Link>
+                <Link
+                  href={profileHref}
+                  className="rounded-xl border px-3 py-2 text-center text-xs"
+                  style={{ borderColor: crew.theme.palette.borderSoft }}
+                >
+                  Профиль
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
       </FranchizePageShell>
       <SaleBikeLanding
         crew={crew}

--- a/app/franchize/[slug]/rental/[id]/page.tsx
+++ b/app/franchize/[slug]/rental/[id]/page.tsx
@@ -8,6 +8,7 @@ import { FranchizeRentalLifecycleActions } from "../../../components/FranchizeRe
 import { FranchizeHero } from "../../../components/FranchizeHero";
 import { FranchizePageShell } from "../../../components/FranchizePageShell";
 import { FranchizeRentalDocumentsPanel } from "../../../components/FranchizeRentalDocumentsPanel";
+import { getTelegramHandleHref } from "../../../lib/telegram-links";
 import { crewPaletteForSurface } from "../../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../../metadata";
 
@@ -23,22 +24,33 @@ const statusLabel: Record<string, string> = {
   cancelled: "Отменена",
 };
 
-
-export async function generateMetadata({ params }: FranchizeRentalPageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: FranchizeRentalPageProps): Promise<Metadata> {
   const { slug, id } = await params;
   return buildFranchizeSectionMetadata(slug, {
     sectionTitle: "Карточка аренды",
-    sectionDescription: "Карточка аренды экипажа: статус сделки, документы, проверка контракта и дальнейшие действия.",
+    sectionDescription:
+      "Карточка аренды экипажа: статус сделки, документы, проверка контракта и дальнейшие действия.",
     pathSuffix: `/rental/${id}`,
   });
 }
 
-export default async function FranchizeRentalPage({ params }: FranchizeRentalPageProps) {
+export default async function FranchizeRentalPage({
+  params,
+}: FranchizeRentalPageProps) {
   const { slug, id } = await params;
-  const [{ crew, items }, rental] = await Promise.all([getFranchizeBySlug(slug), getFranchizeRentalCard(slug, id)]);
+  const [{ crew, items }, rental] = await Promise.all([
+    getFranchizeBySlug(slug),
+    getFranchizeRentalCard(slug, id),
+  ]);
   const resolvedSlug = crew.slug || slug;
   const surface = crewPaletteForSurface(crew.theme);
   const dealStarted = rental.found || rental.paymentStatus === "interest_paid";
+  const catalogHref = `/franchize/${resolvedSlug}`;
+  const profileHref = `/franchize/${resolvedSlug}/profile`;
+  const contactsHref = `/franchize/${resolvedSlug}/contacts`;
+  const telegramSupportHref = getTelegramHandleHref(crew.contacts.telegram);
   const verificationText =
     rental.contractVerificationStatus === "verified"
       ? "Верифицирован"
@@ -54,23 +66,177 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${resolvedSlug}/rental/${id}`} groupLinks={items.map((item) => item.category)} />
+      <CrewHeader
+        crew={crew}
+        activePath={`/franchize/${resolvedSlug}/rental/${id}`}
+        groupLinks={items.map((item) => item.category)}
+      />
 
       <FranchizePageShell theme={crew.theme} contentClassName="space-y-6">
         <FranchizeHero
           eyebrow={`/franchize/${resolvedSlug}/rental/${id} · сделка`}
           title="Карточка аренды"
-          subcopy={rental.found
-            ? "Сделка активирована. Управляй следующим шагом аренды из Telegram WebApp или через runtime-карточку."
-            : "Сделка пока не найдена. Проверь ссылку и дождись синхронизации после оплаты XTR."}
-          primaryCta={{ label: "Продолжить оформление", href: `/franchize/${resolvedSlug}/order/demo-order` }}
-          secondaryCta={{ label: "К каталогу", href: `/franchize/${resolvedSlug}` }}
+          subcopy={
+            rental.found
+              ? "Сделка активирована. Управляй следующим шагом аренды из Telegram WebApp или через runtime-карточку."
+              : "Сделка пока не найдена. Проверь ссылку и дождись синхронизации после оплаты XTR."
+          }
+          primaryCta={{
+            label: "Продолжить оформление",
+            href: `/franchize/${resolvedSlug}/order/demo-order`,
+          }}
+          secondaryCta={{
+            label: "К каталогу",
+            href: `/franchize/${resolvedSlug}`,
+          }}
         />
+
+        <section className="rounded-3xl border p-4" style={surface.subtleCard}>
+          <div className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+            <div>
+              <p
+                className="text-xs font-semibold uppercase tracking-[0.16em]"
+                style={{ color: crew.theme.palette.accentMain }}
+              >
+                Что будет дальше
+              </p>
+              <ol className="mt-3 space-y-2 text-sm">
+                {(rental.found
+                  ? [
+                      "Проверим статус оплаты, договора и выдачи в карточке аренды.",
+                      "Если нужен следующий шаг — продолжите оформление или откройте сделку в Telegram WebApp.",
+                      "После завершения аренды появится отзыв и финальная сверка залога/документов.",
+                    ]
+                  : [
+                      "Подождём синхронизацию: иногда XTR/бот присылает карточку с задержкой.",
+                      "Откройте Telegram fallback или напишите оператору номер сделки.",
+                      "Если сделка не найдётся, вернитесь в каталог или профиль без потери навигации.",
+                    ]
+                ).map((step, index) => (
+                  <li key={step} className="flex gap-2">
+                    <span
+                      className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold"
+                      style={{
+                        backgroundColor: `${crew.theme.palette.accentMain}24`,
+                        color: crew.theme.palette.accentMain,
+                      }}
+                    >
+                      {index + 1}
+                    </span>
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ol>
+              <p
+                className="mt-3 rounded-2xl border p-3 text-xs"
+                style={{
+                  ...surface.card,
+                  borderColor: crew.theme.palette.borderSoft,
+                }}
+              >
+                Безопасность оплаты и договора: статус договора показывается
+                отдельно, документы проверяются через verifier, а новые списания
+                или изменения условий согласуются с оператором.
+              </p>
+            </div>
+            <div className="space-y-2 text-sm">
+              <a
+                href={rental.telegramDeepLink}
+                target="_blank"
+                rel="noreferrer"
+                className="flex justify-center rounded-xl px-4 py-3 font-semibold"
+                style={{
+                  backgroundColor: crew.theme.palette.accentMain,
+                  color: crew.theme.palette.accentTextOn,
+                }}
+              >
+                Открыть сделку в Telegram
+              </a>
+              <a
+                href={telegramSupportHref}
+                target="_blank"
+                rel="noreferrer"
+                className="flex justify-center rounded-xl border px-4 py-3"
+                style={{
+                  borderColor: crew.theme.palette.borderSoft,
+                  color: crew.theme.palette.textPrimary,
+                }}
+              >
+                Написать оператору
+              </a>
+              <Link
+                href={contactsHref}
+                className="flex justify-center rounded-xl border px-4 py-3"
+                style={{
+                  borderColor: crew.theme.palette.borderSoft,
+                  color: crew.theme.palette.textPrimary,
+                }}
+              >
+                Поддержка / контакты
+              </Link>
+              <div className="grid grid-cols-2 gap-2">
+                <Link
+                  href={catalogHref}
+                  className="rounded-xl border px-3 py-2 text-center text-xs"
+                  style={{ borderColor: crew.theme.palette.borderSoft }}
+                >
+                  Каталог
+                </Link>
+                <Link
+                  href={profileHref}
+                  className="rounded-xl border px-3 py-2 text-center text-xs"
+                  style={{ borderColor: crew.theme.palette.borderSoft }}
+                >
+                  Профиль
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {!rental.found ? (
+          <section
+            className="rounded-3xl border border-dashed p-4 text-sm"
+            style={surface.card}
+          >
+            <h2 className="font-semibold">Карточка аренды ещё не найдена</h2>
+            <p className="mt-2" style={surface.mutedText}>
+              Проверьте ID в ссылке, откройте fallback deeplink Telegram или
+              вернитесь в профиль — там останутся последние активные заявки.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Link
+                href={catalogHref}
+                className="rounded-xl border px-3 py-2 text-xs"
+                style={{ borderColor: crew.theme.palette.borderSoft }}
+              >
+                Вернуться в каталог
+              </Link>
+              <Link
+                href={profileHref}
+                className="rounded-xl border px-3 py-2 text-xs"
+                style={{ borderColor: crew.theme.palette.borderSoft }}
+              >
+                Вернуться в профиль
+              </Link>
+              <Link
+                href={contactsHref}
+                className="rounded-xl border px-3 py-2 text-xs"
+                style={{ borderColor: crew.theme.palette.borderSoft }}
+              >
+                Связаться с поддержкой
+              </Link>
+            </div>
+          </section>
+        ) : null}
 
         {dealStarted && (
           <div
             className="mt-3 inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold"
-            style={{ borderColor: crew.theme.palette.accentMain, color: crew.theme.palette.accentMain }}
+            style={{
+              borderColor: crew.theme.palette.accentMain,
+              color: crew.theme.palette.accentMain,
+            }}
           >
             <Sparkles className="h-3.5 w-3.5" />
             Deal is starting for real — продолжаем оформление 🚀
@@ -79,37 +245,85 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
 
         <section className="rounded-3xl border p-4" style={surface.subtleCard}>
           <div className="mb-4 flex flex-wrap items-center gap-2">
-            <span className="text-xs" style={{ color: crew.theme.palette.textSecondary }}>Проверка контракта:</span>
-            <span className="rounded-full border px-3 py-1 text-xs font-semibold" style={{ borderColor: verificationColor, color: verificationColor }}>
+            <span
+              className="text-xs"
+              style={{ color: crew.theme.palette.textSecondary }}
+            >
+              Проверка контракта:
+            </span>
+            <span
+              className="rounded-full border px-3 py-1 text-xs font-semibold"
+              style={{
+                borderColor: verificationColor,
+                color: verificationColor,
+              }}
+            >
               {verificationText}
             </span>
             <Link
               href={`/doc-verifier?integrationScope=${encodeURIComponent(rental.contractVerifierScope || `rental:${rental.rentalId}`)}&documentKey=${encodeURIComponent(rental.contractDocumentKey || `rental-${slug}-${rental.rentalId}`)}`}
               className="rounded-full border px-3 py-1 text-xs font-semibold"
-              style={{ borderColor: crew.theme.palette.accentMain, color: crew.theme.palette.accentMain }}
+              style={{
+                borderColor: crew.theme.palette.accentMain,
+                color: crew.theme.palette.accentMain,
+              }}
             >
               Verify contract
             </Link>
             {rental.docVerifierRecordId ? (
-              <span className="text-[11px]" style={{ color: crew.theme.palette.textSecondary }}>
+              <span
+                className="text-[11px]"
+                style={{ color: crew.theme.palette.textSecondary }}
+              >
                 record: {rental.docVerifierRecordId.slice(0, 8)}…
               </span>
             ) : null}
             {rental.contractSourceScope ? (
-              <span className="text-[11px]" style={{ color: crew.theme.palette.textSecondary }}>
+              <span
+                className="text-[11px]"
+                style={{ color: crew.theme.palette.textSecondary }}
+              >
                 source: {rental.contractSourceScope}
               </span>
             ) : null}
           </div>
           <div className="grid gap-3 text-sm sm:grid-cols-2">
-            <p><span style={{ color: crew.theme.palette.textSecondary }}>Rental ID:</span> {rental.rentalId}</p>
-            <p><span style={{ color: crew.theme.palette.textSecondary }}>Статус:</span> {statusLabel[rental.status] ?? rental.status}</p>
-            <p><span style={{ color: crew.theme.palette.textSecondary }}>Оплата:</span> {rental.paymentStatus}</p>
-            <p><span style={{ color: crew.theme.palette.textSecondary }}>Итого:</span> {rental.totalCost.toLocaleString("ru-RU")} ₽</p>
-            <p className="sm:col-span-2"><span style={{ color: crew.theme.palette.textSecondary }}>Транспорт:</span> {rental.vehicleTitle}</p>
+            <p>
+              <span style={{ color: crew.theme.palette.textSecondary }}>
+                Rental ID:
+              </span>{" "}
+              {rental.rentalId}
+            </p>
+            <p>
+              <span style={{ color: crew.theme.palette.textSecondary }}>
+                Статус:
+              </span>{" "}
+              {statusLabel[rental.status] ?? rental.status}
+            </p>
+            <p>
+              <span style={{ color: crew.theme.palette.textSecondary }}>
+                Оплата:
+              </span>{" "}
+              {rental.paymentStatus}
+            </p>
+            <p>
+              <span style={{ color: crew.theme.palette.textSecondary }}>
+                Итого:
+              </span>{" "}
+              {rental.totalCost.toLocaleString("ru-RU")} ₽
+            </p>
+            <p className="sm:col-span-2">
+              <span style={{ color: crew.theme.palette.textSecondary }}>
+                Транспорт:
+              </span>{" "}
+              {rental.vehicleTitle}
+            </p>
             {rental.contractOriginalSha256 ? (
               <p className="sm:col-span-2 break-all">
-                <span style={{ color: crew.theme.palette.textSecondary }}>Contract SHA256:</span> {rental.contractOriginalSha256}
+                <span style={{ color: crew.theme.palette.textSecondary }}>
+                  Contract SHA256:
+                </span>{" "}
+                {rental.contractOriginalSha256}
               </p>
             ) : null}
           </div>
@@ -118,15 +332,21 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
             <Link
               href={`/franchize/${resolvedSlug}/order/demo-order`}
               className="inline-flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold"
-              style={{ backgroundColor: crew.theme.palette.accentMain, color: crew.theme.palette.bgBase }}
+              style={{
+                backgroundColor: crew.theme.palette.accentMain,
+                color: crew.theme.palette.accentTextOn,
+              }}
             >
               <Sparkles className="h-4 w-4" />
               Продолжить оформление
             </Link>
             <Link
-              href={`/franchize/${resolvedSlug}`}
+              href={catalogHref}
               className="inline-flex justify-center rounded-xl border px-4 py-3 text-sm"
-              style={{ borderColor: crew.theme.palette.borderSoft, color: crew.theme.palette.textPrimary }}
+              style={{
+                borderColor: crew.theme.palette.borderSoft,
+                color: crew.theme.palette.textPrimary,
+              }}
             >
               К каталогу
             </Link>
@@ -150,7 +370,10 @@ export default async function FranchizeRentalPage({ params }: FranchizeRentalPag
             palette={crew.theme.palette}
           />
 
-          <div className="mt-4 flex items-center justify-end gap-2 text-xs" style={{ color: crew.theme.palette.textSecondary }}>
+          <div
+            className="mt-4 flex items-center justify-end gap-2 text-xs"
+            style={{ color: crew.theme.palette.textSecondary }}
+          >
             <span
               className="inline-flex h-6 w-6 items-center justify-center rounded-full border"
               style={{ borderColor: crew.theme.palette.borderSoft }}

--- a/app/franchize/[slug]/review/[rentalId]/page.tsx
+++ b/app/franchize/[slug]/review/[rentalId]/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { getFranchizeBySlug, getRentalReviewContext } from "../../../actions";
 import { CrewHeader } from "../../../components/CrewHeader";
 import { CrewFooter } from "../../../components/CrewFooter";
+import {
+  getTelegramHandleHref,
+  getTelegramWebAppFallbackHref,
+} from "../../../lib/telegram-links";
 import { crewPaletteForSurface } from "../../../lib/theme";
 import { ReviewForm } from "./ReviewForm";
 import { buildFranchizeSectionMetadata } from "../../metadata";
@@ -10,17 +15,21 @@ interface RentalReviewPageProps {
   params: Promise<{ slug: string; rentalId: string }>;
 }
 
-
-export async function generateMetadata({ params }: RentalReviewPageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: RentalReviewPageProps): Promise<Metadata> {
   const { slug, rentalId } = await params;
   return buildFranchizeSectionMetadata(slug, {
     sectionTitle: "Отзыв об аренде",
-    sectionDescription: "Страница отзыва после аренды: оценка байка, впечатления райдера и обратная связь экипажу.",
+    sectionDescription:
+      "Страница отзыва после аренды: оценка байка, впечатления райдера и обратная связь экипажу.",
     pathSuffix: `/review/${rentalId}`,
   });
 }
 
-export default async function RentalReviewPage({ params }: RentalReviewPageProps) {
+export default async function RentalReviewPage({
+  params,
+}: RentalReviewPageProps) {
   const { slug, rentalId } = await params;
   const [{ crew, items }, context] = await Promise.all([
     getFranchizeBySlug(slug),
@@ -28,27 +37,171 @@ export default async function RentalReviewPage({ params }: RentalReviewPageProps
   ]);
   const surface = crewPaletteForSurface(crew.theme);
   const rental = context.rental;
+  const resolvedSlug = crew.slug || slug;
+  const catalogHref = `/franchize/${resolvedSlug}`;
+  const profileHref = `/franchize/${resolvedSlug}/profile`;
+  const contactsHref = `/franchize/${resolvedSlug}/contacts`;
+  const telegramSupportHref = getTelegramHandleHref(crew.contacts.telegram);
+  const telegramFallbackHref = getTelegramWebAppFallbackHref(
+    "review",
+    rentalId,
+    crew.contacts.telegramBotUsername,
+  );
 
   return (
     <main className="min-h-screen" style={surface.page}>
-      <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}`} groupLinks={items.map((item) => item.category)} />
+      <CrewHeader
+        crew={crew}
+        activePath={`/franchize/${resolvedSlug}`}
+        groupLinks={items.map((item) => item.category)}
+      />
       <section className="px-4 py-8">
-        {rental ? (
-          <ReviewForm
-            slug={crew.slug || slug}
-            rentalId={rental.rentalId}
-            bikeTitle={rental.bikeTitle}
-            status={rental.status}
-            renterUserId={rental.userId}
-            theme={crew.theme}
-            existingReview={rental.existingReview}
-          />
-        ) : (
-          <div className="mx-auto max-w-xl rounded-3xl border p-5" style={surface.card}>
-            <h1 className="text-xl font-semibold">Отзыв недоступен</h1>
-            <p className="mt-2 text-sm" style={surface.mutedText}>{context.error || "Проверьте ссылку аренды."}</p>
-          </div>
-        )}
+        <div className="mx-auto grid max-w-5xl gap-4 lg:grid-cols-[minmax(0,1fr)_340px]">
+          {rental ? (
+            <ReviewForm
+              slug={resolvedSlug}
+              rentalId={rental.rentalId}
+              bikeTitle={rental.bikeTitle}
+              status={rental.status}
+              renterUserId={rental.userId}
+              theme={crew.theme}
+              existingReview={rental.existingReview}
+            />
+          ) : (
+            <div className="rounded-3xl border p-5" style={surface.card}>
+              <h1 className="text-xl font-semibold">Отзыв недоступен</h1>
+              <p className="mt-2 text-sm" style={surface.mutedText}>
+                {context.error ||
+                  "Мы не нашли аренду по этой ссылке. Проверьте rental ID, откройте ссылку из Telegram или напишите оператору."}
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2 text-sm">
+                <Link
+                  href={catalogHref}
+                  className="rounded-xl border px-3 py-2"
+                  style={{ borderColor: crew.theme.palette.borderSoft }}
+                >
+                  Вернуться в каталог
+                </Link>
+                <Link
+                  href={profileHref}
+                  className="rounded-xl border px-3 py-2"
+                  style={{ borderColor: crew.theme.palette.borderSoft }}
+                >
+                  Вернуться в профиль
+                </Link>
+                <Link
+                  href={contactsHref}
+                  className="rounded-xl border px-3 py-2"
+                  style={{ borderColor: crew.theme.palette.borderSoft }}
+                >
+                  Поддержка
+                </Link>
+              </div>
+            </div>
+          )}
+
+          <aside
+            className="h-fit rounded-3xl border p-4 text-sm"
+            style={surface.subtleCard}
+          >
+            <p
+              className="text-xs font-semibold uppercase tracking-[0.16em]"
+              style={{ color: crew.theme.palette.accentMain }}
+            >
+              Что будет дальше
+            </p>
+            <ol className="mt-3 space-y-2">
+              {(rental
+                ? [
+                    "Проверьте, что аренда завершена и Telegram-профиль совпадает с арендатором.",
+                    "Оставьте оценку и пару строк — отзыв попадёт экипажу после безопасной WebApp-проверки.",
+                    "Если форма закрыта, оператор поможет сверить статус аренды и ссылку на отзыв.",
+                  ]
+                : [
+                    "Сначала восстановим правильную карточку аренды через Telegram или профиль.",
+                    "Оператор проверит статус договора/оплаты и пришлёт рабочую ссылку.",
+                    "После завершения аренды отзыв можно будет сохранить без повторной оплаты.",
+                  ]
+              ).map((step, index) => (
+                <li key={step} className="flex gap-2">
+                  <span
+                    className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold"
+                    style={{
+                      backgroundColor: `${crew.theme.palette.accentMain}24`,
+                      color: crew.theme.palette.accentMain,
+                    }}
+                  >
+                    {index + 1}
+                  </span>
+                  <span>{step}</span>
+                </li>
+              ))}
+            </ol>
+            <p
+              className="mt-3 rounded-2xl border p-3 text-xs"
+              style={{
+                ...surface.card,
+                borderColor: crew.theme.palette.borderSoft,
+              }}
+            >
+              Безопасность: отзыв не запускает списания; договор и оплата уже
+              проверяются в карточке аренды, а доступ к сохранению
+              подтверждается Telegram WebApp-сессией.
+            </p>
+            <div className="mt-3 space-y-2">
+              <a
+                href={telegramFallbackHref}
+                target="_blank"
+                rel="noreferrer"
+                className="flex justify-center rounded-xl px-4 py-3 font-semibold"
+                style={{
+                  backgroundColor: crew.theme.palette.accentMain,
+                  color: crew.theme.palette.accentTextOn,
+                }}
+              >
+                Открыть отзыв в Telegram
+              </a>
+              <a
+                href={telegramSupportHref}
+                target="_blank"
+                rel="noreferrer"
+                className="flex justify-center rounded-xl border px-4 py-3"
+                style={{
+                  borderColor: crew.theme.palette.borderSoft,
+                  color: crew.theme.palette.textPrimary,
+                }}
+              >
+                Написать оператору
+              </a>
+              <Link
+                href={contactsHref}
+                className="flex justify-center rounded-xl border px-4 py-3"
+                style={{
+                  borderColor: crew.theme.palette.borderSoft,
+                  color: crew.theme.palette.textPrimary,
+                }}
+              >
+                Поддержка / контакты
+              </Link>
+              <div className="grid grid-cols-2 gap-2">
+                <Link
+                  href={catalogHref}
+                  className="rounded-xl border px-3 py-2 text-center text-xs"
+                  style={{ borderColor: crew.theme.palette.borderSoft }}
+                >
+                  Каталог
+                </Link>
+                <Link
+                  href={profileHref}
+                  className="rounded-xl border px-3 py-2 text-center text-xs"
+                  style={{ borderColor: crew.theme.palette.borderSoft }}
+                >
+                  Профиль
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </div>
       </section>
       <CrewFooter crew={crew} />
     </main>

--- a/app/franchize/actions-runtime.ts
+++ b/app/franchize/actions-runtime.ts
@@ -108,6 +108,7 @@ export interface FranchizeCrewVM {
     email: string;
     address: string;
     telegram: string;
+    telegramBotUsername: string;
     workingHours: string;
     map: {
       id?: string;
@@ -495,6 +496,7 @@ const emptyCrew = (slug: string): FranchizeCrewVM => ({
     email: "",
     address: "",
     telegram: "",
+    telegramBotUsername: "oneBikePlsBot",
     workingHours: "",
     map: {
       gps: "",
@@ -665,6 +667,7 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
           readPath(franchize, ["footer", "address"], crew.hq_location ?? ""),
         ),
         telegram: readPath(franchize, ["contacts", "telegram"], ""),
+        telegramBotUsername: readPath(franchize, ["contacts", "telegramBotUsername"], "oneBikePlsBot"),
         workingHours: readPath(franchize, ["contacts", "workingHours"], ""),
         map: {
           gps: readPath(franchize, ["contacts", "map", "gps"], ""),

--- a/app/franchize/components/OrderPageClient.tsx
+++ b/app/franchize/components/OrderPageClient.tsx
@@ -12,6 +12,7 @@ import type { CatalogItemVM, FranchizeCrewVM } from "../actions";
 import { checkFranchizeCarsAvailability, createFranchizeOrderCheckout, validateFranchizePromoCode } from "../actions";
 import { useFranchizeCartLines } from "../hooks/useFranchizeCartLines";
 import { crewPaletteForSurface, focusRingOutlineStyle } from "../lib/theme";
+import { getTelegramHandleHref, getTelegramWebAppFallbackHref } from "../lib/telegram-links";
 import { getFranchizeFormPrefillAction } from "../profile-actions";
 
 interface OrderPageClientProps {
@@ -178,6 +179,11 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
   const saleLinesCount = useMemo(() => cartLines.filter((line) => line.saleAvailable).length, [cartLines]);
   const flowType: "rental" | "sale" | "mixed" = saleLinesCount === 0 ? "rental" : saleLinesCount === cartLines.length ? "sale" : "mixed";
   const flowLabel = flowType === "sale" ? "покупки" : flowType === "mixed" ? "аренды/покупки" : "аренды";
+  const catalogHref = `/franchize/${slug}`;
+  const profileHref = `/franchize/${slug}/profile`;
+  const contactsHref = `/franchize/${slug}/contacts`;
+  const telegramSupportHref = getTelegramHandleHref(crew.contacts.telegram);
+  const telegramWebAppFallbackHref = getTelegramWebAppFallbackHref("franchize", slug, crew.contacts.telegramBotUsername);
   const selectedExtraItems = useMemo(
     () => orderExtras.filter((extra) => selectedExtras.includes(extra.id)),
     [selectedExtras],
@@ -529,6 +535,54 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
       </p>
       <h1 className="mt-2 text-2xl font-semibold">Оформление заказа</h1>
 
+      <div className="mt-4 grid gap-3 rounded-3xl border p-4 text-sm md:grid-cols-[1.2fr_0.8fr]" style={surface.subtleCard}>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--order-accent)]">Что будет дальше</p>
+          <ol className="mt-3 space-y-2">
+            {[
+              `Проверим корзину, даты и контакт для ${flowLabel}.`,
+              payment === "telegram_xtr" ? "Передадим счёт в Telegram Stars и покажем резервный способ, если WebApp не открылся." : "Передадим заявку оператору: оплату подтвердим вручную до выдачи.",
+              "Оператор сверит договор, подготовку байка и точку выдачи без скрытых списаний.",
+            ].map((step, index) => (
+              <li key={step} className="flex gap-2">
+                <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--order-accent-soft)] text-[11px] font-semibold text-[var(--order-accent)]">{index + 1}</span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-3 rounded-2xl border border-[var(--order-border)] p-3 text-xs" style={surface.card}>
+            Безопасность оплаты и договора: сумма фиксируется в заявке, договор/чек проверяются до старта, спорные изменения подтверждаются только через оператора или Telegram.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <a
+            href={telegramSupportHref}
+            target="_blank"
+            rel="noreferrer"
+            className="flex w-full justify-center rounded-xl bg-[var(--order-accent)] px-3 py-2 text-center text-sm font-semibold text-[var(--order-accent-contrast)] transition hover:brightness-105 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+            style={focusRingOutlineStyle(crew.theme)}
+          >
+            Написать оператору в Telegram
+          </a>
+          <a
+            href={telegramWebAppFallbackHref}
+            target="_blank"
+            rel="noreferrer"
+            className="flex w-full justify-center rounded-xl border border-[var(--order-border)] px-3 py-2 text-center text-xs transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+            style={focusRingOutlineStyle(crew.theme)}
+          >
+            Открыть WebApp fallback
+          </a>
+          <Link href={contactsHref} className="flex w-full justify-center rounded-xl border border-[var(--order-border)] px-3 py-2 text-center text-xs transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" style={focusRingOutlineStyle(crew.theme)}>
+            Поддержка / контакты
+          </Link>
+          <div className="grid grid-cols-2 gap-2">
+            <Link href={catalogHref} className="rounded-xl border border-[var(--order-border)] px-3 py-2 text-center text-xs transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" style={focusRingOutlineStyle(crew.theme)}>Каталог</Link>
+            <Link href={profileHref} className="rounded-xl border border-[var(--order-border)] px-3 py-2 text-center text-xs transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" style={focusRingOutlineStyle(crew.theme)}>Профиль</Link>
+          </div>
+        </div>
+      </div>
+
       <div className="mt-4 flex items-center gap-2 text-xs" style={surface.mutedText}>
         {[
           ["1", "Корзина"],
@@ -839,13 +893,22 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
 
           {isCartEmpty ? (
             <div className="mt-3 rounded-xl border border-dashed p-3 text-sm" style={surface.subtleCard}>
-              <p>Корзина пуста — добавьте байк из каталога перед оформлением.</p>
-              <Link
-                href={`/franchize/${slug}`}
-                className="mt-3 inline-flex font-medium text-[var(--order-accent)] underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--order-accent)]"
-              >
-                Вернуться в каталог
-              </Link>
+              <p className="font-medium">Корзина пуста — заказ ещё некуда оформлять.</p>
+              <p className="mt-1 text-xs" style={surface.mutedText}>Вернитесь в каталог, выберите байк и пакет аренды/покупки. Если позиция пропала — напишите оператору, он подберёт замену.</p>
+              <div className="mt-3 flex flex-wrap gap-3">
+                <Link
+                  href={catalogHref}
+                  className="inline-flex font-medium text-[var(--order-accent)] underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--order-accent)]"
+                >
+                  Вернуться в каталог
+                </Link>
+                <Link
+                  href={profileHref}
+                  className="inline-flex font-medium text-[var(--order-accent)] underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--order-accent)]"
+                >
+                  Открыть профиль
+                </Link>
+              </div>
             </div>
           ) : (
             <ul className="mt-2 space-y-2 text-sm">
@@ -888,6 +951,9 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
             {submitLabel}
           </button>
           <p className="mt-2 text-xs" style={surface.mutedText}>{submitHint}</p>
+          <p className="mt-3 rounded-xl border border-[var(--order-border)] p-3 text-xs" style={surface.subtleCard}>
+            Если оплата или договор не открылись, не перезагружайте страницу: нажмите Telegram fallback выше или напишите в поддержку — оператор продолжит заявку по #{orderId}.
+          </p>
         </aside>
       </form>
     </section>

--- a/app/franchize/lib/telegram-links.ts
+++ b/app/franchize/lib/telegram-links.ts
@@ -1,0 +1,30 @@
+export const DEFAULT_TELEGRAM_BOT_USERNAME = "oneBikePlsBot";
+
+function sanitizeTelegramUsername(value?: string | null): string {
+  return String(value || "")
+    .trim()
+    .replace(/^@+/, "")
+    .replace(/[^a-zA-Z0-9_]/g, "");
+}
+
+export function getTelegramHandleHref(handle?: string | null): string {
+  const normalized =
+    sanitizeTelegramUsername(handle) || DEFAULT_TELEGRAM_BOT_USERNAME;
+
+  return `https://t.me/${normalized}`;
+}
+
+export function getTelegramWebAppFallbackHref(
+  prefix: string,
+  value: string,
+  botUsername?: string | null,
+): string {
+  const normalizedBot =
+    sanitizeTelegramUsername(botUsername) || DEFAULT_TELEGRAM_BOT_USERNAME;
+  const safePrefix =
+    prefix.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 24) || "franchize";
+  const safeValue =
+    value.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 40) || "open";
+
+  return `https://t.me/${normalizedBot}/app?startapp=${safePrefix}-${safeValue}`;
+}

--- a/docs/sql/sly13-franchize-test-hydration.sql
+++ b/docs/sql/sly13-franchize-test-hydration.sql
@@ -115,6 +115,7 @@ set
           'phone', '+7 9200-789-888',
           'email', 'sly13@cybervibe.local',
           'telegram', '@SALAVEY13',
+          'telegramBotUsername', 'oneBikePlsBot',
           'workingHours', 'Гибкий график по договорённости',
           'map', jsonb_build_object(
             'imageUrl', 'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/nnmap.jpg',

--- a/docs/sql/vip-bike-franchize-hydration.sql
+++ b/docs/sql/vip-bike-franchize-hydration.sql
@@ -186,6 +186,7 @@ set
           'phone', '+7 9200-789-888',
           'email', 'hello@vipbike-rental.example',
           'telegram', '@I_O_S_NN',
+          'telegramBotUsername', 'oneBikePlsBot',
           'workingHours', '10:00 - 22:00 (ежедневно)',
           'map', jsonb_build_object(
             'imageUrl', 'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/nnmap.jpg',

--- a/docs/sql/vip-cross-franchize-hydration.sql
+++ b/docs/sql/vip-cross-franchize-hydration.sql
@@ -178,6 +178,7 @@ set
           'phone', '+7 9200-789-999',
           'email', 'hello@vipcross-rental.example',
           'telegram', '@VIP_CROSS_NN',
+          'telegramBotUsername', 'oneBikePlsBot',
           'workingHours', '09:00 - 21:00 (ежедневно, сезон апрель-октябрь)',
           'map', jsonb_build_object(
             'imageUrl', 'https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/nnmap.jpg',


### PR DESCRIPTION
### Motivation
- Provide reliable Telegram deep-linking and WebApp fallback URLs and surface operator contact actions when orders/rentals/reviews or sale flows are unavailable or require manual operator confirmation.
- Expose franchize bot username in crew data so pages can construct proper t.me links and app fallback URLs.

### Description
- Add `app/franchize/lib/telegram-links.ts` with `getTelegramHandleHref` and `getTelegramWebAppFallbackHref` utilities and `DEFAULT_TELEGRAM_BOT_USERNAME` fallback.
- Extend `FranchizeCrewVM` to include `contacts.telegramBotUsername` and default/hydration values in `actions-runtime.ts` and SQL fixtures (`docs/sql/*_hydration.sql`).
- Update buy (`market/[bike_id]/buy`), rental (`rental/[id]`), review (`review/[rentalId]`) and order client (`components/OrderPageClient`) pages to use the new helpers and bot username, add contextual “What will happen next” side panels, Telegram support/fallback buttons and navigation shortcuts (catalog, profile, contacts), and improve copy when sale/rental/review is not available.
- Minor formatting and metadata tweaks across the modified pages and use of theme palette for new UI elements.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd18e1a3648324b697a676be9d83a4)