### PR TITLE
Add route CTA policy, conditional floating cart rendering and header safe-area styles

### DIFF
--- a/app/franchize/[slug]/about/page.tsx
+++ b/app/franchize/[slug]/about/page.tsx
@@ -21,6 +21,7 @@ import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
 import { FranchizeHero } from "../../components/FranchizeHero";
 import { FranchizePageShell } from "../../components/FranchizePageShell";
+import { getFranchizeRouteCtaPolicy } from "../../lib/route-cta-policy";
 import { buildFranchizeIntentLinks } from "../../lib/section-links";
 import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
@@ -140,6 +141,7 @@ export default async function FranchizeAboutPage({ params }: FranchizeAboutPageP
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
+  const ctaPolicy = getFranchizeRouteCtaPolicy("content");
   const resolvedSlug = crew.slug || slug;
   const activePath = `/franchize/${resolvedSlug}/about`;
   const brandName = crew.header.brandName || crew.name || "Экипаж OneBikePls";
@@ -182,7 +184,7 @@ export default async function FranchizeAboutPage({ params }: FranchizeAboutPageP
   ];
 
   return (
-    <main className="min-h-screen" style={surface.page}>
+    <main className={`min-h-screen ${ctaPolicy.pageBottomSafeAreaClassName}`} style={surface.page}>
       <CrewHeader
         crew={crew}
         activePath={activePath}

--- a/app/franchize/[slug]/cart/page.tsx
+++ b/app/franchize/[slug]/cart/page.tsx
@@ -3,7 +3,7 @@ import { getFranchizeBySlug } from "../../actions";
 import { CartPageClient } from "../../components/CartPageClient";
 import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
-import { FranchizeFloatingCart } from "../../components/FranchizeFloatingCart";
+import { getFranchizeRouteCtaPolicy } from "../../lib/route-cta-policy";
 import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
@@ -25,21 +25,13 @@ export default async function FranchizeCartPage({ params }: FranchizeCartPagePro
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
+  const ctaPolicy = getFranchizeRouteCtaPolicy("checkout");
 
   return (
-    <main className="min-h-screen" style={surface.page}>
+    <main className={`min-h-screen ${ctaPolicy.pageBottomSafeAreaClassName}`} style={surface.page}>
       <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/cart`} groupLinks={items.map((item) => item.category)} />
       <CartPageClient crew={crew} slug={crew.slug || slug} items={items} />
       <CrewFooter crew={crew} />
-      <FranchizeFloatingCart
-        slug={crew.slug || slug}
-        href={`/franchize/${crew.slug || slug}/cart`}
-        items={items}
-        accentColor={crew.theme.palette.accentMain}
-        textColor={crew.theme.palette.textPrimary}
-        borderColor={crew.theme.palette.borderSoft}
-        theme={crew.theme}
-      />
     </main>
   );
 }

--- a/app/franchize/[slug]/contacts/page.tsx
+++ b/app/franchize/[slug]/contacts/page.tsx
@@ -8,6 +8,7 @@ import { FranchizeFloatingCart } from "../../components/FranchizeFloatingCart";
 import { FranchizeHero } from "../../components/FranchizeHero";
 import { FranchizePageShell } from "../../components/FranchizePageShell";
 import { FranchizeContactsMap } from "../../components/FranchizeContactsMap";
+import { getFranchizeRouteCtaPolicy, shouldShowFloatingCart } from "../../lib/route-cta-policy";
 import { buildFranchizeIntentLinks } from "../../lib/section-links";
 import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
@@ -48,9 +49,11 @@ export default async function FranchizeContactsPage({ params }: FranchizeContact
   const directionsHref = directionsTarget
     ? `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(directionsTarget)}`
     : "";
+  const ctaPolicy = getFranchizeRouteCtaPolicy("contacts");
+  const showFloatingCart = shouldShowFloatingCart(ctaPolicy, { cartRelevant: false });
 
   return (
-    <main className="min-h-screen" style={surface.page}>
+    <main className={`min-h-screen ${ctaPolicy.pageBottomSafeAreaClassName}`} style={surface.page}>
       <CrewHeader crew={crew} activePath={activePath} groupLinks={items.map((item) => item.category)} sectionLinks={buildFranchizeIntentLinks(resolvedSlug, activePath)} />
 
       <FranchizePageShell theme={crew.theme}>
@@ -186,15 +189,18 @@ export default async function FranchizeContactsPage({ params }: FranchizeContact
       </FranchizePageShell>
 
       <CrewFooter crew={crew} />
-      <FranchizeFloatingCart
-        slug={resolvedSlug}
-        href={`/franchize/${resolvedSlug}/cart`}
-        items={items}
-        accentColor={crew.theme.palette.accentMain}
-        textColor={crew.theme.palette.textPrimary}
-        borderColor={crew.theme.palette.borderSoft}
-        theme={crew.theme}
-      />
+      {showFloatingCart && (
+        <FranchizeFloatingCart
+          slug={resolvedSlug}
+          href={`/franchize/${resolvedSlug}/cart`}
+          items={items}
+          accentColor={crew.theme.palette.accentMain}
+          textColor={crew.theme.palette.textPrimary}
+          borderColor={crew.theme.palette.borderSoft}
+          theme={crew.theme}
+          className={ctaPolicy.floatingCartClassName}
+        />
+      )}
     </main>
   );
 }

--- a/app/franchize/[slug]/map-riders/page.tsx
+++ b/app/franchize/[slug]/map-riders/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
+import { getFranchizeRouteCtaPolicy } from "@/app/franchize/lib/route-cta-policy";
 import { buildFranchizeIntentLinks } from "@/app/franchize/lib/section-links";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import dynamic from "next/dynamic";
@@ -28,9 +29,10 @@ export default async function MapRidersPage({ params }: { params: Promise<{ slug
   const crewSlug = crew.slug || slug;
   const activePath = `/franchize/${crewSlug}/map-riders`;
   const surface = crewPaletteForSurface(crew.theme);
+  const ctaPolicy = getFranchizeRouteCtaPolicy("map-riders");
 
   return (
-    <main className="min-h-screen" style={surface.page}>
+    <main className={`min-h-screen ${ctaPolicy.pageBottomSafeAreaClassName}`} style={surface.page}>
       <CrewHeader crew={crew} activePath={activePath} sectionLinks={buildFranchizeIntentLinks(crewSlug, activePath)} />
       <MapRidersClient crew={crew} slug={crewSlug} />
       <CrewFooter crew={crew} />

--- a/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
+++ b/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
@@ -11,6 +11,7 @@ import {
   getTelegramHandleHref,
   getTelegramWebAppFallbackHref,
 } from "@/app/franchize/lib/telegram-links";
+import { getFranchizeRouteCtaPolicy, shouldShowFloatingCart } from "@/app/franchize/lib/route-cta-policy";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { SaleBikeLanding } from "@/app/franchize/components/SaleBikeLanding";
 import { isSameCatalogPropulsion } from "@/app/franchize/lib/catalog-propulsion";
@@ -75,6 +76,7 @@ export default async function BuyBikePage({
   const { crew, items } = await getFranchizeBySlug(slug);
   const resolvedSlug = crew.slug || slug;
   const surface = crewPaletteForSurface(crew.theme);
+  const ctaPolicy = getFranchizeRouteCtaPolicy("product-buy");
   const item = items.find((candidate) => candidate.id === bike_id);
   const contactHref = `/franchize/${resolvedSlug}/contacts`;
   const catalogHref = `/franchize/${resolvedSlug}`;
@@ -87,7 +89,7 @@ export default async function BuyBikePage({
   if (!item.saleAvailable && !isSaleEnabled(item.rawSpecs?.sale)) {
     return (
       <main
-        className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center gap-4 p-6 text-center"
+          className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center gap-4 p-6 text-center"
         style={surface.page}
       >
         <h1 className="text-2xl font-semibold">
@@ -133,6 +135,8 @@ export default async function BuyBikePage({
     );
   }
 
+  const showFloatingCart = shouldShowFloatingCart(ctaPolicy, { cartRelevant: true, hasItemContext: true });
+
   const otherSaleBikes = items.filter(
     (candidate) =>
       candidate.id !== item.id &&
@@ -144,7 +148,7 @@ export default async function BuyBikePage({
     : null;
 
   return (
-    <main className="min-h-screen" style={surface.page}>
+    <main className={`min-h-screen ${ctaPolicy.pageBottomSafeAreaClassName}`} style={surface.page}>
       <CrewHeader
         crew={crew}
         activePath={`/franchize/${resolvedSlug}/market/${bike_id}/buy`}
@@ -264,15 +268,18 @@ export default async function BuyBikePage({
         otherSaleBikes={otherSaleBikes}
       />
       <CrewFooter crew={crew} />
-      <FranchizeFloatingCart
-        slug={resolvedSlug}
-        href={`/franchize/${resolvedSlug}/cart`}
-        items={items}
-        accentColor={crew.theme.palette.accentMain}
-        textColor={crew.theme.palette.textPrimary}
-        borderColor={crew.theme.palette.borderSoft}
-        theme={crew.theme}
-      />
+      {showFloatingCart && (
+        <FranchizeFloatingCart
+          slug={resolvedSlug}
+          href={`/franchize/${resolvedSlug}/cart`}
+          items={items}
+          accentColor={crew.theme.palette.accentMain}
+          textColor={crew.theme.palette.textPrimary}
+          borderColor={crew.theme.palette.borderSoft}
+          theme={crew.theme}
+          className={ctaPolicy.floatingCartClassName}
+        />
+      )}
     </main>
   );
 }

--- a/app/franchize/[slug]/order/[id]/page.tsx
+++ b/app/franchize/[slug]/order/[id]/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import { getFranchizeBySlug } from "../../../actions";
 import { CrewFooter } from "../../../components/CrewFooter";
 import { CrewHeader } from "../../../components/CrewHeader";
-import { FranchizeFloatingCart } from "../../../components/FranchizeFloatingCart";
 import { OrderPageClient } from "../../../components/OrderPageClient";
+import { getFranchizeRouteCtaPolicy } from "../../../lib/route-cta-policy";
 import { crewPaletteForSurface } from "../../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../../metadata";
 
@@ -25,21 +25,13 @@ export default async function FranchizeOrderPage({ params }: FranchizeOrderPageP
   const { slug, id } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
+  const ctaPolicy = getFranchizeRouteCtaPolicy("order");
 
   return (
-    <main className="min-h-screen" style={surface.page}>
+    <main className={`min-h-screen ${ctaPolicy.pageBottomSafeAreaClassName}`} style={surface.page}>
       <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/order/${id}`} groupLinks={items.map((item) => item.category)} />
       <OrderPageClient crew={crew} slug={crew.slug || slug} orderId={id} items={items} />
       <CrewFooter crew={crew} />
-      <FranchizeFloatingCart
-        slug={crew.slug || slug}
-        href={`/franchize/${crew.slug || slug}/cart`}
-        items={items}
-        accentColor={crew.theme.palette.accentMain}
-        textColor={crew.theme.palette.textPrimary}
-        borderColor={crew.theme.palette.borderSoft}
-        theme={crew.theme}
-      />
     </main>
   );
 }

--- a/app/franchize/[slug]/page.tsx
+++ b/app/franchize/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { CrewHeader } from "../components/CrewHeader";
 import { CatalogClient } from "../components/CatalogClient";
 import { FranchizeErrorBoundary } from "../components/ErrorBoundary";
 import { getFranchizeBySlug } from "../actions";
+import { getFranchizeRouteCtaPolicy } from "../lib/route-cta-policy";
 import { crewPaletteForSurface } from "../lib/theme";
 
 interface FranchizeSlugPageProps {
@@ -13,9 +14,10 @@ export default async function FranchizeSlugPage({ params }: FranchizeSlugPagePro
   const { slug } = await params;
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
+  const ctaPolicy = getFranchizeRouteCtaPolicy("catalog");
 
   return (
-    <main className="min-h-screen" style={surface.page}>
+    <main className={`min-h-screen ${ctaPolicy.pageBottomSafeAreaClassName}`} style={surface.page}>
       <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}`} groupLinks={items.map((item) => item.category)} />
       <FranchizeErrorBoundary
         resetKey={slug}
@@ -23,7 +25,7 @@ export default async function FranchizeSlugPage({ params }: FranchizeSlugPagePro
         fallbackHref={`/franchize/${crew.slug || slug}`}
         fallbackLinkLabel="Обновить каталог экипажа"
       >
-        <CatalogClient crew={crew} slug={slug} items={items} />
+        <CatalogClient crew={crew} slug={slug} items={items} ctaPolicy={ctaPolicy} />
       </FranchizeErrorBoundary>
       <CrewFooter crew={crew} />
     </main>

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -6,6 +6,8 @@ import { useSearchParams } from "next/navigation";
 import { ShoppingCart } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toCategoryId } from "../lib/navigation";
+import type { FranchizeRouteCtaPolicy } from "../lib/route-cta-policy";
+import { shouldShowFloatingCart } from "../lib/route-cta-policy";
 import { catalogCardVariantStyles, crewPaletteForSurface, interactionRingStyle } from "../lib/theme";
 import type { CatalogItemVM, FranchizeCrewVM } from "../actions";
 import { FloatingCartIconLinkBySlug } from "./FloatingCartIconLinkBySlug";
@@ -17,6 +19,7 @@ interface CatalogClientProps {
   slug: string;
   items: CatalogItemVM[];
   mode?: "rental" | "electro";
+  ctaPolicy?: FranchizeRouteCtaPolicy;
 }
 
 type QuickFilterKey = "all" | "budget" | "premium" | "newbie" | "topRated";
@@ -55,7 +58,7 @@ function CatalogCardSkeleton({ index }: { index: number }) {
   );
 }
 
-export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogClientProps) {
+export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }: CatalogClientProps) {
   const surface = crewPaletteForSurface(crew.theme);
   const [selectedItem, setSelectedItem] = useState<CatalogItemVM | null>(null);
   const { addItem } = useFranchizeCart(crew.slug || slug);
@@ -68,6 +71,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
   const [quickFilter, setQuickFilter] = useState<QuickFilterKey>("all");
   const [campaignIndex, setCampaignIndex] = useState(0);
   const searchParams = useSearchParams();
+  const showFloatingCart = ctaPolicy ? shouldShowFloatingCart(ctaPolicy, { cartRelevant: true }) : true;
 
   const promoModules = useMemo(() => {
     const now = Date.now();
@@ -530,7 +534,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
       </section>
 
       {/* 🛒 Floating Cart: Hide when modal is open to avoid z-index overlap */}
-      {!selectedItem && (
+      {!selectedItem && showFloatingCart && (
         <FloatingCartIconLinkBySlug
           slug={crew.slug || slug}
           href={`/franchize/${crew.slug || slug}/cart`}
@@ -539,6 +543,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental" }: CatalogCli
           textColor={crew.theme.palette.textPrimary}
           borderColor={crew.theme.palette.borderSoft}
           theme={crew.theme}
+          className={ctaPolicy?.floatingCartClassName}
         />
       )}
 

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -10,6 +10,7 @@ import type { FranchizeCrewVM } from "../actions";
 import { HeaderMenu } from "../modals/HeaderMenu";
 import { FranchizeProfileButton } from "./FranchizeProfileButton";
 import { toCategoryId } from "../lib/navigation";
+import { FRANCHIZE_HEADER_CORNER_GUARD_STYLE, FRANCHIZE_HEADER_SAFE_AREA_STYLE } from "../lib/route-cta-policy";
 import type { FranchizeSectionLink } from "../lib/section-links";
 
 interface CrewHeaderProps {
@@ -162,8 +163,9 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
 
   return (
     <header
-      className="sticky top-0 z-50 border-b px-4 pb-2 pt-[max(env(safe-area-inset-top),0.2rem)] backdrop-blur-2xl"
+      className="sticky top-0 z-50 border-b pb-2 backdrop-blur-2xl"
       style={{
+        ...FRANCHIZE_HEADER_SAFE_AREA_STYLE,
         borderColor: crew.theme.palette.borderSoft,
         backgroundColor: `${crew.theme.palette.bgCard}F0`,
         color: crew.theme.palette.textPrimary,
@@ -172,6 +174,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
       <div className="mx-auto w-full max-w-7xl overflow-hidden">
         <div
           style={{
+            ...FRANCHIZE_HEADER_CORNER_GUARD_STYLE,
             display: "grid",
             gridTemplateColumns: "44px 1fr auto",
             alignItems: "center",
@@ -179,7 +182,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
             maxHeight: isCompact ? 0 : 112,
             opacity: isCompact ? 0 : 1,
             paddingBottom: isCompact ? 0 : "0.5rem",
-            transform: isCompact ? "scaleY(0.85) translateY(-8px)" : "scaleY(1) translateY(0)",
+            transform: isCompact ? "scaleY(0.85) translateY(-6px)" : "scaleY(1) translateY(0.15rem)",
             transformOrigin: "top center",
             transition: "transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease, padding 0.3s ease, max-height 0.32s ease",
             pointerEvents: "auto",

--- a/app/franchize/components/FloatingCartIconLink.tsx
+++ b/app/franchize/components/FloatingCartIconLink.tsx
@@ -11,14 +11,15 @@ interface FloatingCartIconLinkProps {
   textColor: string;
   borderColor: string;
   backgroundColor: string;
+  className?: string;
 }
 
-export function FloatingCartIconLink({ href, itemCount, totalPrice, accentColor, textColor, borderColor, backgroundColor }: FloatingCartIconLinkProps) {
+export function FloatingCartIconLink({ href, itemCount, totalPrice, accentColor, textColor, borderColor, backgroundColor, className }: FloatingCartIconLinkProps) {
   const isCartEmpty = itemCount === 0;
 
   return (
     <div
-      className="fixed bottom-24 right-4 z-[60] flex items-center gap-3"
+      className={className ?? "fixed bottom-[calc(6rem+env(safe-area-inset-bottom))] right-4 z-[60] flex items-center gap-3"}
       style={{
         ["--floating-cart-accent" as string]: accentColor,
         ["--floating-cart-border" as string]: borderColor,

--- a/app/franchize/components/FloatingCartIconLinkBySlug.tsx
+++ b/app/franchize/components/FloatingCartIconLinkBySlug.tsx
@@ -13,9 +13,10 @@ interface FloatingCartIconLinkBySlugProps {
   textColor: string;
   borderColor: string;
   theme: FranchizeTheme;
+  className?: string;
 }
 
-export function FloatingCartIconLinkBySlug({ slug, href, items, accentColor, textColor, borderColor, theme }: FloatingCartIconLinkBySlugProps) {
+export function FloatingCartIconLinkBySlug({ slug, href, items, accentColor, textColor, borderColor, theme, className }: FloatingCartIconLinkBySlugProps) {
   const { itemCount, subtotal } = useFranchizeCartLines(slug, items);
 
   return (
@@ -27,6 +28,7 @@ export function FloatingCartIconLinkBySlug({ slug, href, items, accentColor, tex
       textColor={textColor}
       borderColor={borderColor}
       backgroundColor={floatingCartOverlayBackground(theme)}
+      className={className}
     />
   );
 }

--- a/app/franchize/components/FranchizeFloatingCart.tsx
+++ b/app/franchize/components/FranchizeFloatingCart.tsx
@@ -11,9 +11,10 @@ interface FranchizeFloatingCartProps {
   textColor: string;
   borderColor: string;
   theme: FranchizeTheme;
+  className?: string;
 }
 
-export function FranchizeFloatingCart({ slug, href, items, accentColor, textColor, borderColor, theme }: FranchizeFloatingCartProps) {
+export function FranchizeFloatingCart({ slug, href, items, accentColor, textColor, borderColor, theme, className }: FranchizeFloatingCartProps) {
   return (
     <FloatingCartIconLinkBySlug
       slug={slug}
@@ -23,6 +24,7 @@ export function FranchizeFloatingCart({ slug, href, items, accentColor, textColo
       textColor={textColor}
       borderColor={borderColor}
       theme={theme}
+      className={className}
     />
   );
 }

--- a/app/franchize/lib/route-cta-policy.ts
+++ b/app/franchize/lib/route-cta-policy.ts
@@ -1,0 +1,145 @@
+export type FranchizeRoutePageIntent =
+  | "catalog"
+  | "product-buy"
+  | "content"
+  | "contacts"
+  | "checkout"
+  | "order"
+  | "rental"
+  | "map-riders";
+
+export type FranchizeRouteCtaPriority =
+  | "cart"
+  | "continue-contact"
+  | "contact"
+  | "form-lifecycle"
+  | "map-controls"
+  | "content";
+
+export type FloatingCartMode = "enabled" | "if-cart-relevant" | "if-item-context" | "optional" | "disabled";
+
+export interface FranchizeRouteCtaPolicy {
+  intent: FranchizeRoutePageIntent;
+  priority: FranchizeRouteCtaPriority;
+  floatingCartMode: FloatingCartMode;
+  /** Padding for Telegram WebApp / mobile bottom bars when the route has bottom CTAs or form actions. */
+  pageBottomSafeAreaClassName: string;
+  /** Padding for Telegram WebApp / mobile top bars when a route renders sticky chrome. */
+  pageTopSafeAreaClassName: string;
+  /** Fixed overlay placement that stays above iOS/Telegram bottom safe areas. */
+  floatingCartClassName: string;
+  /** Routes with forms, lifecycle actions, or maps should not receive bottom overlays. */
+  avoidBottomOverlays: boolean;
+}
+
+export interface FloatingCartVisibilityContext {
+  hasItemContext?: boolean;
+  cartRelevant?: boolean;
+}
+
+const TELEGRAM_TOP_SAFE_AREA_CLASS = "pt-[calc(0.5rem+env(safe-area-inset-top))]";
+const TELEGRAM_BOTTOM_SAFE_AREA_CLASS = "pb-[calc(1.5rem+env(safe-area-inset-bottom))]";
+const TELEGRAM_FORM_BOTTOM_SAFE_AREA_CLASS = "pb-[calc(2rem+env(safe-area-inset-bottom))]";
+
+export const FRANCHIZE_HEADER_SAFE_AREA_STYLE = {
+  paddingTop: "calc(max(env(safe-area-inset-top), 0px) + 0.55rem)",
+  paddingLeft: "calc(max(env(safe-area-inset-left), 0px) + 1rem)",
+  paddingRight: "calc(max(env(safe-area-inset-right), 0px) + 1rem)",
+} as const;
+
+export const FRANCHIZE_HEADER_CORNER_GUARD_STYLE = {
+  paddingInline: "clamp(0.25rem, max(env(safe-area-inset-left), env(safe-area-inset-right)), 1.25rem)",
+} as const;
+
+export const FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS =
+  "fixed bottom-[calc(6rem+env(safe-area-inset-bottom))] right-4 z-[60] flex items-center gap-3";
+
+const policiesByIntent: Record<FranchizeRoutePageIntent, Omit<FranchizeRouteCtaPolicy, "intent">> = {
+  catalog: {
+    priority: "cart",
+    floatingCartMode: "enabled",
+    pageBottomSafeAreaClassName: TELEGRAM_BOTTOM_SAFE_AREA_CLASS,
+    pageTopSafeAreaClassName: TELEGRAM_TOP_SAFE_AREA_CLASS,
+    floatingCartClassName: FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS,
+    avoidBottomOverlays: false,
+  },
+  "product-buy": {
+    priority: "continue-contact",
+    floatingCartMode: "if-cart-relevant",
+    pageBottomSafeAreaClassName: TELEGRAM_BOTTOM_SAFE_AREA_CLASS,
+    pageTopSafeAreaClassName: TELEGRAM_TOP_SAFE_AREA_CLASS,
+    floatingCartClassName: FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS,
+    avoidBottomOverlays: false,
+  },
+  content: {
+    priority: "content",
+    floatingCartMode: "if-item-context",
+    pageBottomSafeAreaClassName: TELEGRAM_BOTTOM_SAFE_AREA_CLASS,
+    pageTopSafeAreaClassName: TELEGRAM_TOP_SAFE_AREA_CLASS,
+    floatingCartClassName: FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS,
+    avoidBottomOverlays: false,
+  },
+  contacts: {
+    priority: "contact",
+    floatingCartMode: "optional",
+    pageBottomSafeAreaClassName: TELEGRAM_BOTTOM_SAFE_AREA_CLASS,
+    pageTopSafeAreaClassName: TELEGRAM_TOP_SAFE_AREA_CLASS,
+    floatingCartClassName: FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS,
+    avoidBottomOverlays: false,
+  },
+  checkout: {
+    priority: "form-lifecycle",
+    floatingCartMode: "disabled",
+    pageBottomSafeAreaClassName: TELEGRAM_FORM_BOTTOM_SAFE_AREA_CLASS,
+    pageTopSafeAreaClassName: TELEGRAM_TOP_SAFE_AREA_CLASS,
+    floatingCartClassName: FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS,
+    avoidBottomOverlays: true,
+  },
+  order: {
+    priority: "form-lifecycle",
+    floatingCartMode: "disabled",
+    pageBottomSafeAreaClassName: TELEGRAM_FORM_BOTTOM_SAFE_AREA_CLASS,
+    pageTopSafeAreaClassName: TELEGRAM_TOP_SAFE_AREA_CLASS,
+    floatingCartClassName: FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS,
+    avoidBottomOverlays: true,
+  },
+  rental: {
+    priority: "form-lifecycle",
+    floatingCartMode: "disabled",
+    pageBottomSafeAreaClassName: TELEGRAM_FORM_BOTTOM_SAFE_AREA_CLASS,
+    pageTopSafeAreaClassName: TELEGRAM_TOP_SAFE_AREA_CLASS,
+    floatingCartClassName: FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS,
+    avoidBottomOverlays: true,
+  },
+  "map-riders": {
+    priority: "map-controls",
+    floatingCartMode: "disabled",
+    pageBottomSafeAreaClassName: TELEGRAM_FORM_BOTTOM_SAFE_AREA_CLASS,
+    pageTopSafeAreaClassName: TELEGRAM_TOP_SAFE_AREA_CLASS,
+    floatingCartClassName: FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS,
+    avoidBottomOverlays: true,
+  },
+};
+
+export function getFranchizeRouteCtaPolicy(intent: FranchizeRoutePageIntent): FranchizeRouteCtaPolicy {
+  return { intent, ...policiesByIntent[intent] };
+}
+
+export function shouldShowFloatingCart(
+  policy: FranchizeRouteCtaPolicy,
+  context: FloatingCartVisibilityContext = {},
+) {
+  switch (policy.floatingCartMode) {
+    case "enabled":
+      return true;
+    case "if-cart-relevant":
+      return Boolean(context.cartRelevant || context.hasItemContext);
+    case "if-item-context":
+      return Boolean(context.hasItemContext);
+    case "optional":
+      return Boolean(context.cartRelevant);
+    case "disabled":
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
### Motivation
- Centralize route-specific CTA and floating cart behavior to ensure consistent UI rules across franchize pages. 
- Prevent bottom overlays and floating cart conflicts on routes with forms, maps or lifecycle actions (checkout, order, rental, map). 
- Provide safe-area and corner-guard styling for the sticky header to improve appearance in mobile / Telegram WebApp contexts.

### Description
- Added a new policy module `app/franchize/lib/route-cta-policy.ts` that defines `FranchizeRouteCtaPolicy`, route intents, floating cart modes, safe-area classes and helper functions `getFranchizeRouteCtaPolicy` and `shouldShowFloatingCart`.
- Integrated `getFranchizeRouteCtaPolicy` into multiple pages and applied `ctaPolicy.pageBottomSafeAreaClassName` to the `<main>` container so pages respect mobile/Telegram bottom safe area paddings.
- Made floating cart components accept a `className` prop and switched to conditional rendering with `shouldShowFloatingCart(ctaPolicy, ...)` on pages and in `CatalogClient`, passing `ctaPolicy.floatingCartClassName` when shown.
- Added `FRANCHIZE_HEADER_SAFE_AREA_STYLE` and `FRANCHIZE_HEADER_CORNER_GUARD_STYLE` from the policy module and applied them in `CrewHeader` while slightly adjusting header transform/spacing for compact mode.

### Testing
- Ran TypeScript type check with `tsc --noEmit` and the codebase type checks succeeded. 
- Executed the test suite with `pnpm test` and all automated tests passed. 
- Performed a Next.js production build with `next build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd1ddf041083249a9c438fad61d952)