### PR TITLE
Enhance franchize loading/error UIs with themed skeletons and safe error handling

### DIFF
--- a/app/franchize/[slug]/error.tsx
+++ b/app/franchize/[slug]/error.tsx
@@ -2,32 +2,67 @@
 
 import Link from "next/link";
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { DEFAULT_FRANCHIZE_THEME } from "@/lib/franchize-config";
 import { debugLogger } from "@/lib/debugLogger";
+import { crewPaletteForSurface } from "../lib/theme";
+
+const slugFromPath = (pathname: string | null) => {
+  const parts = (pathname ?? "").split("/").filter(Boolean);
+  const franchizeIndex = parts.indexOf("franchize");
+  return franchizeIndex >= 0 ? parts[franchizeIndex + 1] : undefined;
+};
 
 export default function FranchizeSlugError({
   error,
-  reset,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
 }) {
+  const pathname = usePathname();
+  const slug = slugFromPath(pathname);
+
   useEffect(() => {
-    debugLogger.error("[franchize/[slug]/error]", error);
+    debugLogger.error("[franchize/[slug]/error]", {
+      name: error.name,
+      digest: error.digest,
+    });
   }, [error]);
 
+  const surface = crewPaletteForSurface(DEFAULT_FRANCHIZE_THEME);
+  const catalogHref = slug ? `/franchize/${slug}` : "/franchize";
+
   return (
-    <main className="mx-auto flex min-h-[60vh] w-full max-w-2xl flex-col justify-center px-4 py-10">
-      <p className="text-xs uppercase tracking-[0.2em] text-red-400">crew shell error</p>
-      <h1 className="mt-2 text-2xl font-semibold">Экипаж временно недоступен</h1>
-      <p className="mt-3 text-sm text-muted-foreground">Не удалось загрузить страницу франшизы. Это может быть сетевой сбой или ошибка данных.</p>
-      <div className="mt-5 flex flex-wrap gap-2">
-        <button type="button" onClick={reset} className="rounded-xl border px-3 py-1.5 text-sm">
-          Повторить
-        </button>
-        <Link href="/franchize" className="rounded-xl border px-3 py-1.5 text-sm">
-          Все франшизы
-        </Link>
-      </div>
+    <main className="min-h-screen" style={surface.page}>
+      <section className="mx-auto flex min-h-screen w-full max-w-5xl items-center px-3 py-5 sm:px-4 sm:py-8">
+        <div className="w-full rounded-[2rem] border p-4 shadow-2xl sm:p-6" style={surface.subtleCard}>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em]" style={surface.mutedText}>
+            crew recovery
+          </p>
+          <h1 className="mt-3 text-3xl font-black tracking-tight sm:text-5xl">Экипаж временно недоступен</h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6" style={surface.mutedText}>
+            Клиент видит спокойный fallback без секретов, stack trace и сырых ответов базы.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-[1.2fr_0.8fr]">
+            <div className="rounded-3xl border p-4" style={surface.card}>
+              <div className="h-28 rounded-2xl" style={{ backgroundColor: surface.accentPill.backgroundColor }} />
+              <div className="mt-4 h-3 w-2/3 rounded-full" style={{ backgroundColor: surface.accentPill.backgroundColor }} />
+              <div className="mt-2 h-3 w-1/2 rounded-full opacity-70" style={{ backgroundColor: surface.accentPill.backgroundColor }} />
+            </div>
+            <div className="grid gap-3">
+              {["Каталог", "Контакты", "Поддержка"].map((label) => (
+                <div key={label} className="rounded-3xl border p-4" style={surface.card}>
+                  <div className="h-2 w-12 rounded-full" style={{ backgroundColor: surface.accentPill.backgroundColor }} />
+                  <p className="mt-3 text-sm font-semibold">{label}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+          {error.digest ? <p className="mt-4 text-[11px] opacity-50" style={surface.mutedText}>debug digest: {error.digest}</p> : null}
+          <Link href={catalogHref} className="mt-6 inline-flex text-sm font-semibold" style={{ color: DEFAULT_FRANCHIZE_THEME.palette.accentMain }}>
+            Вернуться в каталог
+          </Link>
+        </div>
+      </section>
     </main>
   );
 }

--- a/app/franchize/[slug]/loading.tsx
+++ b/app/franchize/[slug]/loading.tsx
@@ -1,5 +1,52 @@
-import { Loading } from "@/components/Loading";
+import Link from "next/link";
+import { DEFAULT_FRANCHIZE_THEME } from "@/lib/franchize-config";
+import { crewPaletteForSurface } from "../lib/theme";
+
+const crewSkeletonLabels = ["Категории", "Доступность", "Контакты"] as const;
 
 export default function FranchizeSlugLoading() {
-  return <Loading variant="bike" text="СИНХРОНИЗИРУЕМ ГАРАЖ И КАТАЛОГ..." />;
+  const theme = DEFAULT_FRANCHIZE_THEME;
+  const surface = crewPaletteForSurface(theme);
+  const accentBackground = surface.accentPill.backgroundColor;
+
+  return (
+    <main className="min-h-screen" style={surface.page} aria-busy="true">
+      <section className="mx-auto flex min-h-screen w-full max-w-5xl items-center px-3 py-5 sm:px-4 sm:py-8">
+        <div
+          className="w-full overflow-hidden rounded-[2rem] border p-4 shadow-2xl sm:p-6"
+          style={surface.subtleCard}
+        >
+          <p className="text-xs font-semibold uppercase tracking-[0.24em]" style={surface.mutedText}>
+            crew storefront
+          </p>
+          <h1 className="mt-3 text-3xl font-black tracking-tight sm:text-5xl">Загрузка VIP BIKE...</h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6" style={surface.mutedText} role="status">
+            Подготавливаем мотопарк, цены, доступность и витрину экипажа.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-[1.2fr_0.8fr]">
+            <div className="rounded-3xl border p-4" style={surface.card}>
+              <div className="relative h-28 overflow-hidden rounded-2xl" style={{ backgroundColor: accentBackground }}>
+                <div className="absolute bottom-7 left-8 h-10 w-10 rounded-full border-4" style={{ borderColor: theme.palette.accentMain }} />
+                <div className="absolute bottom-7 right-8 h-10 w-10 rounded-full border-4" style={{ borderColor: theme.palette.accentMain }} />
+                <div className="absolute bottom-12 left-[30%] h-4 w-[38%] -skew-x-12 rounded-full" style={{ backgroundColor: theme.palette.accentMain }} />
+              </div>
+              <div className="mt-4 h-3 w-2/3 animate-pulse rounded-full motion-reduce:animate-none" style={{ backgroundColor: accentBackground }} />
+              <div className="mt-2 h-3 w-1/2 animate-pulse rounded-full opacity-70 motion-reduce:animate-none" style={{ backgroundColor: accentBackground }} />
+            </div>
+            <div className="grid gap-3">
+              {crewSkeletonLabels.map((label) => (
+                <div key={label} className="rounded-3xl border p-4" style={surface.card}>
+                  <div className="h-2 w-12 animate-pulse rounded-full motion-reduce:animate-none" style={{ backgroundColor: accentBackground }} />
+                  <p className="mt-3 text-sm font-semibold">{label}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+          <Link href="/franchize" className="mt-6 inline-flex text-sm font-semibold" style={{ color: theme.palette.accentMain }}>
+            Вернуться в каталог
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/app/franchize/error.tsx
+++ b/app/franchize/error.tsx
@@ -2,26 +2,45 @@
 
 import Link from "next/link";
 import { useEffect } from "react";
+import { DEFAULT_FRANCHIZE_THEME } from "@/lib/franchize-config";
 import { debugLogger } from "@/lib/debugLogger";
+import { crewPaletteForSurface } from "./lib/theme";
 
-export default function FranchizeSegmentError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+export default function FranchizeSegmentError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
-    debugLogger.error("[franchize/error]", error);
+    debugLogger.error("[franchize/error]", {
+      name: error.name,
+      digest: error.digest,
+    });
   }, [error]);
 
+  const surface = crewPaletteForSurface(DEFAULT_FRANCHIZE_THEME);
+
   return (
-    <main className="mx-auto flex min-h-[60vh] w-full max-w-2xl flex-col justify-center px-4 py-10">
-      <p className="text-xs uppercase tracking-[0.2em] text-red-400">franchize route error</p>
-      <h1 className="mt-2 text-2xl font-semibold">Ошибка в разделе franchize</h1>
-      <p className="mt-3 text-sm text-muted-foreground">Мы уже получили сигнал о проблеме. Попробуйте перезагрузить экран или открыть раздел позже.</p>
-      <div className="mt-5 flex flex-wrap gap-2">
-        <button type="button" onClick={reset} className="rounded-xl border px-3 py-1.5 text-sm">
-          Повторить
-        </button>
-        <Link href="/franchize" className="rounded-xl border px-3 py-1.5 text-sm">
-          К франшизам
-        </Link>
-      </div>
+    <main className="min-h-screen" style={surface.page}>
+      <section className="mx-auto flex min-h-screen w-full max-w-5xl items-center px-3 py-5 sm:px-4 sm:py-8">
+        <div className="w-full rounded-[2rem] border p-4 shadow-2xl sm:p-6" style={surface.subtleCard}>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em]" style={surface.mutedText}>
+            safe recovery
+          </p>
+          <h1 className="mt-3 text-3xl font-black tracking-tight sm:text-5xl">Витрина временно не открылась</h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6" style={surface.mutedText}>
+            Показываем только безопасное сообщение без сырых ответов сервера, ключей и внутренней диагностики.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="rounded-3xl border p-4" style={surface.card}>
+                <div className="h-16 rounded-2xl" style={{ backgroundColor: surface.accentPill.backgroundColor }} />
+                <div className="mt-4 h-3 w-2/3 rounded-full" style={{ backgroundColor: surface.accentPill.backgroundColor }} />
+              </div>
+            ))}
+          </div>
+          {error.digest ? <p className="mt-4 text-[11px] opacity-50" style={surface.mutedText}>debug digest: {error.digest}</p> : null}
+          <Link href="/franchize" className="mt-6 inline-flex text-sm font-semibold" style={{ color: DEFAULT_FRANCHIZE_THEME.palette.accentMain }}>
+            Вернуться в каталог
+          </Link>
+        </div>
+      </section>
     </main>
   );
 }

--- a/app/franchize/loading.tsx
+++ b/app/franchize/loading.tsx
@@ -1,5 +1,42 @@
-import { Loading } from "@/components/Loading";
+import Link from "next/link";
+import { DEFAULT_FRANCHIZE_THEME } from "@/lib/franchize-config";
+import { crewPaletteForSurface } from "./lib/theme";
+
+const catalogSkeletonCards = ["Витрины", "Экипажи", "Мотопарк"] as const;
 
 export default function FranchizeLoading() {
-  return <Loading variant="bike" text="ЗАВОДИМ ВИТРИНУ ЭКИПАЖА..." />;
+  const surface = crewPaletteForSurface(DEFAULT_FRANCHIZE_THEME);
+  const accentBackground = surface.accentPill.backgroundColor;
+
+  return (
+    <main className="min-h-screen" style={surface.page} aria-busy="true">
+      <section className="mx-auto flex min-h-screen w-full max-w-5xl items-center px-3 py-5 sm:px-4 sm:py-8">
+        <div
+          className="w-full overflow-hidden rounded-[2rem] border p-4 shadow-2xl sm:p-6"
+          style={surface.subtleCard}
+        >
+          <p className="text-xs font-semibold uppercase tracking-[0.24em]" style={surface.mutedText}>
+            franchize catalog
+          </p>
+          <h1 className="mt-3 text-3xl font-black tracking-tight sm:text-5xl">Загрузка каталога...</h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6" style={surface.mutedText} role="status">
+            Готовим список экипажей, витрины и быстрый переход в мотопарк.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-3">
+            {catalogSkeletonCards.map((label) => (
+              <div key={label} className="rounded-3xl border p-4" style={surface.card}>
+                <div className="h-24 animate-pulse rounded-2xl motion-reduce:animate-none" style={{ backgroundColor: accentBackground }} />
+                <div className="mt-4 h-3 w-2/3 rounded-full" style={{ backgroundColor: accentBackground }} />
+                <div className="mt-2 h-3 w-1/2 rounded-full opacity-70" style={{ backgroundColor: accentBackground }} />
+                <p className="mt-3 text-xs font-semibold" style={surface.mutedText}>{label}</p>
+              </div>
+            ))}
+          </div>
+          <Link href="/franchize" className="mt-6 inline-flex text-sm font-semibold" style={{ color: DEFAULT_FRANCHIZE_THEME.palette.accentMain }}>
+            Вернуться в каталог
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -47,6 +47,16 @@ This root file stays intentionally compact so operators and agents can load it q
 
 ## 2) Mini execution diary
 
+### 2026-05-08 — Franchize server-rendered loading/error correction
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-08T00:00:00Z
+- `owner`: codex
+- `notes`: Corrected the previous client hydration fallback and then self-reviewed for loading best practice: removed the shared fallback component, kept loading markup inside the route loading files, removed Supabase/page-data fetches from `loading.tsx` so the fallback can appear immediately, and removed retry/contact/Telegram action clusters from loading/error states. Error boundaries remain client files because Next.js requires `error.tsx` to be client-side, but they render only safe fallback copy, skeleton cards, a subdued digest line, and a catalog link.
+- `next_step`: Mobile-smoke `/franchize/vip-bike` loading and a forced error state to confirm instant default shell, no action-button clutter, reduced-motion-safe shimmer, and safe digest behavior.
+- `risks`: Truly instant exact crew palette in `loading.tsx` needs an early theme source such as middleware/cookie/static slug theme manifest; fetching Supabase inside the loading boundary delays the fallback and was intentionally removed.
+
+
 ### 2026-05-07 — Franchize palette variable contrast pass
 
 - `status`: ready_for_pr


### PR DESCRIPTION
### Motivation

- Improve the user experience for `/franchize` and `/franchize/[slug]` during loading and error states by providing immediate, themed skeletons and safe fallback copy without exposing raw server data. 
- Replace cramped client fallback UI and action clutter with a calm, accessible skeleton and a single catalog navigation to reduce accidental retries and surface sensitive info.

### Description

- Reworked `app/franchize/loading.tsx`, `app/franchize/[slug]/loading.tsx`, `app/franchize/error.tsx`, and `app/franchize/[slug]/error.tsx` to render themed skeleton cards and a subdued error surface using `crewPaletteForSurface(DEFAULT_FRANCHIZE_THEME)` instead of the previous compact fallback components. 
- Made error boundaries client-only but safer by logging only `name` and `digest` to `debugLogger` and showing a short, non-sensitive digest line when present; removed `reset` prop and retry button from error components. 
- Added slug extraction in `[slug]/error.tsx` via `usePathname` to build a back-to-catalog link (`/franchize/{slug}` when available). 
- Introduced skeleton label arrays (`catalogSkeletonCards` and `crewSkeletonLabels`) and accessible attributes like `aria-busy` and `role="status"` for loading states. 
- Updated `docs/THE_FRANCHEEZEPLAN.md` with a diary entry documenting the loading/error corrections and rationale.

### Testing

- Ran a local build/typecheck with `npm run build` and a linter pass with `npm run lint`, and both completed successfully. 
- No new unit tests were added for the visual/shell changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd2c27286c8324859496d6be773631)