### PR TITLE
fix: align bike loader wheels

### DIFF
--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -428,23 +428,23 @@ const BikeSpeedster = ({ gear }: { gear: number }) => {
               transition={{ duration: 0.18, ease: "easeOut" }}
             >
               <motion.div
-                className="absolute left-[41px] top-[63px] h-[63px] w-[63px] rounded-full border-4 border-orange-400/90"
+                className="absolute left-[52px] top-[74px] h-[58px] w-[58px] rounded-full border-4 border-orange-400/90"
                 animate={{ rotate: -360 }}
                 transition={{ duration: 0.45, repeat: Infinity, ease: "linear" }}
                 style={{ animation: "bike-loading-wheel-spin 0.45s linear infinite" }}
               >
                 {[0, 45, 90, 135].map((deg) => (
-                  <div key={deg} className="absolute left-1/2 top-1/2 h-[2px] w-[26px] -translate-x-1/2 -translate-y-1/2 bg-orange-200/90" style={{ transform: `translate(-50%, -50%) rotate(${deg}deg)` }} />
+                  <div key={deg} className="absolute left-1/2 top-1/2 h-[2px] w-[23px] -translate-x-1/2 -translate-y-1/2 bg-orange-200/90" style={{ transform: `translate(-50%, -50%) rotate(${deg}deg)` }} />
                 ))}
               </motion.div>
               <motion.div
-                className="absolute left-[157px] top-[63px] h-[63px] w-[63px] rounded-full border-4 border-orange-400/90"
+                className="absolute left-[146px] top-[74px] h-[58px] w-[58px] rounded-full border-4 border-orange-400/90"
                 animate={{ rotate: -360 }}
                 transition={{ duration: 0.45, repeat: Infinity, ease: "linear" }}
                 style={{ animation: "bike-loading-wheel-spin 0.45s linear infinite" }}
               >
                 {[0, 45, 90, 135].map((deg) => (
-                  <div key={deg} className="absolute left-1/2 top-1/2 h-[2px] w-[26px] -translate-x-1/2 -translate-y-1/2 bg-orange-200/90" style={{ transform: `translate(-50%, -50%) rotate(${deg}deg)` }} />
+                  <div key={deg} className="absolute left-1/2 top-1/2 h-[2px] w-[23px] -translate-x-1/2 -translate-y-1/2 bg-orange-200/90" style={{ transform: `translate(-50%, -50%) rotate(${deg}deg)` }} />
                 ))}
               </motion.div>
             </motion.div>


### PR DESCRIPTION
### Motivation
- Improve visual alignment of the bike loading animation so the animated wheels better match the Lucide `Bike` icon silhouette for a tighter, more consistent loader look.

### Description
- Adjusted wheel positions and sizes in `components/Loading.tsx` inside the `BikeSpeedster` loader by moving the rear wheel to `left-[52px] top-[74px]` and the front wheel to `left-[146px] top-[74px]`.
- Reduced animated wheel diameter from `h/w-[63px]` to `h/w-[58px]` and shortened spoke width from `w-[26px]` to `w-[23px]` so spokes sit closer to the icon geometry.
- Change scope is limited to the `BikeSpeedster` animation and does not touch other loader variants or runtime logic.

### Testing
- Ran `npm run lint -- --file components/Loading.tsx` which returned no ESLint warnings or errors.
- Confirmed local diff only modified `components/Loading.tsx` and there are no `git diff --check` issues.
- Screenshot intentionally not captured per operator request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd759c9bc483249cc790e1bc7be9c8)