### PR TITLE
feat(franchize): add ride-today availability strip & rent intent tracking (supaplan_task:558d6b85-3f4a-48b5-ad4d-98b92746991e)

### DIFF
--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -76,6 +76,9 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
   const searchParams = useSearchParams();
   const { user, dbUser } = useAppContext();
   const lastQueryViewedVehicleRef = useRef<string>("");
+  const recordRentIntentRef = useRef<
+    (item: CatalogItemVM, stage: "viewed" | "configured", metadata?: Record<string, unknown>) => Promise<unknown>
+  >();
   const resolvedSlug = crew.slug || slug;
   const showFloatingCart = ctaPolicy ? shouldShowFloatingCart(ctaPolicy, { cartRelevant: true }) : true;
 
@@ -270,6 +273,10 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
     }).catch((error) => console.warn("rent intent tracking failed", error));
   }, [crew, dbUser, resolvedSlug, user]);
 
+  useEffect(() => {
+    recordRentIntentRef.current = recordRentIntent;
+  }, [recordRentIntent]);
+
   const openItem = (item: CatalogItemVM) => {
     setSelectedItem(item);
     const defaultOptions = {
@@ -296,9 +303,9 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
         auction: auctionTickOptions[0] ?? "Без аукциона",
       };
       setSelectedOptions(defaultOptions);
-      void recordRentIntent(target, "viewed", { trigger: "vehicle_query", options: defaultOptions });
+      void recordRentIntentRef.current?.(target, "viewed", { trigger: "vehicle_query", options: defaultOptions });
     }
-  }, [auctionTickOptions, items, recordRentIntent, searchParams]);
+  }, [auctionTickOptions, items, searchParams]);
 
   return (
     <>

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { ShoppingCart } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAppContext } from "@/contexts/AppContext";
 import { toCategoryId } from "../lib/navigation";
 import type { FranchizeRouteCtaPolicy } from "../lib/route-cta-policy";
@@ -75,6 +75,8 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
   const [campaignIndex, setCampaignIndex] = useState(0);
   const searchParams = useSearchParams();
   const { user, dbUser } = useAppContext();
+  const lastQueryViewedVehicleRef = useRef<string>("");
+  const resolvedSlug = crew.slug || slug;
   const showFloatingCart = ctaPolicy ? shouldShowFloatingCart(ctaPolicy, { cartRelevant: true }) : true;
 
   const promoModules = useMemo(() => {
@@ -247,11 +249,11 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
   const recordRentIntent = useCallback((item: CatalogItemVM, stage: "viewed" | "configured", metadata: Record<string, unknown> = {}) => {
     const strip = buildCatalogRentalStrip(item, crew);
     return upsertFranchizeIntent({
-      slug: crew.slug || slug,
+      slug: resolvedSlug,
       bikeId: item.id,
       intentType: "rent",
       stage,
-      sourceRoute: `/franchize/${crew.slug || slug}`,
+      sourceRoute: `/franchize/${resolvedSlug}`,
       contactChannel: "catalog_card",
       urgencyScore: stage === "configured" ? 68 : 42,
       telegramUserId: user?.id ? String(user.id) : dbUser?.user_id ? String(dbUser.user_id) : undefined,
@@ -266,7 +268,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
         ...metadata,
       },
     }).catch((error) => console.warn("rent intent tracking failed", error));
-  }, [crew, dbUser, slug, user]);
+  }, [crew, dbUser, resolvedSlug, user]);
 
   const openItem = (item: CatalogItemVM) => {
     setSelectedItem(item);
@@ -284,7 +286,8 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
     const focusedVehicle = (searchParams.get("vehicle") || "").trim().toLowerCase();
     if (!focusedVehicle) return;
     const target = items.find((item) => item.id.toLowerCase() === focusedVehicle);
-    if (target) {
+    if (target && lastQueryViewedVehicleRef.current !== target.id) {
+      lastQueryViewedVehicleRef.current = target.id;
       setSelectedItem(target);
       const defaultOptions = {
         package: "Базовый",
@@ -568,7 +571,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                           <div className="mt-2 flex gap-2">
                             <span className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--catalog-accent)] px-2 py-2.5 text-xs font-bold text-[var(--catalog-accent-contrast)] transition-transform active:scale-95">
                               <ShoppingCart className="h-4 w-4" />
-                              {item.saleAvailable ? "Hold this bike / купить" : "Забронировать байк"}
+                              {item.saleAvailable ? "Hold this bike / Забронировать байк" : "Забронировать байк"}
                             </span>
                           </div>
                         </div>
@@ -586,8 +589,8 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
       {/* 🛒 Floating Cart: Hide when modal is open to avoid z-index overlap */}
       {!selectedItem && showFloatingCart && (
         <FloatingCartIconLinkBySlug
-          slug={crew.slug || slug}
-          href={`/franchize/${crew.slug || slug}/cart`}
+          slug={resolvedSlug}
+          href={`/franchize/${resolvedSlug}/cart`}
           items={items}
           accentColor={crew.theme.palette.accentMain}
           textColor={crew.theme.palette.textPrimary}
@@ -600,7 +603,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
       <ItemModal
         item={selectedItem}
         items={items}
-        slug={crew.slug || slug}
+        slug={resolvedSlug}
         theme={crew.theme}
         pickupAddress={crew.contacts.address || crew.hqLocation}
         workingHours={crew.contacts.workingHours}

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -4,15 +4,18 @@ import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { ShoppingCart } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAppContext } from "@/contexts/AppContext";
 import { toCategoryId } from "../lib/navigation";
 import type { FranchizeRouteCtaPolicy } from "../lib/route-cta-policy";
 import { shouldShowFloatingCart } from "../lib/route-cta-policy";
 import { catalogCardVariantStyles, crewPaletteForSurface, interactionRingStyle } from "../lib/theme";
 import type { CatalogItemVM, FranchizeCrewVM } from "../actions";
+import { upsertFranchizeIntent } from "../actions";
 import { FloatingCartIconLinkBySlug } from "./FloatingCartIconLinkBySlug";
 import { ItemModal } from "../modals/Item";
 import { useFranchizeCart } from "../hooks/useFranchizeCart";
+import { buildCatalogRentalStrip } from "../lib/catalog-rental-strip";
 
 interface CatalogClientProps {
   crew: FranchizeCrewVM;
@@ -71,6 +74,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
   const [quickFilter, setQuickFilter] = useState<QuickFilterKey>("all");
   const [campaignIndex, setCampaignIndex] = useState(0);
   const searchParams = useSearchParams();
+  const { user, dbUser } = useAppContext();
   const showFloatingCart = ctaPolicy ? shouldShowFloatingCart(ctaPolicy, { cartRelevant: true }) : true;
 
   const promoModules = useMemo(() => {
@@ -240,14 +244,40 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
     return [{ category: saleCategory, items: saleGroup }, ...normalized];
   }, [filteredItems, mode, orderedCategories, quickFilter]);
 
+  const recordRentIntent = useCallback((item: CatalogItemVM, stage: "viewed" | "configured", metadata: Record<string, unknown> = {}) => {
+    const strip = buildCatalogRentalStrip(item, crew);
+    return upsertFranchizeIntent({
+      slug: crew.slug || slug,
+      bikeId: item.id,
+      intentType: "rent",
+      stage,
+      sourceRoute: `/franchize/${crew.slug || slug}`,
+      contactChannel: "catalog_card",
+      urgencyScore: stage === "configured" ? 68 : 42,
+      telegramUserId: user?.id ? String(user.id) : dbUser?.user_id ? String(dbUser.user_id) : undefined,
+      phone: typeof (dbUser as { phone?: unknown } | null)?.phone === "string" ? (dbUser as { phone?: string } | null)?.phone : undefined,
+      metadata: {
+        itemTitle: item.title,
+        availabilityStatus: item.availabilityStatus,
+        availabilityLabel: strip.availabilityLabel,
+        nearestStartWindow: strip.nearestStartWindow,
+        pickupHint: strip.pickupHint,
+        priceTeaser: strip.priceTeaser,
+        ...metadata,
+      },
+    }).catch((error) => console.warn("rent intent tracking failed", error));
+  }, [crew, dbUser, slug, user]);
+
   const openItem = (item: CatalogItemVM) => {
     setSelectedItem(item);
-    setSelectedOptions({
+    const defaultOptions = {
       package: "Базовый",
       duration: "1 день",
       perk: "Стандарт",
       auction: auctionTickOptions[0] ?? "Без аукциона",
-    });
+    };
+    setSelectedOptions(defaultOptions);
+    void recordRentIntent(item, "viewed", { trigger: "catalog_card", options: defaultOptions });
   };
 
   useEffect(() => {
@@ -256,14 +286,16 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
     const target = items.find((item) => item.id.toLowerCase() === focusedVehicle);
     if (target) {
       setSelectedItem(target);
-      setSelectedOptions({
+      const defaultOptions = {
         package: "Базовый",
         duration: "1 день",
         perk: "Стандарт",
         auction: auctionTickOptions[0] ?? "Без аукциона",
-      });
+      };
+      setSelectedOptions(defaultOptions);
+      void recordRentIntent(target, "viewed", { trigger: "vehicle_query", options: defaultOptions });
     }
-  }, [auctionTickOptions, items, searchParams]);
+  }, [auctionTickOptions, items, recordRentIntent, searchParams]);
 
   return (
     <>
@@ -449,7 +481,9 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                   </span>
                 </div>
                 <div className="grid grid-cols-2 gap-3 xl:grid-cols-3 2xl:grid-cols-4">
-                  {group.items.map((item) => (
+                  {group.items.map((item) => {
+                    const rentalStrip = buildCatalogRentalStrip(item, crew);
+                    return (
                     <article
                       key={item.id}
                       data-catalog-item="true"
@@ -483,12 +517,12 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                             <span
                               className="inline-flex rounded-full px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em]"
                               style={{
-                                backgroundColor: item.availabilityStatus === "available" ? "#1f7a3a3d" : "#dc262640",
+                                backgroundColor: rentalStrip.isAvailable ? "#1f7a3a3d" : "#dc262640",
                                 color: "#e6f4ea",
-                                border: item.availabilityStatus === "available" ? "1px solid rgba(46, 160, 67, 0.45)" : "1px solid rgba(220, 38, 38, 0.45)",
+                                border: rentalStrip.isAvailable ? "1px solid rgba(46, 160, 67, 0.45)" : "1px solid rgba(220, 38, 38, 0.45)",
                               }}
                             >
-                              {item.availabilityLabel}
+                              {rentalStrip.availabilityLabel}
                             </span>
                             {item.saleAvailable && (
                               <span className="inline-flex rounded-full border border-amber-300/60 bg-amber-400/25 px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em] text-amber-100">
@@ -503,6 +537,21 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                           )}
                           <h3 className="mt-1 text-sm font-semibold leading-5">{item.title}</h3>
                           <p className="text-xs" style={surface.mutedText}>{item.description || item.subtitle}</p>
+                          <div
+                            className="mt-2 rounded-2xl border border-white/10 bg-black/15 p-2 text-[10px] leading-4"
+                            aria-label={`Аренда ${item.title}: ${rentalStrip.todayLabel}`}
+                          >
+                            <div className="flex items-center justify-between gap-2 font-semibold text-[var(--catalog-text)]">
+                              <span>Сегодня: {rentalStrip.todayLabel}</span>
+                              <span className={rentalStrip.isAvailable ? "text-emerald-200" : "text-amber-100"}>
+                                {rentalStrip.nearestStartWindow}
+                              </span>
+                            </div>
+                            <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5" style={surface.mutedText}>
+                              <span>Выдача: {rentalStrip.pickupHint}</span>
+                              <span>{rentalStrip.priceTeaser}</span>
+                            </div>
+                          </div>
                           {item.reviewSummary.latest?.text && (
                             <p className="mt-2 rounded-xl border border-white/10 px-2 py-1.5 text-[11px] leading-4" style={surface.mutedText}>
                               “{item.reviewSummary.latest.text}”
@@ -519,13 +568,14 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                           <div className="mt-2 flex gap-2">
                             <span className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--catalog-accent)] px-2 py-2.5 text-xs font-bold text-[var(--catalog-accent-contrast)] transition-transform active:scale-95">
                               <ShoppingCart className="h-4 w-4" />
-                              {item.saleAvailable ? "Аренда / Покупка" : item.pricePerDay >= 6000 ? "Выбрать" : "Добавить"}
+                              {item.saleAvailable ? "Hold this bike / купить" : "Забронировать байк"}
                             </span>
                           </div>
                         </div>
                       </button>
                     </article>
-                  ))}
+                    );
+                  })}
                 </div>
               </section>
             ))}
@@ -552,12 +602,18 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
         items={items}
         slug={crew.slug || slug}
         theme={crew.theme}
+        pickupAddress={crew.contacts.address || crew.hqLocation}
+        workingHours={crew.contacts.workingHours}
         options={selectedOptions}
         auctionOptions={auctionTickOptions}
         onChangeOption={(key, value) => setSelectedOptions((prev) => ({ ...prev, [key]: value }))}
         onClose={() => setSelectedItem(null)}
         onAddToCart={() => {
           if (!selectedItem) return;
+          void recordRentIntent(selectedItem, "configured", {
+            trigger: "modal_cta",
+            options: selectedOptions,
+          });
           addItem(selectedItem.id, selectedOptions, 1);
           setSelectedItem(null);
         }}

--- a/app/franchize/lib/catalog-rental-strip.ts
+++ b/app/franchize/lib/catalog-rental-strip.ts
@@ -1,0 +1,86 @@
+import type { CatalogItemVM } from "../actions";
+
+const UNKNOWN_TELEGRAM_LABEL = "Уточним в Telegram";
+const PICKUP_HINT_MAX = 42;
+
+function firstTextSpec(specs: Record<string, unknown> | undefined, keys: string[]) {
+  if (!specs) return "";
+  for (const key of keys) {
+    const value = specs[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return `${value.toLocaleString("ru-RU")} ₽`;
+    }
+  }
+  return "";
+}
+
+function truncatePickupHint(value: string) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= PICKUP_HINT_MAX) return normalized;
+  return `${normalized.slice(0, PICKUP_HINT_MAX - 1).trim()}…`;
+}
+
+function normalizeWorkingHours(value: string) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return "";
+
+  const timeRange = normalized.match(/(\d{1,2}[:.]\d{2})\s*[–—-]\s*(\d{1,2}[:.]\d{2})/);
+  if (timeRange) {
+    return `с ${timeRange[1].replace(".", ":")}`;
+  }
+
+  const firstTime = normalized.match(/\d{1,2}[:.]\d{2}/)?.[0];
+  if (firstTime) {
+    return `с ${firstTime.replace(".", ":")}`;
+  }
+
+  return normalized.length > 22 ? `${normalized.slice(0, 21).trim()}…` : normalized;
+}
+
+export function hasCatalogAvailabilitySignal(item: CatalogItemVM) {
+  return ["available", "busy"].includes(item.availabilityStatus) && item.availabilityLabel.trim().length > 0;
+}
+
+export function buildCatalogRentalStrip(
+  item: CatalogItemVM,
+  crew: { contacts: { address?: string; workingHours?: string }; hqLocation?: string },
+) {
+  const hasAvailability = hasCatalogAvailabilitySignal(item);
+  const isAvailable = hasAvailability && item.availabilityStatus === "available";
+  const pickupAddress = crew.contacts.address || crew.hqLocation || "адрес выдачи уточним";
+  const depositLabel = firstTextSpec(item.rawSpecs, [
+    "deposit_label",
+    "deposit_rub",
+    "deposit",
+    "security_deposit",
+    "security_deposit_rub",
+    "pledge",
+  ]);
+  const startWindowSpec = firstTextSpec(item.rawSpecs, [
+    "nearest_start_window",
+    "start_window",
+    "pickup_window",
+    "handoff_window",
+  ]);
+  const workingWindow = normalizeWorkingHours(crew.contacts.workingHours ?? "");
+  const availabilityLabel = item.availabilityLabel.trim();
+
+  return {
+    hasAvailability,
+    isAvailable,
+    todayLabel: hasAvailability ? (isAvailable ? "доступен" : "занят") : UNKNOWN_TELEGRAM_LABEL,
+    availabilityLabel: hasAvailability ? availabilityLabel : UNKNOWN_TELEGRAM_LABEL,
+    nearestStartWindow: hasAvailability
+      ? isAvailable
+        ? startWindowSpec || (workingWindow ? `сегодня ${workingWindow}` : "сегодня по договорённости")
+        : availabilityLabel || UNKNOWN_TELEGRAM_LABEL
+      : UNKNOWN_TELEGRAM_LABEL,
+    pickupHint: truncatePickupHint(pickupAddress),
+    priceTeaser: depositLabel
+      ? `Залог ${depositLabel} · ${item.rentPriceLabel}`
+      : `Залог обсудим · ${item.rentPriceLabel}`,
+  };
+}

--- a/app/franchize/lib/catalog-rental-strip.ts
+++ b/app/franchize/lib/catalog-rental-strip.ts
@@ -1,4 +1,9 @@
-import type { CatalogItemVM } from "../actions";
+type CatalogRentalStripItem = {
+  availabilityStatus?: string | null;
+  availabilityLabel?: string | null;
+  rawSpecs?: Record<string, unknown>;
+  rentPriceLabel: string;
+};
 
 const UNKNOWN_TELEGRAM_LABEL = "Уточним в Telegram";
 const PICKUP_HINT_MAX = 42;
@@ -40,12 +45,12 @@ function normalizeWorkingHours(value: string) {
   return normalized.length > 22 ? `${normalized.slice(0, 21).trim()}…` : normalized;
 }
 
-export function hasCatalogAvailabilitySignal(item: CatalogItemVM) {
-  return ["available", "busy"].includes(item.availabilityStatus) && item.availabilityLabel.trim().length > 0;
+export function hasCatalogAvailabilitySignal(item: CatalogRentalStripItem) {
+  return ["available", "busy"].includes(String(item.availabilityStatus ?? "")) && String(item.availabilityLabel ?? "").trim().length > 0;
 }
 
 export function buildCatalogRentalStrip(
-  item: CatalogItemVM,
+  item: CatalogRentalStripItem,
   crew: { contacts: { address?: string; workingHours?: string }; hqLocation?: string },
 ) {
   const hasAvailability = hasCatalogAvailabilitySignal(item);
@@ -66,7 +71,7 @@ export function buildCatalogRentalStrip(
     "handoff_window",
   ]);
   const workingWindow = normalizeWorkingHours(crew.contacts.workingHours ?? "");
-  const availabilityLabel = item.availabilityLabel.trim();
+  const availabilityLabel = String(item.availabilityLabel ?? "").trim();
 
   return {
     hasAvailability,

--- a/app/franchize/modals/Item.tsx
+++ b/app/franchize/modals/Item.tsx
@@ -15,6 +15,7 @@ import {
   isSameCatalogPropulsion,
 } from "@/app/franchize/lib/catalog-propulsion";
 import { ItemGallery } from "../components/ItemGallery";
+import { buildCatalogRentalStrip } from "../lib/catalog-rental-strip";
 import { crewPaletteForSurface } from "../lib/theme";
 
 interface ItemModalProps {
@@ -22,6 +23,8 @@ interface ItemModalProps {
   items: CatalogItemVM[];
   slug: string;
   theme: FranchizeTheme;
+  pickupAddress?: string;
+  workingHours?: string;
   options: {
     package: string;
     duration: string;
@@ -34,7 +37,7 @@ interface ItemModalProps {
     value: string,
   ) => void;
   onClose: () => void;
-  onAddToCart: () => void;
+  onAddToCart: () => void | Promise<void>;
 }
 
 const packageOptions = ["Базовый", "Комфорт", "Максимум"];
@@ -103,6 +106,8 @@ export function ItemModal({
   items,
   slug,
   theme,
+  pickupAddress = "",
+  workingHours = "",
   options,
   auctionOptions,
   onChangeOption,
@@ -227,6 +232,14 @@ export function ItemModal({
   );
   const propulsionLabel = getCatalogPropulsionLabel(propulsionSegment);
 
+  const rentalStrip = useMemo(() => {
+    if (!item) return null;
+    return buildCatalogRentalStrip(item, {
+      hqLocation: pickupAddress,
+      contacts: { address: pickupAddress, workingHours },
+    });
+  }, [item, pickupAddress, workingHours]);
+
   const comparableBikes = useMemo(() => {
     if (!item) return [];
     return items
@@ -309,11 +322,41 @@ export function ItemModal({
               <p className="text-sm" style={surface.mutedText}>
                 {item.subtitle}
               </p>
-              {item.saleAvailable && (
-                <p className="mt-1 inline-flex rounded-full border border-amber-300/60 bg-amber-400/20 px-2 py-0.5 text-xs font-semibold text-amber-100">
-                  Этот мот доступен к покупке (параллельно аренде)
-                </p>
-              )}
+              <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                <span
+                  className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${
+                    rentalStrip?.isAvailable
+                      ? "border-emerald-300/50 bg-emerald-400/15 text-emerald-100"
+                      : "border-amber-300/50 bg-amber-400/15 text-amber-100"
+                  }`}
+                >
+                  Сегодня: {rentalStrip?.todayLabel ?? "Уточним в Telegram"}
+                </span>
+                {item.saleAvailable && (
+                  <span className="inline-flex rounded-full border border-amber-300/60 bg-amber-400/20 px-2.5 py-1 font-semibold text-amber-100">
+                    Аренда + покупка
+                  </span>
+                )}
+              </div>
+              {rentalStrip ? (
+                <div
+                  className="mt-3 grid gap-2 rounded-2xl border border-white/10 bg-black/15 p-3 text-xs sm:grid-cols-3"
+                  aria-label={`Быстрая аренда ${item.title}`}
+                >
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--item-muted-text)]">Ближайшее окно</p>
+                    <p className="mt-1 font-semibold text-[var(--item-text)]">{rentalStrip.nearestStartWindow}</p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--item-muted-text)]">Выдача</p>
+                    <p className="mt-1 font-semibold text-[var(--item-text)]">{rentalStrip.pickupHint}</p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--item-muted-text)]">Залог / тариф</p>
+                    <p className="mt-1 font-semibold text-[var(--item-text)]">{rentalStrip.priceTeaser}</p>
+                  </div>
+                </div>
+              ) : null}
               <p
                 id={`item-modal-description-${item.id}`}
                 className={`mt-2 text-sm leading-6 ${descriptionExpanded ? "" : "line-clamp-4"}`}
@@ -511,8 +554,8 @@ export function ItemModal({
               {isAdding
                 ? "Добавляем..."
                 : item.saleAvailable
-                  ? `Оформить • аренда/покупка`
-                  : `Добавить • ${item.pricePerDay.toLocaleString("ru-RU")} ₽`}
+                  ? `Hold this bike • Забронировать байк`
+                  : `Забронировать байк • Hold this bike`}
             </button>
           </div>
         </div>

--- a/app/franchize/server-actions/intents.ts
+++ b/app/franchize/server-actions/intents.ts
@@ -14,6 +14,7 @@ const franchizeIntentTypes = [
   "contact_click",
   "test_ride_click",
   "prebuy",
+  "rent",
 ] as const;
 
 const franchizeIntentStages = [
@@ -26,6 +27,8 @@ const franchizeIntentStages = [
   "payment_confirmed",
   "contacted",
   "test_ride_requested",
+  "viewed",
+  "configured",
 ] as const;
 
 const metadataSchema = z.record(z.string(), z.unknown()).default({});

--- a/docs/FRANCHIZE_MONEY_MICROPOLISH_PLAN.md
+++ b/docs/FRANCHIZE_MONEY_MICROPOLISH_PLAN.md
@@ -100,12 +100,14 @@ This turns the app from a catalog into sales memory: failed payments, checkout b
 ### R2 — Ride-today availability strip
 
 - SupaPlan task: `558d6b85-3f4a-48b5-ad4d-98b92746991e`
-- Status: `todo`
+- Status: `ready_for_pr`
 - Capability: `franchize.rental`
 - Primary zone: catalog cards and bike modal components.
 - Goal: answer “Can I ride today?” directly on bike cards and modal open.
 - Depends on: R1 for event capture, but visual availability can be built behind a feature-safe fallback first.
 - Acceptance: rider sees today/tomorrow availability, pickup hint, and a `Hold this bike` CTA in under five seconds.
+- Updated: `2026-05-08T14:30:00Z`
+- Notes: Catalog cards and item modal now show today availability, nearest start window, pickup hint, deposit/price teaser, and the dominant hold/reserve CTA; rent intents are recorded as `viewed` on modal open and `configured` on CTA taps.
 
 ### R3 — Hold/reservation CTA
 

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -50,6 +50,16 @@ This root file stays intentionally compact so operators and agents can load it q
 
 
 
+### 2026-05-08 — SupaPlan rent card strip task 558d6b85
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-08T14:30:00Z
+- `owner`: codex
+- `notes`: Added the rental decision strip to franchize catalog cards and item modal: today availability, nearest start window, pickup hint, deposit/price teaser, and dominant “Hold this bike / Забронировать байк” CTA. Wired `intent_type='rent'` with `viewed` and `configured` stages for modal open and CTA taps.
+- `next_step`: Apply the rent-intent constraint migration, then smoke `/franchize/vip-bike` on mobile viewport with real availability rows.
+- `risks`: The nearest window uses item specs or crew working hours when explicit rental windows are absent; unknown availability falls back to “Уточним в Telegram” rather than blocking render.
+
+
 ### 2026-05-08 — Franchize intent link review fix
 
 - `status`: ready_for_pr

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -50,6 +50,16 @@ This root file stays intentionally compact so operators and agents can load it q
 
 
 
+### 2026-05-08 — SupaPlan rent strip self-review polish
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-08T14:45:00Z
+- `owner`: codex
+- `notes`: Self-reviewed task `558d6b85-3f4a-48b5-ad4d-98b92746991e`: removed a type-only dependency on the server-action barrel from the shared strip helper, made malformed/missing availability labels fall back safely, prevented duplicate `viewed` tracking for `?vehicle=` modal auto-open rerenders, and aligned sale-card CTA text with the required reserve wording.
+- `next_step`: Review PR visually in an environment with live `vip-bike` catalog rows, then merge so SupaPlan can close R2.
+- `risks`: Local visual smoke remains data-limited when Supabase fetch fails; production/preview smoke should be performed with real crew catalog data.
+
+
 ### 2026-05-08 — SupaPlan rent card strip task 558d6b85
 
 - `status`: ready_for_pr

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -50,6 +50,16 @@ This root file stays intentionally compact so operators and agents can load it q
 
 
 
+### 2026-05-08 — SupaPlan rent strip deep-link review fix
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-08T14:55:00Z
+- `owner`: codex
+- `notes`: Addressed Codex review on `?vehicle=` deep-link modal initialization: rent tracking now uses a latest-callback ref, so Telegram auth/user hydration no longer recreates the effect dependency path and cannot reset in-progress modal options or double-log `viewed` for the same vehicle.
+- `next_step`: Keep the live-data mobile smoke as the final verification gate before merge.
+- `risks`: The deep-link initializer intentionally runs only from URL/items/auction option changes; user identity changes update the tracking ref but do not reinitialize the modal.
+
+
 ### 2026-05-08 — SupaPlan rent strip self-review polish
 
 - `status`: ready_for_pr

--- a/supabase/migrations/20260508143000_extend_franchize_rent_intents.sql
+++ b/supabase/migrations/20260508143000_extend_franchize_rent_intents.sql
@@ -1,0 +1,39 @@
+-- Extend server-only franchize intent ledger for rental catalog/card signals.
+
+alter table public.franchize_intents
+  drop constraint if exists franchize_intents_intent_type_allowed;
+
+alter table public.franchize_intents
+  add constraint franchize_intents_intent_type_allowed check (
+    intent_type in (
+      'checkout_start',
+      'payment_failure',
+      'payment_success',
+      'hold_created',
+      'map_click',
+      'contact_click',
+      'test_ride_click',
+      'prebuy',
+      'rent'
+    )
+  );
+
+alter table public.franchize_intents
+  drop constraint if exists franchize_intents_stage_allowed;
+
+alter table public.franchize_intents
+  add constraint franchize_intents_stage_allowed check (
+    stage in (
+      'discovered',
+      'clicked',
+      'prebuy_started',
+      'checkout_started',
+      'hold_created',
+      'payment_failed',
+      'payment_confirmed',
+      'contacted',
+      'test_ride_requested',
+      'viewed',
+      'configured'
+    )
+  );


### PR DESCRIPTION
### Motivation
- Surface the answer to “Can I ride today?” quickly on catalog cards and item modal so users see availability, nearest start window, pickup hint and a clear reserve CTA without blocking UI.
- Capture early commercial signals for the rent flow by recording `rent` intents when a user views a modal (`viewed`) and when they tap the dominant CTA (`configured`).

### Description
- Added a new helper `app/franchize/lib/catalog-rental-strip.ts` that derives today availability, nearest start window, pickup address hint and deposit/price teaser with a safe fallback `Уточним в Telegram` when availability data is missing. 
- Updated `app/franchize/components/CatalogClient.tsx` to render a compact ride-today strip on each catalog card, use `buildCatalogRentalStrip(...)` for display, show the dominant CTA text (`Забронировать байк` / `Hold this bike`) and record `rent` intents (`viewed` on modal open, `configured` on CTA). 
- Updated `app/franchize/modals/Item.tsx` to display the same rental strip inside the modal and to prefer the unified CTA label; modal receives `pickupAddress` and `workingHours` props for context. 
- Wired intent persistence via existing server action: client calls `upsertFranchizeIntent` for `intentType: 'rent'` with `stage: 'viewed' | 'configured'`. 
- Extended server-side intent enums and added a migration stub `supabase/migrations/20260508143000_extend_franchize_rent_intents.sql` to allow `intent_type='rent'` and new stages `viewed`/`configured`. 
- Updated planning/docs: `docs/FRANCHIZE_MONEY_MICROPOLISH_PLAN.md` and `docs/THE_FRANCHEEZEPLAN.md` mark R2 as `ready_for_pr` and describe the change.

supaplan_task: 558d6b85-3f4a-48b5-ad4d-98b92746991e

### Testing
- Ran lint with `npm run lint` and it passed with no ESLint warnings or errors. (success)
- Ran the franchize typecheck `npm run typecheck:franchize` and the strict slice passed. (success)
- Built the app with `npm run build` to validate bundling and server code; the build completed and pages compiled. (success)
- Updated SupaPlan task status `running -> ready_for_pr` and verified `node scripts/supaplan-skill.mjs task-status --taskId 558d6b85-3f4a-48b5-ad4d-98b92746991e` shows `ready_for_pr`. (success)
- Attempted mobile Playwright smoke to open `/franchize/vip-bike` and exercise the modal; Playwright/chromium was installed and ran, but the local Supabase fetch failed in this environment so the page rendered the safe fallback and no catalog cards were available to open the modal (smoke could not fully validate UI end-to-end). (partial: tooling ok, runtime data dependency prevented full verification)

Files changed (high level): `CatalogClient.tsx`, `modals/Item.tsx`, `lib/catalog-rental-strip.ts` (new), `server-actions/intents.ts` (enum extension), `supabase/migrations/20260508143000_extend_franchize_rent_intents.sql` (new migration), and docs updates for SupaPlan tracking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd4a3e631c83248de78c911168bf6a)