### PR TITLE
Introduce palette contrast helpers and migrate franchize pages/components to CSS palette variables

### DIFF
--- a/app/franchize/[slug]/community/page.tsx
+++ b/app/franchize/[slug]/community/page.tsx
@@ -5,7 +5,7 @@ import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
 import { buildFranchizeIntentLinks } from "@/app/franchize/lib/section-links";
-import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { crewPaletteForSurface, readablePaletteTextOnColor, withAlpha } from "@/app/franchize/lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
 
@@ -28,48 +28,55 @@ export default async function FranchizeCommunityPage({ params }: { params: Promi
   const brandName = crew.header.brandName || crew.name || "VIP BIKE";
   const telegramHref = crew.contacts.telegram ? `https://t.me/${crew.contacts.telegram.replace("@", "")}` : "https://t.me/oneBikePlsBot";
   const { communityEvents, partnerCards, cityRiderTips } = crew.contentBlocks;
+  const accentText = readablePaletteTextOnColor(crew.theme.palette.accentMain, crew.theme.palette);
 
   return (
     <main className="min-h-screen" style={surface.page}>
       <CrewHeader crew={crew} activePath={activePath} sectionLinks={buildFranchizeIntentLinks(crewSlug, activePath)} />
 
       <div
-        className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-16 pt-20 text-white md:pt-24"
+        className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-16 pt-20 text-[var(--community-text)] md:pt-24"
         style={{
           ["--community-accent" as string]: crew.theme.palette.accentMain,
           ["--community-border" as string]: crew.theme.palette.borderSoft,
           ["--community-card" as string]: surface.subtleCard.backgroundColor,
+          ["--community-base-soft" as string]: withAlpha(crew.theme.palette.bgBase, 0.35),
+          ["--community-card-soft" as string]: withAlpha(crew.theme.palette.bgCard, 0.86),
+          ["--community-card-faint" as string]: withAlpha(crew.theme.palette.bgCard, 0.54),
+          ["--community-text" as string]: crew.theme.palette.textPrimary,
+          ["--community-muted" as string]: crew.theme.palette.textSecondary,
+          ["--community-accent-text" as string]: accentText,
           color: crew.theme.palette.textPrimary,
         }}
       >
-        <section className="overflow-hidden rounded-3xl border border-[var(--community-border)] bg-black/40 p-6 shadow-2xl shadow-black/25 backdrop-blur-xl md:p-8">
+        <section className="overflow-hidden rounded-3xl border border-[var(--community-border)] bg-[var(--community-card-soft)] p-6 shadow-2xl backdrop-blur-xl md:p-8">
           <div className="grid gap-8 lg:grid-cols-[1.2fr,0.8fr] lg:items-end">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--community-accent)]">FRZ-R9 • community hub</p>
               <h1 className="mt-4 font-orbitron text-4xl leading-tight md:text-6xl">
                 Куда ехать с {brandName} прямо сейчас
               </h1>
-              <p className="mt-4 max-w-2xl text-base text-white/68 md:text-lg">
+              <p className="mt-4 max-w-2xl text-base text-[var(--community-muted)] md:text-lg">
                 События, партнёры и понятные городские сценарии для тех, кто открыл MapRiders и спросил: «а что мне реально делать?»
               </p>
               <div className="mt-6 flex flex-wrap gap-3">
-                <Link href={`/franchize/${crewSlug}/map-riders`} className="rounded-full bg-[var(--community-accent)] px-5 py-3 text-sm font-semibold text-black transition hover:brightness-110">
+                <Link href={`/franchize/${crewSlug}/map-riders`} className="rounded-full bg-[var(--community-accent)] px-5 py-3 text-sm font-semibold text-[var(--community-accent-text)] transition hover:brightness-110">
                   Открыть live-карту
                 </Link>
-                <a href={telegramHref} target="_blank" rel="noreferrer" className="rounded-full border border-white/15 px-5 py-3 text-sm font-semibold text-white transition hover:border-white/40">
+                <a href={telegramHref} target="_blank" rel="noreferrer" className="rounded-full border border-[var(--community-border)] px-5 py-3 text-sm font-semibold text-[var(--community-text)] transition hover:border-[var(--community-accent)]">
                   Написать экипажу
                 </a>
               </div>
             </div>
-            <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+            <div className="rounded-3xl border border-[var(--community-border)] bg-[var(--community-card-faint)] p-5">
               <div className="flex items-center gap-3 text-[var(--community-accent)]">
                 <UsersRound className="h-5 w-5" />
                 <span className="text-sm font-semibold uppercase tracking-[0.16em]">как это работает</span>
               </div>
-              <ol className="mt-4 space-y-3 text-sm text-white/70">
-                <li><span className="text-white">1.</span> Проходишь быстрый quiz на MapRiders.</li>
-                <li><span className="text-white">2.</span> Включаешь геошеринг с приватностью экипажа.</li>
-                <li><span className="text-white">3.</span> Едешь к событию или meetup-пину без хаоса.</li>
+              <ol className="mt-4 space-y-3 text-sm text-[var(--community-muted)]">
+                <li><span className="text-[var(--community-text)]">1.</span> Проходишь быстрый quiz на MapRiders.</li>
+                <li><span className="text-[var(--community-text)]">2.</span> Включаешь геошеринг с приватностью экипажа.</li>
+                <li><span className="text-[var(--community-text)]">3.</span> Едешь к событию или meetup-пину без хаоса.</li>
               </ol>
             </div>
           </div>
@@ -77,25 +84,25 @@ export default async function FranchizeCommunityPage({ params }: { params: Promi
 
         <section className="grid gap-4 md:grid-cols-3">
           {communityEvents.map((event) => (
-            <article key={event.title} className="rounded-3xl border border-white/10 bg-white/[0.04] p-5 backdrop-blur-xl">
+            <article key={event.title} className="rounded-3xl border border-[var(--community-border)] bg-[var(--community-card-faint)] p-5 backdrop-blur-xl">
               <CalendarDays className="h-6 w-6 text-[var(--community-accent)]" />
-              <p className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-white/45">{event.time}</p>
-              <h2 className="mt-2 text-xl font-semibold text-white">{event.title}</h2>
+              <p className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--community-muted)] opacity-70">{event.time}</p>
+              <h2 className="mt-2 text-xl font-semibold text-[var(--community-text)]">{event.title}</h2>
               <p className="mt-1 text-sm text-[var(--community-accent)]">{event.place}</p>
-              <p className="mt-3 text-sm leading-6 text-white/62">{event.text}</p>
+              <p className="mt-3 text-sm leading-6 text-[var(--community-muted)]">{event.text}</p>
             </article>
           ))}
         </section>
 
         <section className="grid gap-4 lg:grid-cols-[0.9fr,1.1fr]">
-          <div className="rounded-3xl border border-white/10 bg-black/35 p-6">
+          <div className="rounded-3xl border border-[var(--community-border)] bg-[var(--community-base-soft)] p-6">
             <div className="flex items-center gap-3 text-[var(--community-accent)]">
               <MapPinned className="h-6 w-6" />
-              <h2 className="font-orbitron text-2xl text-white">Городской riding-гайд</h2>
+              <h2 className="font-orbitron text-2xl text-[var(--community-text)]">Городской riding-гайд</h2>
             </div>
-            <ul className="mt-5 space-y-3 text-sm text-white/68">
+            <ul className="mt-5 space-y-3 text-sm text-[var(--community-muted)]">
               {cityRiderTips.map((tip) => (
-                <li key={tip.text} className="flex gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-3">
+                <li key={tip.text} className="flex gap-3 rounded-2xl border border-[var(--community-border)] bg-[var(--community-card-faint)] p-3">
                   <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-[var(--community-accent)]" />
                   <span>{tip.text}</span>
                 </li>
@@ -103,19 +110,19 @@ export default async function FranchizeCommunityPage({ params }: { params: Promi
             </ul>
           </div>
 
-          <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
+          <div className="rounded-3xl border border-[var(--community-border)] bg-[var(--community-card-faint)] p-6">
             <div className="flex items-center gap-3 text-[var(--community-accent)]">
               <Handshake className="h-6 w-6" />
-              <h2 className="font-orbitron text-2xl text-white">Партнёры экипажа</h2>
+              <h2 className="font-orbitron text-2xl text-[var(--community-text)]">Партнёры экипажа</h2>
             </div>
             <div className="mt-5 grid gap-3">
               {partnerCards.map((partner) => (
-                <article key={partner.name} className="rounded-2xl border border-white/10 bg-black/25 p-4">
+                <article key={partner.name} className="rounded-2xl border border-[var(--community-border)] bg-[var(--community-base-soft)] p-4">
                   <div className="flex flex-wrap items-center justify-between gap-2">
-                    <h3 className="font-semibold text-white">{partner.name}</h3>
+                    <h3 className="font-semibold text-[var(--community-text)]">{partner.name}</h3>
                     <span className="rounded-full border border-[var(--community-accent)]/35 bg-[var(--community-accent)]/10 px-3 py-1 text-xs text-[var(--community-accent)]">{partner.role}</span>
                   </div>
-                  <p className="mt-2 text-sm text-white/62">{partner.perk}</p>
+                  <p className="mt-2 text-sm text-[var(--community-muted)]">{partner.perk}</p>
                 </article>
               ))}
             </div>

--- a/app/franchize/[slug]/electro-enduro/page.tsx
+++ b/app/franchize/[slug]/electro-enduro/page.tsx
@@ -3,7 +3,7 @@ import { CrewFooter } from "../../components/CrewFooter";
 import { CrewHeader } from "../../components/CrewHeader";
 import { CatalogClient } from "../../components/CatalogClient";
 import { type CatalogItemVM, getFranchizeBySlug } from "../../actions";
-import { crewPaletteForSurface } from "../../lib/theme";
+import { crewPaletteForSurface, readablePaletteTextOnColor, withAlpha } from "../../lib/theme";
 import Link from "next/link";
 import { fallbackBikes } from "../configurator/fallback-catalog";
 import { buildFranchizeSectionMetadata } from "../metadata";
@@ -130,6 +130,7 @@ export default async function ElectroEnduroPage({
     ? configuratorFallbackItems()
     : hydrated.items;
   const surface = crewPaletteForSurface(crew.theme);
+  const accentText = readablePaletteTextOnColor(crew.theme.palette.accentMain, crew.theme.palette);
   const saleItems = items.filter((item) => {
     const id = item.id.toLowerCase();
     return (
@@ -174,29 +175,43 @@ export default async function ElectroEnduroPage({
   ).slice(0, 8);
 
   return (
-    <main className="min-h-screen" style={surface.page}>
+    <main
+      className="min-h-screen text-[var(--enduro-text)]"
+      style={{
+        ...surface.page,
+        ["--enduro-accent" as string]: crew.theme.palette.accentMain,
+        ["--enduro-accent-text" as string]: accentText,
+        ["--enduro-border" as string]: crew.theme.palette.borderSoft,
+        ["--enduro-text" as string]: crew.theme.palette.textPrimary,
+        ["--enduro-muted" as string]: crew.theme.palette.textSecondary,
+        ["--enduro-card" as string]: surface.subtleCard.backgroundColor,
+        ["--enduro-card-faint" as string]: withAlpha(crew.theme.palette.bgCard, 0.7),
+        ["--enduro-card-soft" as string]: withAlpha(crew.theme.palette.bgCard, 0.48),
+        ["--enduro-accent-faint" as string]: withAlpha(crew.theme.palette.accentMain, 0.12),
+      }}
+    >
       <CrewHeader
         crew={crew}
         activePath={`/franchize/${crew.slug || slug}/electro-enduro`}
         groupLinks={saleItems.map((item) => item.category)}
       />
       <section className="mx-auto w-full max-w-7xl px-4 pt-6 2xl:max-w-[1600px]">
-        <div className="rounded-3xl border border-white/15 bg-black/30 p-5 backdrop-blur-sm sm:p-8">
-          <p className="text-xs uppercase tracking-[0.18em] text-white/60">
+        <div className="rounded-3xl border border-[var(--enduro-border)] bg-[var(--enduro-card)] p-5 backdrop-blur-sm sm:p-8">
+          <p className="text-xs uppercase tracking-[0.18em] text-[var(--enduro-muted)]">
             Electro-Enduro flow
           </p>
-          <h1 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">
+          <h1 className="mt-2 text-2xl font-semibold text-[var(--enduro-text)] sm:text-3xl">
             Electro-enduro: два сценария в одном каталоге
           </h1>
-          <p className="mt-3 max-w-3xl text-sm text-white/75 sm:text-base">
+          <p className="mt-3 max-w-3xl text-sm text-[var(--enduro-muted)] sm:text-base">
             Для быстрого старта удобно взять байк в аренду и оценить поведение
             на маршруте. Для заказа в собственность используйте конфигуратор:
             параметры, комплектация и оформление идут отдельным потоком.
           </p>
           <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2">
-            <article className="rounded-2xl border border-emerald-300/35 bg-emerald-950/70 p-4 text-white shadow-lg shadow-black/20">
+            <article className="rounded-2xl border border-[var(--enduro-border)] bg-[var(--enduro-card-faint)] p-4 text-[var(--enduro-text)] shadow-lg">
               <h2 className="text-lg font-medium">Аренда / тест-драйв</h2>
-              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-white/80">
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[var(--enduro-muted)]">
                 <li>Быстрый старт для знакомства с техникой.</li>
                 <li>
                   Подходит для сравнения нескольких моделей перед покупкой.
@@ -204,17 +219,17 @@ export default async function ElectroEnduroPage({
                 <li>Маршрутный формат и базовый инструктаж перед выездом.</li>
               </ul>
               <Link
-                className="mt-4 inline-flex rounded-xl border border-white/30 px-3 py-2 text-sm hover:bg-white hover:text-black"
+                className="mt-4 inline-flex rounded-xl border border-[var(--enduro-border)] px-3 py-2 text-sm text-[var(--enduro-text)] hover:border-[var(--enduro-accent)] hover:bg-[var(--enduro-accent)] hover:text-[var(--enduro-accent-text)]"
                 href={`/franchize/${crew.slug || slug}`}
               >
                 Открыть каталог аренды
               </Link>
             </article>
-            <article className="rounded-2xl border border-amber-300/35 bg-amber-950/75 p-4 text-white shadow-lg shadow-black/20">
+            <article className="rounded-2xl border border-[var(--enduro-border)] bg-[var(--enduro-card-faint)] p-4 text-[var(--enduro-text)] shadow-lg">
               <h2 className="text-lg font-medium">
                 Продажа / кастомная сборка
               </h2>
-              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-white/80">
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[var(--enduro-muted)]">
                 <li>
                   Выбор батареи, мощности, подвески и дополнительных опций.
                 </li>
@@ -222,7 +237,7 @@ export default async function ElectroEnduroPage({
                 <li>Лучше для тех, кто ищет байк в постоянное владение.</li>
               </ul>
               <Link
-                className="mt-4 inline-flex rounded-xl border border-white/30 px-3 py-2 text-sm hover:bg-white hover:text-black"
+                className="mt-4 inline-flex rounded-xl border border-[var(--enduro-border)] px-3 py-2 text-sm text-[var(--enduro-text)] hover:border-[var(--enduro-accent)] hover:bg-[var(--enduro-accent)] hover:text-[var(--enduro-accent-text)]"
                 href={`/franchize/${crew.slug || slug}/configurator`}
               >
                 Перейти в конфигуратор
@@ -233,11 +248,11 @@ export default async function ElectroEnduroPage({
       </section>
       <section className="mx-auto w-full max-w-7xl px-4 pt-6 2xl:max-w-[1600px]">
         <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
-          <article className="rounded-3xl border border-emerald-300/35 bg-emerald-950/70 p-5 text-white shadow-lg shadow-black/20">
+          <article className="rounded-3xl border border-[var(--enduro-border)] bg-[var(--enduro-card-faint)] p-5 text-[var(--enduro-text)] shadow-lg">
             <h3 className="text-xl font-semibold">
               Группа аренды (test-ride friendly)
             </h3>
-            <p className="mt-2 text-sm text-white/75">
+            <p className="mt-2 text-sm text-[var(--enduro-muted)]">
               Включает модели для первого знакомства и коротких прокатных
               сессий.
             </p>
@@ -246,7 +261,7 @@ export default async function ElectroEnduroPage({
                 <Link
                   key={item.id}
                   href={`/franchize/${crew.slug || slug}/electro-enduro?vehicle=${item.id}`}
-                  className="flex items-center justify-between rounded-xl border border-white/20 px-3 py-2 text-sm hover:bg-white hover:text-black"
+                  className="flex items-center justify-between rounded-xl border border-[var(--enduro-border)] px-3 py-2 text-sm text-[var(--enduro-text)] hover:border-[var(--enduro-accent)] hover:bg-[var(--enduro-accent)] hover:text-[var(--enduro-accent-text)]"
                 >
                   <span>{item.title}</span>
                   <span className="text-xs opacity-80">
@@ -256,11 +271,11 @@ export default async function ElectroEnduroPage({
               ))}
             </div>
           </article>
-          <article className="rounded-3xl border border-amber-300/35 bg-amber-950/75 p-5 text-white shadow-lg shadow-black/20">
+          <article className="rounded-3xl border border-[var(--enduro-border)] bg-[var(--enduro-card-faint)] p-5 text-[var(--enduro-text)] shadow-lg">
             <h3 className="text-xl font-semibold">
               Группа продажи (build-to-order)
             </h3>
-            <p className="mt-2 text-sm text-white/75">
+            <p className="mt-2 text-sm text-[var(--enduro-muted)]">
               Фокус на кастомизации и заказе модели в конфигураторе.
             </p>
             <div className="mt-4 space-y-2">
@@ -268,7 +283,7 @@ export default async function ElectroEnduroPage({
                 <Link
                   key={item.id}
                   href={`/franchize/${crew.slug || slug}/configurator?vehicle=${item.id}`}
-                  className="flex items-center justify-between rounded-xl border border-white/20 px-3 py-2 text-sm hover:bg-white hover:text-black"
+                  className="flex items-center justify-between rounded-xl border border-[var(--enduro-border)] px-3 py-2 text-sm text-[var(--enduro-text)] hover:border-[var(--enduro-accent)] hover:bg-[var(--enduro-accent)] hover:text-[var(--enduro-accent-text)]"
                 >
                   <span>{item.title}</span>
                   <span className="text-xs opacity-80">
@@ -282,11 +297,11 @@ export default async function ElectroEnduroPage({
       </section>
       {accessoryHighlights.length > 0 && (
         <section className="mx-auto w-full max-w-7xl px-4 pt-6 2xl:max-w-[1600px]">
-          <div className="rounded-3xl border border-white/15 bg-white/5 p-5 text-white">
+          <div className="rounded-3xl border border-[var(--enduro-border)] bg-[var(--enduro-card-soft)] p-5 text-[var(--enduro-text)]">
             <h3 className="text-xl font-semibold">
               Экип и аксессуары из текущих спецификаций
             </h3>
-            <p className="mt-2 text-sm text-white/75">
+            <p className="mt-2 text-sm text-[var(--enduro-muted)]">
               Ниже карточки, которые уже встречаются в спецификациях моделей.
               Это помогает быстро проверить, что входит в комплект и что стоит
               добавить к заказу.
@@ -295,7 +310,7 @@ export default async function ElectroEnduroPage({
               {accessoryHighlights.map((entry) => (
                 <div
                   key={entry}
-                  className="rounded-xl border border-white/20 px-3 py-2 text-sm text-white/85"
+                  className="rounded-xl border border-[var(--enduro-border)] px-3 py-2 text-sm text-[var(--enduro-text)]"
                 >
                   {entry}
                 </div>
@@ -306,7 +321,7 @@ export default async function ElectroEnduroPage({
       )}
       {shouldUseVipBikeFallback && (
         <section className="mx-auto w-full max-w-7xl px-4 pt-6 2xl:max-w-[1600px]">
-          <div className="rounded-2xl border border-amber-300/30 bg-amber-500/10 p-4 text-sm text-white/80">
+          <div className="rounded-2xl border border-[var(--enduro-border)] bg-[var(--enduro-accent-faint)] p-4 text-sm text-[var(--enduro-muted)]">
             Live crew hydration is temporarily unavailable, so this page is
             using the VipBike configurator fallback catalog instead of an empty
             showroom.

--- a/app/franchize/[slug]/onboarding/page.tsx
+++ b/app/franchize/[slug]/onboarding/page.tsx
@@ -5,7 +5,7 @@ import { getFranchizeBySlug } from "@/app/franchize/actions";
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
 import { buildFranchizeIntentLinks } from "@/app/franchize/lib/section-links";
-import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { crewPaletteForSurface, readablePaletteTextOnColor, withAlpha } from "@/app/franchize/lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
 interface PartnerOnboardingPageProps {
@@ -48,6 +48,7 @@ export default async function PartnerOnboardingPage({ params }: PartnerOnboardin
   const brandName = crew.header.brandName || crew.name || "VIP BIKE";
   const telegramHref = crew.contacts.telegram ? `https://t.me/${crew.contacts.telegram.replace("@", "")}` : "https://t.me/oneBikePlsBot";
   const { onboardingChecklist, onboardingReadinessRows } = crew.contentBlocks;
+  const accentText = readablePaletteTextOnColor(crew.theme.palette.accentMain, crew.theme.palette);
 
   return (
     <main className="min-h-screen" style={surface.page}>
@@ -58,10 +59,13 @@ export default async function PartnerOnboardingPage({ params }: PartnerOnboardin
           ["--onboarding-accent" as string]: crew.theme.palette.accentMain,
           ["--onboarding-border" as string]: crew.theme.palette.borderSoft,
           ["--onboarding-card" as string]: surface.subtleCard.backgroundColor,
+          ["--onboarding-base-soft" as string]: withAlpha(crew.theme.palette.bgBase, 0.25),
+          ["--onboarding-card-faint" as string]: withAlpha(crew.theme.palette.bgCard, 0.55),
+          ["--onboarding-accent-text" as string]: accentText,
           color: crew.theme.palette.textPrimary,
         }}
       >
-        <section className="overflow-hidden rounded-3xl border border-[var(--onboarding-border)] bg-[var(--onboarding-card)] p-6 shadow-2xl shadow-black/20 md:p-8">
+        <section className="overflow-hidden rounded-3xl border border-[var(--onboarding-border)] bg-[var(--onboarding-card)] p-6 shadow-2xl md:p-8">
           <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--onboarding-accent)]">FRZ-R4 • partner onboarding</p>
           <div className="mt-4 grid gap-8 lg:grid-cols-[1.1fr,0.9fr] lg:items-end">
             <div>
@@ -70,7 +74,7 @@ export default async function PartnerOnboardingPage({ params }: PartnerOnboardin
                 Один понятный маршрут от первого сообщения до живой витрины: каталог, продажи, аренда, MapRiders и операционные роли без хаоса в чатах.
               </p>
               <div className="mt-6 flex flex-wrap gap-3">
-                <a href={telegramHref} target="_blank" rel="noreferrer" className="rounded-full bg-[var(--onboarding-accent)] px-5 py-3 text-sm font-semibold text-black transition hover:brightness-110">
+                <a href={telegramHref} target="_blank" rel="noreferrer" className="rounded-full bg-[var(--onboarding-accent)] px-5 py-3 text-sm font-semibold text-[var(--onboarding-accent-text)] transition hover:brightness-110">
                   Начать в Telegram
                 </a>
                 <Link href={`/franchize/${crewSlug}/sales`} className="rounded-full border border-current/20 px-5 py-3 text-sm font-semibold transition hover:border-current/50">
@@ -78,14 +82,14 @@ export default async function PartnerOnboardingPage({ params }: PartnerOnboardin
                 </Link>
               </div>
             </div>
-            <div className="rounded-3xl border border-current/10 bg-black/25 p-5">
+            <div className="rounded-3xl border border-[var(--onboarding-border)] bg-[var(--onboarding-base-soft)] p-5">
               <div className="flex items-center gap-3 text-[var(--onboarding-accent)]">
                 <Handshake className="h-6 w-6" />
                 <span className="text-sm font-semibold uppercase tracking-[0.16em]">Definition of ready</span>
               </div>
               <ul className="mt-4 space-y-3 text-sm opacity-75">
                 {onboardingReadinessRows.map((row) => (
-                  <li key={row.label} className="grid gap-1 rounded-2xl border border-current/10 bg-white/[0.03] p-3">
+                  <li key={row.label} className="grid gap-1 rounded-2xl border border-[var(--onboarding-border)] bg-[var(--onboarding-card-faint)] p-3">
                     <span className="font-semibold opacity-100">{row.label}</span>
                     <span>{row.text}</span>
                   </li>
@@ -111,7 +115,7 @@ export default async function PartnerOnboardingPage({ params }: PartnerOnboardin
           })}
         </section>
 
-        <section className="rounded-3xl border border-[var(--onboarding-border)] bg-black/25 p-6">
+        <section className="rounded-3xl border border-[var(--onboarding-border)] bg-[var(--onboarding-base-soft)] p-6">
           <div className="flex items-start gap-3">
             <CheckCircle2 className="mt-1 h-6 w-6 shrink-0 text-[var(--onboarding-accent)]" />
             <div>

--- a/app/franchize/[slug]/sales/page.tsx
+++ b/app/franchize/[slug]/sales/page.tsx
@@ -5,7 +5,7 @@ import { getFranchizeBySlug, type CatalogItemVM } from "@/app/franchize/actions"
 import { CrewFooter } from "@/app/franchize/components/CrewFooter";
 import { CrewHeader } from "@/app/franchize/components/CrewHeader";
 import { buildFranchizeIntentLinks } from "@/app/franchize/lib/section-links";
-import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { crewPaletteForSurface, readablePaletteTextOnColor, withAlpha } from "@/app/franchize/lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
 interface SalesPageProps {
@@ -58,6 +58,7 @@ export default async function FranchizeSalesPage({ params }: SalesPageProps) {
   const brandName = crew.header.brandName || crew.name || "VIP BIKE";
   const saleItems = items.filter((item) => item.saleAvailable || Number(item.salePrice || 0) > 0 || isTruthySpec(item.rawSpecs?.sale));
   const salesVerticals = crew.contentBlocks.salesVerticals;
+  const accentText = readablePaletteTextOnColor(crew.theme.palette.accentMain, crew.theme.palette);
 
   return (
     <main className="min-h-screen" style={surface.page}>
@@ -68,10 +69,13 @@ export default async function FranchizeSalesPage({ params }: SalesPageProps) {
           ["--sales-accent" as string]: crew.theme.palette.accentMain,
           ["--sales-border" as string]: crew.theme.palette.borderSoft,
           ["--sales-card" as string]: surface.subtleCard.backgroundColor,
+          ["--sales-base-soft" as string]: withAlpha(crew.theme.palette.bgBase, 0.25),
+          ["--sales-card-faint" as string]: withAlpha(crew.theme.palette.bgCard, 0.55),
+          ["--sales-accent-text" as string]: accentText,
           color: crew.theme.palette.textPrimary,
         }}
       >
-        <section className="rounded-3xl border border-[var(--sales-border)] bg-[var(--sales-card)] p-6 shadow-2xl shadow-black/20 md:p-8">
+        <section className="rounded-3xl border border-[var(--sales-border)] bg-[var(--sales-card)] p-6 shadow-2xl md:p-8">
           <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--sales-accent)]">FRZ-R8 • sales vertical</p>
           <div className="mt-4 grid gap-8 lg:grid-cols-[1.15fr,0.85fr] lg:items-end">
             <div>
@@ -80,7 +84,7 @@ export default async function FranchizeSalesPage({ params }: SalesPageProps) {
                 Страница собирает все продажные сценарии в один операторский вход: от заявки на новый байк до trade-in оценки и электро-конфигуратора.
               </p>
               <div className="mt-6 flex flex-wrap gap-3">
-                <Link href={`/franchize/${crewSlug}/configurator`} className="rounded-full bg-[var(--sales-accent)] px-5 py-3 text-sm font-semibold text-black transition hover:brightness-110">
+                <Link href={`/franchize/${crewSlug}/configurator`} className="rounded-full bg-[var(--sales-accent)] px-5 py-3 text-sm font-semibold text-[var(--sales-accent-text)] transition hover:brightness-110">
                   Открыть конфигуратор
                 </Link>
                 <Link href={`/franchize/${crewSlug}/onboarding`} className="rounded-full border border-current/20 px-5 py-3 text-sm font-semibold transition hover:border-current/50">
@@ -88,17 +92,17 @@ export default async function FranchizeSalesPage({ params }: SalesPageProps) {
                 </Link>
               </div>
             </div>
-            <aside className="rounded-3xl border border-current/10 bg-black/25 p-5">
+            <aside className="rounded-3xl border border-[var(--sales-border)] bg-[var(--sales-base-soft)] p-5">
               <div className="flex items-center gap-3 text-[var(--sales-accent)]">
                 <ClipboardList className="h-6 w-6" />
                 <span className="text-sm font-semibold uppercase tracking-[0.16em]">pipeline snapshot</span>
               </div>
               <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
-                <div className="rounded-2xl border border-current/10 bg-white/[0.03] p-3">
+                <div className="rounded-2xl border border-[var(--sales-border)] bg-[var(--sales-card-faint)] p-3">
                   <dt className="opacity-55">Продажных SKU</dt>
                   <dd className="mt-1 text-2xl font-semibold text-[var(--sales-accent)]">{saleItems.length}</dd>
                 </div>
-                <div className="rounded-2xl border border-current/10 bg-white/[0.03] p-3">
+                <div className="rounded-2xl border border-[var(--sales-border)] bg-[var(--sales-card-faint)] p-3">
                   <dt className="opacity-55">Вертикалей</dt>
                   <dd className="mt-1 text-2xl font-semibold text-[var(--sales-accent)]">{salesVerticals.length}</dd>
                 </div>
@@ -121,7 +125,7 @@ export default async function FranchizeSalesPage({ params }: SalesPageProps) {
                 <p className="mt-2 text-sm leading-6 opacity-70">{vertical.pitch}</p>
                 <div className="mt-4 space-y-2">
                   {previews.map((item) => (
-                    <Link key={`${vertical.id}-${item.id}`} href={`/franchize/${crewSlug}/market/${item.id}/buy`} className="flex items-center justify-between gap-3 rounded-2xl border border-current/10 bg-black/20 px-3 py-2 text-sm transition hover:border-[var(--sales-accent)]/60">
+                    <Link key={`${vertical.id}-${item.id}`} href={`/franchize/${crewSlug}/market/${item.id}/buy`} className="flex items-center justify-between gap-3 rounded-2xl border border-[var(--sales-border)] bg-[var(--sales-base-soft)] px-3 py-2 text-sm transition hover:border-[var(--sales-accent)]/60">
                       <span className="min-w-0 truncate">{item.title}</span>
                       <span className="shrink-0 text-xs opacity-65">{item.salePrice ? `${item.salePrice.toLocaleString("ru-RU")} ₽` : item.rentPriceLabel}</span>
                     </Link>

--- a/app/franchize/components/CrewFooter.tsx
+++ b/app/franchize/components/CrewFooter.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ChevronRight, MapPin, Phone, Send } from "lucide-react";
 import type { FranchizeCrewVM } from "../actions";
 import { isExternalHref } from "../lib/navigation";
+import { readablePaletteTextOnColor, withAlpha } from "../lib/theme";
 
 interface CrewFooterProps {
   crew: FranchizeCrewVM;
@@ -11,8 +12,8 @@ interface CrewFooterProps {
 
 export function CrewFooter({ crew }: CrewFooterProps) {
   const bg = crew.theme.palette.accentMain;
-  const text = crew.footer.textColor || "#16130A";
-  const border = "rgba(22, 19, 10, 0.22)";
+  const text = readablePaletteTextOnColor(bg, crew.theme.palette);
+  const border = withAlpha(text, 0.22);
 
   const socialLinks =
     crew.footer.socialLinks.length > 0
@@ -28,13 +29,13 @@ export function CrewFooter({ crew }: CrewFooterProps) {
 
   return (
     <footer
-      className="mt-8 overflow-hidden border-t border-black/10"
+      className="mt-8 overflow-hidden border-t border-[var(--footer-border)]"
       style={{
         background: `linear-gradient(135deg, ${bg} 0%, ${crew.theme.palette.accentDeep || bg} 100%)`,
         color: text,
         ["--footer-text" as string]: text,
         ["--footer-border" as string]: border,
-        ["--footer-sub-bg" as string]: "rgba(0, 0, 0, 0.12)",
+        ["--footer-sub-bg" as string]: withAlpha(crew.theme.palette.bgBase, 0.12),
       }}
     >
       <div className="mx-auto grid w-full max-w-7xl gap-x-8 gap-y-6 px-4 py-6 md:grid-cols-3">

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -12,6 +12,7 @@ import { FranchizeProfileButton } from "./FranchizeProfileButton";
 import { toCategoryId } from "../lib/navigation";
 import { FRANCHIZE_HEADER_CORNER_GUARD_STYLE, FRANCHIZE_HEADER_SAFE_AREA_STYLE } from "../lib/route-cta-policy";
 import type { FranchizeSectionLink } from "../lib/section-links";
+import { readablePaletteTextOnColor, withAlpha } from "../lib/theme";
 
 interface CrewHeaderProps {
   crew: FranchizeCrewVM;
@@ -30,6 +31,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
   const headerLogoHref = crew.header.logoHref || mainCatalogPath;
   const railRef = useRef<HTMLDivElement | null>(null);
   const prevPathnameRef = useRef<string | null>(null);
+  const activePillText = readablePaletteTextOnColor(crew.theme.palette.accentMain, crew.theme.palette);
 
   // Reset active category when navigating away from main catalog
   // Scheduling setState via setTimeout to satisfy linter
@@ -167,8 +169,14 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
       style={{
         ...FRANCHIZE_HEADER_SAFE_AREA_STYLE,
         borderColor: crew.theme.palette.borderSoft,
-        backgroundColor: `${crew.theme.palette.bgCard}F0`,
+        backgroundColor: withAlpha(crew.theme.palette.bgCard, 0.94),
         color: crew.theme.palette.textPrimary,
+        ["--crew-header-text" as string]: crew.theme.palette.textPrimary,
+        ["--crew-header-card" as string]: crew.theme.palette.bgCard,
+        ["--crew-header-base" as string]: crew.theme.palette.bgBase,
+        ["--crew-header-border" as string]: crew.theme.palette.borderSoft,
+        ["--crew-header-accent" as string]: crew.theme.palette.accentMain,
+        ["--crew-header-accent-text" as string]: activePillText,
       }}
     >
       <div className="mx-auto w-full max-w-7xl overflow-hidden">
@@ -196,7 +204,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
             onClick={() => setMenuOpen(true)}
             className="inline-flex h-11 w-11 items-center justify-center rounded-xl transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
             style={{
-              backgroundColor: `${crew.theme.palette.bgBase}CC`,
+              backgroundColor: withAlpha(crew.theme.palette.bgBase, 0.8),
               color: crew.theme.palette.textPrimary,
               pointerEvents: "auto",
             }}
@@ -237,7 +245,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
           </Link>
 
           <FranchizeProfileButton
-            bgColor={`${crew.theme.palette.bgBase}CC`}
+            bgColor={withAlpha(crew.theme.palette.bgBase, 0.8)}
             textColor={crew.theme.palette.textPrimary}
             borderColor={crew.theme.palette.borderSoft}
             currentSlug={crew.slug}
@@ -264,7 +272,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
                   className="shrink-0 snap-start rounded-full bg-[var(--pill-bg)] px-4 py-2 text-xs font-medium tracking-wide text-[var(--pill-text)] transition-colors pointer-events-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
                   style={{
                     ["--pill-bg" as string]: isActive ? crew.theme.palette.accentMain : crew.theme.palette.bgCard,
-                    ["--pill-text" as string]: isActive ? "#000000" : crew.theme.palette.textPrimary,
+                    ["--pill-text" as string]: isActive ? activePillText : crew.theme.palette.textPrimary,
                   }}
                 >
                   {link.label}

--- a/app/franchize/components/FranchizePageShell.tsx
+++ b/app/franchize/components/FranchizePageShell.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactNode } from "react";
 import type { FranchizeTheme } from "../actions";
+import { readablePaletteTextOnColor } from "../lib/theme";
 
 type FranchizePageShellProps = {
   theme: FranchizeTheme;
@@ -20,55 +21,6 @@ type FranchizeShellVars = CSSProperties & {
   "--franchize-shell-ring": string;
 };
 
-const hexToRgb = (hex: string) => {
-  const normalized = hex.replace("#", "").trim();
-  const base =
-    normalized.length === 3
-      ? normalized
-          .split("")
-          .map((char) => `${char}${char}`)
-          .join("")
-      : normalized;
-
-  if (!/^[0-9A-Fa-f]{6}$/.test(base)) return null;
-
-  return {
-    r: Number.parseInt(base.slice(0, 2), 16),
-    g: Number.parseInt(base.slice(2, 4), 16),
-    b: Number.parseInt(base.slice(4, 6), 16),
-  };
-};
-
-const relativeLuminance = (hex: string) => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return 0;
-
-  const channels = [rgb.r, rgb.g, rgb.b].map((channel) => {
-    const value = channel / 255;
-    return value <= 0.03928
-      ? value / 12.92
-      : ((value + 0.055) / 1.055) ** 2.4;
-  });
-
-  return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
-};
-
-const contrastRatio = (foreground: string, background: string) => {
-  const foregroundLuminance = relativeLuminance(foreground);
-  const backgroundLuminance = relativeLuminance(background);
-  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
-  const darker = Math.min(foregroundLuminance, backgroundLuminance);
-
-  return (lighter + 0.05) / (darker + 0.05);
-};
-
-const pickBestAccentText = (palette: FranchizeTheme["palette"]) =>
-  [palette.textPrimary, palette.bgBase, palette.bgCard].sort(
-    (left, right) =>
-      contrastRatio(right, palette.accentMain) -
-      contrastRatio(left, palette.accentMain),
-  )[0];
-
 export function FranchizePageShell({
   theme,
   children,
@@ -84,7 +36,7 @@ export function FranchizePageShell({
     "--franchize-shell-text": palette.textPrimary,
     "--franchize-shell-muted": palette.textSecondary,
     "--franchize-shell-accent": palette.accentMain,
-    "--franchize-shell-primary-contrast": pickBestAccentText(palette),
+    "--franchize-shell-primary-contrast": readablePaletteTextOnColor(palette.accentMain, palette),
     "--franchize-shell-ring": palette.accentMain,
   };
   const maxWidthClass = width === "wide" ? "max-w-6xl" : "max-w-5xl";

--- a/app/franchize/lib/theme.ts
+++ b/app/franchize/lib/theme.ts
@@ -2,14 +2,15 @@ import type { FranchizeTheme } from "../actions";
 
 export type CrewPalette = FranchizeTheme["palette"];
 
-const hexToRgb = (hex: string) => {
-  const normalized = hex.replace("#", "").trim();
+type Rgb = { r: number; g: number; b: number };
+
+const parseHexToRgb = (color: string): Rgb | null => {
+  const normalized = color.replace("#", "").trim();
   const base = normalized.length === 3
     ? normalized.split("").map((char) => `${char}${char}`).join("")
     : normalized;
-  if (!/^[0-9A-Fa-f]{6}$/.test(base)) {
-    return { r: 242, g: 242, b: 243 };
-  }
+
+  if (!/^[0-9A-Fa-f]{6}$/.test(base)) return null;
 
   return {
     r: Number.parseInt(base.slice(0, 2), 16),
@@ -18,11 +19,56 @@ const hexToRgb = (hex: string) => {
   };
 };
 
-const withAlpha = (hex: string, alpha: number) => {
+export const hexToRgb = (hex: string) => parseHexToRgb(hex) ?? { r: 242, g: 242, b: 243 };
+
+export const withAlpha = (color: string, alpha: number) => {
   const safeAlpha = Math.min(1, Math.max(0, alpha));
-  const { r, g, b } = hexToRgb(hex);
-  return `rgba(${r}, ${g}, ${b}, ${safeAlpha})`;
+  const rgb = parseHexToRgb(color);
+
+  if (!rgb) {
+    return `color-mix(in srgb, ${color} ${Math.round(safeAlpha * 100)}%, transparent)`;
+  }
+
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${safeAlpha})`;
 };
+
+const relativeLuminanceOrNull = (color: string) => {
+  const rgb = parseHexToRgb(color);
+  if (!rgb) return null;
+
+  const toLinear = (channel: number) => {
+    const value = channel / 255;
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  };
+
+  return 0.2126 * toLinear(rgb.r) + 0.7152 * toLinear(rgb.g) + 0.0722 * toLinear(rgb.b);
+};
+
+export const relativeLuminance = (hex: string) => relativeLuminanceOrNull(hex) ?? 0;
+
+export const contrastRatio = (foreground: string, background: string) => {
+  const foregroundLum = relativeLuminanceOrNull(foreground);
+  const backgroundLum = relativeLuminanceOrNull(background);
+
+  if (foregroundLum === null || backgroundLum === null) return 1;
+
+  const lighter = Math.max(foregroundLum, backgroundLum);
+  const darker = Math.min(foregroundLum, backgroundLum);
+
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+export const readableTextOnColor = (background: string, candidates = ["#16130A", "#FFFFFF"]) => {
+  if (relativeLuminanceOrNull(background) === null) return candidates[0] ?? "currentColor";
+
+  return candidates
+    .filter((candidate) => relativeLuminanceOrNull(candidate) !== null)
+    .sort((left, right) => contrastRatio(right, background) - contrastRatio(left, background))[0] ?? candidates[0] ?? "currentColor";
+};
+
+export const readablePaletteTextOnColor = (background: string, palette: CrewPalette) => (
+  readableTextOnColor(background, [palette.textPrimary, palette.bgBase, palette.bgCard, palette.textSecondary])
+);
 
 export function crewPaletteForSurface(theme: FranchizeTheme) {
   const palette = theme.palette;
@@ -68,7 +114,7 @@ export function catalogCardVariantStyles(theme: FranchizeTheme, variantIndex: nu
     {
       borderColor: "transparent",
       backgroundColor: palette.bgCard,
-      boxShadow: `0 0 0 1px ${withAlpha(palette.accentMain, 0.08)}, 0 12px 20px ${withAlpha("#000000", 0.4)}`,
+      boxShadow: `0 0 0 1px ${withAlpha(palette.accentMain, 0.08)}, 0 12px 20px ${withAlpha(palette.bgBase, 0.4)}`,
     },
   ] as const;
 

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -47,6 +47,15 @@ This root file stays intentionally compact so operators and agents can load it q
 
 ## 2) Mini execution diary
 
+### 2026-05-07 — Franchize palette variable contrast pass
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-07T23:55:00Z
+- `owner`: codex
+- `notes`: Refactored community, sales, onboarding, electro-enduro, CrewHeader, and CrewFooter away from hard-coded white/black surface combinations toward crew palette CSS variables for primary/secondary text, base/card surfaces, soft borders, and accent button foregrounds. Self-review tightened alpha handling for non-hex CSS colors, moved accent foreground selection to palette candidates, and reused the shared contrast helper in the reusable page shell. Verified contrast math for the `vip-bike` dark palette and the default light/custom palette.
+- `next_step`: Run browser screenshot QA after Playwright host libraries are available in the runner.
+- `risks`: Local screenshot capture was blocked by missing Playwright system libraries; HTTP smoke and static checks covered this pass.
+
 - 2026-05-04 — Added support for metadata-driven franchize header logo routing via `header.logoHref` with default fallback to `/franchize/{slug}`; seeded `vip-bike` to land on `/vipbikerental` instead of catalog. Next step: expose `header.logoHref` in admin configurator UI for non-SQL operators.
 
 


### PR DESCRIPTION
### Motivation

- Normalize theming across franchize pages by replacing hard-coded white/black surface usages with crew palette CSS variables and ensure readable foregrounds on accent backgrounds.
- Provide robust color utilities that handle non-hex CSS colors and pick accessible text colors for accent buttons/pills.

### Description

- Added contrast and color helpers in `app/franchize/lib/theme.ts`: `parseHexToRgb`, exported `hexToRgb`, `withAlpha` (supports non-hex values), `relativeLuminance`, `contrastRatio`, `readableTextOnColor`, and `readablePaletteTextOnColor` and used them to choose readable accent foregrounds.
- Updated page components (`community`, `electro-enduro`, `onboarding`, `sales`) to set CSS variables derived from the crew palette, replace hard-coded color tokens with `var(...)` usages, and tweak card/background alpha values for consistent surfaces.
- Updated shared components (`CrewHeader`, `CrewFooter`, `FranchizePageShell`) to use the new helpers and CSS variables for header pill text, footer text/border, header background alpha, and shell primary-contrast selection.
- Tweaked catalog card styles and other visual small deltas to use `withAlpha` and new palette variables instead of static rgba/hex combos.

### Testing

- Ran static checks and TypeScript type-checking; these succeeded without errors.
- Ran linting and lightweight HTTP smoke checks referenced in the plan; they passed.
- Browser screenshot / Playwright visual QA was skipped due to missing Playwright system libraries (not available in the runner).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd248ccc1483248a202f9e355eab8c)