### PR TITLE
Show Telegram BackButton only when app-level back target exists and add BackButton.isVisible type

### DIFF
--- a/hooks/useTelegramBackButton.ts
+++ b/hooks/useTelegramBackButton.ts
@@ -21,6 +21,13 @@ function fallbackPathFor(pathname: string) {
   return "/";
 }
 
+function shouldShowBackButton(pathname: string) {
+  // Telegram exposes BackButton and the default close affordance as a mixed pair:
+  // show BackButton only when we can provide an app-level back target; hide it at
+  // the app root so Telegram's native close control remains available.
+  return fallbackPathFor(pathname) !== pathname;
+}
+
 export function useTelegramBackButton() {
   const { tg, isInTelegramContext } = useAppContext();
   const router = useRouter();
@@ -73,14 +80,14 @@ export function useTelegramBackButton() {
       router.push(targetPath);
     };
 
-    if (pathname !== "/") {
-      if (!backButton.isVisible) {
-        logger.debug(`[Telegram BackButton] Path is "${pathname}". Showing button.`);
-        backButton.show();
-      }
+    if (shouldShowBackButton(pathname || "/")) {
+      logger.debug(`[Telegram BackButton] Path is "${pathname}". Showing native back button.`);
+      backButton.show();
       backButton.onClick(handleBackClick);
-    } else if (backButton.isVisible) {
-      logger.debug('[Telegram BackButton] Path is "/". Hiding button.');
+    } else {
+      logger.debug(
+        `[Telegram BackButton] Path is "${pathname}". Hiding native back button so Telegram close stays available.`,
+      );
       backButton.hide();
     }
 

--- a/types/telegram.d.ts
+++ b/types/telegram.d.ts
@@ -17,6 +17,7 @@ export interface TelegramWebApp {
   close: () => void;
   showPopup: (params: { title?: string; message: string; buttons?: Array<{ id?: string; type?: string; text?: string }> }) => void;
   BackButton?: {
+    isVisible?: boolean;
     show: () => void;
     hide: () => void;
     onClick: (callback: () => void) => void;


### PR DESCRIPTION
### Motivation

- Telegram exposes a mixed BackButton/close affordance, so the app should only show the native back button when there is an app-level back target to navigate to, and hide it at the app root so Telegram's native close remains available.
- The BackButton shape needed a small type addition to reflect runtime visibility state.

### Description

- Introduced `shouldShowBackButton(pathname)` which returns true when `fallbackPathFor(pathname) !== pathname` to determine if a native back target exists.
- Updated `useTelegramBackButton` to use `shouldShowBackButton` and to call `BackButton.show()` and `BackButton.onClick()` only when appropriate, otherwise call `BackButton.hide()` and log intent more explicitly.
- Kept the internal SPA navigation stack and click handler logic unchanged but improved log messages to clarify when the native back is shown versus hidden.
- Added `isVisible?: boolean` to the `BackButton` type in `types/telegram.d.ts` to reflect runtime visibility checks.

### Testing

- Ran the TypeScript typecheck with `tsc --noEmit` and verified there were no type errors.
- Executed the repository's automated unit tests with `npm test` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde17fe3cc8324bd29448bf19efb69)