### PR TITLE
docs: add Franchize Money Micropolish plan and SupaPlan backlog (R1–R7)

### DIFF
--- a/docs/FRANCHIZE_MONEY_MICROPOLISH_PLAN.md
+++ b/docs/FRANCHIZE_MONEY_MICROPOLISH_PLAN.md
@@ -1,0 +1,172 @@
+# Franchize Money Micropolish Plan
+
+Status: `active-planning`  
+Owner: `product + codex`  
+Default QA slug: `vip-bike`  
+Updated: `2026-05-08T00:00:00Z`
+
+## 1) Verdict: loading is correct, exact crew first-paint is the frontier
+
+Current franchize loading is the right architecture: instant, static, safe for Suspense, and not blocked on Supabase. The remaining non-God-tier gap is **exact first-paint crew branding**: `/franchize/vip-bike/*` should be able to paint the VIP Bike palette before any page data query resolves.
+
+Recommended implementation order:
+
+1. Add a tiny static slug theme manifest for known high-value crews such as `vip-bike`.
+2. Let middleware or route helpers derive an early theme token from `/franchize/:slug`.
+3. Optionally set a `franchize_theme=<token>` cookie after the first resolved page view so repeat visits stay crew-accurate even before hydration.
+4. Keep `loading.tsx` free of Supabase calls; it may consume only static manifest/cookie/path hints.
+
+Definition of God-tier loading: **instant fallback + crew-accurate palette + no server/data fetch inside loading fallback**.
+
+## 2) Money-printing product question per flow
+
+### Rent flow
+
+Primary question: **Can I ride today?**
+
+The 5-second rent flow should surface, in order:
+
+1. today availability;
+2. start date/time picker;
+3. deposit, total, pickup address, and required docs;
+4. one dominant CTA: `Hold this bike`;
+5. Telegram confirmation card for the rider;
+6. structured hot-deal card for the operator.
+
+### Prebuy flow
+
+Primary question: **Should I buy this bike or rent first?**
+
+The purchase-intent flow should surface:
+
+1. price, availability, condition, and checked status;
+2. rent-before-buy comparison;
+3. test-ride request;
+4. trade-in estimate entry point;
+5. financing/monthly payment hint;
+6. small reservation deposit via Telegram Stars or another configured payment path;
+7. operator cockpit lead, not just a generic message.
+
+## 3) Target shape: Franchize Intent Ledger
+
+The next money layer is a durable intent ledger. Every meaningful rent/prebuy/contact/trade-in/test-ride/finance/map action should create or update a single commercial-memory row.
+
+Minimum event shape:
+
+```ts
+type FranchizeIntentType =
+  | 'rent'
+  | 'prebuy'
+  | 'trade_in'
+  | 'test_ride'
+  | 'finance'
+  | 'contact'
+  | 'map_visit';
+
+type FranchizeIntentStage =
+  | 'viewed'
+  | 'configured'
+  | 'checkout_started'
+  | 'payment_failed'
+  | 'operator_notified'
+  | 'closed';
+
+interface FranchizeIntentLedgerRow {
+  intent_type: FranchizeIntentType;
+  slug: string;
+  bike_id?: string;
+  source_route: string;
+  contact_channel: 'telegram' | 'phone' | 'unknown';
+  urgency_score: number; // 0-100
+  stage: FranchizeIntentStage;
+  metadata: Record<string, unknown>; // dates, price, selected options, blockers, utm/startapp
+}
+```
+
+This turns the app from a catalog into sales memory: failed payments, checkout blockers, repeated views, map opens, trade-in clicks, and return visits become recoverable revenue.
+
+## 4) Seven sequential polishing iterations
+
+### R1 — Franchize Intent Ledger
+
+- SupaPlan task: `92bdb264-a626-450a-93b2-6eca5021711a`
+- Status: `todo`
+- Capability: `franchize.backend.supabase`
+- Primary zone: `supabase/migrations/*`, `app/franchize/*/actions.ts`
+- Goal: create the durable commercial-memory table/API for rent, prebuy, trade-in, test ride, finance, contact, and map intents.
+- Depends on: none.
+- Acceptance: intent upsert action validates slug/type/stage, keeps service-role paths server-only, and stores metadata without exposing secrets.
+
+### R2 — Ride-today availability strip
+
+- SupaPlan task: `558d6b85-3f4a-48b5-ad4d-98b92746991e`
+- Status: `todo`
+- Capability: `franchize.rental`
+- Primary zone: catalog cards and bike modal components.
+- Goal: answer “Can I ride today?” directly on bike cards and modal open.
+- Depends on: R1 for event capture, but visual availability can be built behind a feature-safe fallback first.
+- Acceptance: rider sees today/tomorrow availability, pickup hint, and a `Hold this bike` CTA in under five seconds.
+
+### R3 — Hold/reservation CTA
+
+- SupaPlan task: `a55a75bb-2e1d-4685-b26b-53596a95b594`
+- Status: `todo`
+- Capability: `franchize.sales`
+- Primary zone: checkout/order/payment server actions.
+- Goal: make small hold fee/deposit a visible product mechanism instead of hidden payment plumbing.
+- Depends on: R1, R2.
+- Acceptance: hold attempt writes an intent, successful payment marks hot intent/rental metadata, failed payment creates recovery-ready ledger details.
+
+### R4 — Prebuy test-ride + trade-in mini-flow
+
+- SupaPlan task: `6c5623ac-4e8a-4499-9bef-b062887a9feb`
+- Status: `todo`
+- Capability: `franchize.marketplace`
+- Primary zone: sale/buy pages and configurator handoff.
+- Goal: turn purchase pages into rent-before-buy, test-ride, trade-in, and financing lead machines.
+- Depends on: R1.
+- Acceptance: buyer can request test ride, trade-in estimate, financing hint, or rent-first comparison from the bike page.
+
+### R5 — Abandoned checkout recovery
+
+- SupaPlan task: `cc5ec5ef-e6bb-446b-8d91-a12002fbb57d`
+- Status: `todo`
+- Capability: `franchize.telegram`
+- Primary zone: checkout blocker logic and operator notifications.
+- Goal: convert unfinished checkout state into a compact operator card with exact next action.
+- Depends on: R1, R3.
+- Acceptance: if a rider leaves after meaningful blockers, operator sees bike, dates, phone/Telegram channel when available, last blocker, and suggested next message.
+
+### R6 — Operator closer dashboard
+
+- SupaPlan task: `5993dab3-dd18-49dc-8138-52862bc32edb`
+- Status: `todo`
+- Capability: `franchize.ui.ux`
+- Primary zone: franchize admin/operator console.
+- Goal: show ranked hot leads with one-click Telegram replies, manual reserve, and alternative-bike offer actions.
+- Depends on: R1, R5.
+- Acceptance: operator can sort by urgency score, see last blocker, and take one closing action without opening raw database rows.
+
+### R7 — AI closer assistant
+
+- SupaPlan task: `734d604d-e96f-4b56-830f-977e3d3cfa07`
+- Status: `todo`
+- Capability: `franchize.analytics`
+- Primary zone: server-only AI summarization and admin console display.
+- Goal: summarize lead intent, generate best next message, suggest alternative bike/discount/deposit, and follow up after abandoned checkout.
+- Depends on: R1, R5, R6.
+- Acceptance: AI output is validated, recoverable on malformed JSON, and displayed as operator suggestions rather than automatic unsafe actions.
+
+## 5) Parallelization map after blocker
+
+Sequential execution remains safest for production, but once R1 lands the work can split with low conflict risk:
+
+- R2: catalog/modal conversion strip.
+- R4: sale/prebuy route mini-flow.
+- R5: checkout/Telegram recovery path.
+
+R3 should wait for R2 + payment-product copy, R6 waits for R1/R5 data, and R7 waits until the dashboard has stable operator affordances.
+
+## 6) Success metric
+
+The money metric is not “more forms submitted.” The target is: **every high-intent click becomes structured, ranked, recoverable commercial intent that Telegram/operator workflows can close.**

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -40,12 +40,23 @@ For every task below, keep these fields updated:
 - Execution status board: `docs/THE_FRANCHEEZEPLAN_STATUS.MD`
 - Historical diary/archive: `docs/THE_FRANCHEEZEPLAN_HISTORY_ARCHIVE.md`
 - Visual system + implementation blueprint: `docs/THE_FRANCHEEZEPLAN_BLUEPRINT.md`
+- Money micropolish backlog: `docs/FRANCHIZE_MONEY_MICROPOLISH_PLAN.md`
 
 This root file stays intentionally compact so operators and agents can load it quickly in high-frequency loops.
 
 ---
 
 ## 2) Mini execution diary
+
+
+### 2026-05-08 — Franchize money micropolish backlog shaping
+
+- `status`: active-planning
+- `updated_at`: 2026-05-08T00:00:00Z
+- `owner`: codex
+- `notes`: Converted the operator money-printing direction into a sequenced micropolish plan and wrote seven open SupaPlan tasks (`92bdb264-a626-450a-93b2-6eca5021711a`, `558d6b85-3f4a-48b5-ad4d-98b92746991e`, `a55a75bb-2e1d-4685-b26b-53596a95b594`, `6c5623ac-4e8a-4499-9bef-b062887a9feb`, `cc5ec5ef-e6bb-446b-8d91-a12002fbb57d`, `5993dab3-dd18-49dc-8138-52862bc32edb`, `734d604d-e96f-4b56-830f-977e3d3cfa07`). Exact first-paint crew theme hints remain the loading frontier, while the revenue frontier is an intent ledger feeding ride-today availability, hold deposits, prebuy/test-ride/trade-in flows, abandoned checkout recovery, operator closing, and AI closer suggestions. Detailed plan lives in `docs/FRANCHIZE_MONEY_MICROPOLISH_PLAN.md`.
+- `next_step`: Start R1 Franchize Intent Ledger before parallelizing R2/R4/R5 UI and recovery slices.
+- `risks`: SupaPlan has existing open franchize tasks; newly shaped money tasks should be claimed one-by-one and not used to move unrelated older tasks to ready_for_pr.
 
 ### 2026-05-08 — Franchize server-rendered loading/error correction
 


### PR DESCRIPTION
### Motivation
- Capture the next “money-printing” polishing direction for the Franchize/VIP Bike product by documenting the small, high-impact iterations that turn catalog interest into recoverable commercial intent. 
- Call out the remaining loading frontier (instant first-paint crew palette) and propose low-risk early-theme hint options so the app can be both instant and brand-accurate without calling Supabase in `loading.tsx`.
- Sequence a practical, SupaPlan-driven roadmap (Intent Ledger → Ride Today → Hold CTA → Prebuy flows → Recovery → Operator tools → AI closer) so work can be claimed and executed safely one-by-one.

### Description
- Added a new plan document `docs/FRANCHIZE_MONEY_MICROPOLISH_PLAN.md` that describes the goal, recommended implementation for early crew theme hints, rent/prebuy product questions, the Franchize Intent Ledger shape, and seven sequential R1–R7 iterations. 
- Linked the new plan from the root `docs/THE_FRANCHEEZEPLAN.md` and appended a dated diary entry summarizing the micropolish backlog and next step guidance. 
- Created seven open SupaPlan backlog tasks for the R1→R7 iterations using the repo CLI; task IDs created: `92bdb264-a626-450a-93b2-6eca5021711a`, `558d6b85-3f4a-48b5-ad4d-98b92746991e`, `a55a75bb-2e1d-4685-b26b-53596a95b594`, `6c5623ac-4e8a-4499-9bef-b062887a9feb`, `cc5ec5ef-e6bb-446b-8d91-a12002fbb57d`, `5993dab3-dd18-49dc-8138-52862bc32edb`, `734d604d-e96f-4b56-830f-977e3d3cfa07`. 

### Testing
- Ran capability & status checks with `node scripts/supaplan-skill.mjs inspect-migrations` and `node scripts/supaplan-skill.mjs status --limit 40`, which completed successfully and showed the new open tasks in the SupaPlan index. 
- Created the backlog items via `node scripts/supaplan-skill.mjs add-task --title "FRZ-MONEY-R{n}: ..." --capability <capability>` for R1–R7, and each returned `ok: true` with a task id. 
- Verified repository hygiene with `git diff --check` and a final `node scripts/supaplan-skill.mjs status --limit 40`, both of which succeeded and reported expected state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd3ab67e3083248ff58ca910109f73)