### PR TITLE
Resilient private-secrets reads, safer franchize checkout errors, and repair migration

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -26,6 +26,8 @@
 ### 2) База данных
 Минимум для старта:
 - `supabase/migrations/20240101000000_init.sql`
+- `supabase/migrations/20260304_private_scheme.sql` — приватные `user_secrets`/`crew_secrets` для документов аренды.
+- `supabase/migrations/20260508090000_repair_private_crew_secrets.sql` — idempotent repair/grants guard для окружений, где `private.crew_secrets` отсутствовал.
 
 Дальше — накатывай остальные миграции по модулям, которые реально используешь.
 

--- a/app/franchize/[slug]/configurator/actions_configurator.ts
+++ b/app/franchize/[slug]/configurator/actions_configurator.ts
@@ -4,7 +4,7 @@ import { supabaseAdmin } from "@/lib/supabase-server";
 import { notifyAdmin, sendTelegramDocument } from "@/app/actions";
 import { logger } from "@/lib/logger";
 import { randomUUID } from "crypto";
-import { getCrewSensitiveData } from "@/app/lib/private-secrets";
+import { getCrewSensitiveDataOrDefault } from "@/app/lib/private-secrets";
 import { buildFranchizeDocxFromTemplate } from "@/app/franchize/lib/docx-capability";
 import type {
   ConfiguratorLeadInput,
@@ -139,7 +139,7 @@ const CONFIGURATOR_DOC_TEMPLATE = `# ⚡ Конфигурация электро
 async function buildConfiguratorDocAndNotify(input: ConfiguratorLeadInput) {
   const configId = randomUUID().slice(0, 8);
   const now = new Date();
-  const crewSensitive = await getCrewSensitiveData(input.crewSlug);
+  const crewSensitive = await getCrewSensitiveDataOrDefault(input.crewSlug, { source: "buildConfiguratorDocAndNotify" });
   const contractDefaults = (crewSensitive.contractDefaults ?? {}) as Record<string, unknown>;
   const defaults = ((contractDefaults.defaults ?? {}) as Record<string, unknown>);
   const docTemplates = (crewSensitive.docTemplates ?? {}) as Record<string, unknown>;

--- a/app/franchize/actions-runtime.ts
+++ b/app/franchize/actions-runtime.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { randomUUID } from "crypto";
 import { readFile } from "fs/promises";
 import path from "path";
-import { getCrewSensitiveData, getUserSensitiveData, saveCrewSensitiveData } from "@/app/lib/private-secrets";
+import { getCrewSensitiveDataOrDefault, getUserSensitiveDataOrDefault, saveCrewSensitiveData } from "@/app/lib/private-secrets";
 import { buildFranchizeDocxFromTemplate } from "@/app/franchize/lib/docx-capability";
 import { upsertFranchizeIntent } from "@/app/franchize/server-actions/intents";
 import { cloneFranchizeContentBlocks, readFranchizeContentBlocks, type FranchizeContentBlocks } from "@/app/franchize/lib/content-blocks";
@@ -37,6 +37,23 @@ import {
 
 
 type UnknownRecord = Record<string, unknown>;
+const FRANCHIZE_RENTAL_DOCS_SAFE_ERROR =
+  "Не удалось подготовить документы аренды. Мы уже передали заявку оператору — попробуйте ещё раз или напишите в Telegram.";
+
+function logFranchizeCheckoutFailure(
+  failureSource: "submitFranchizeOrderNotification" | "createFranchizeOrderCheckout",
+  context: { slug: string; orderId: string },
+  error: unknown,
+) {
+  logger.error(`[franchize] ${failureSource} failed`, {
+    slug: context.slug,
+    orderId: context.orderId,
+    failureSource,
+    errorName: error instanceof Error ? error.name : undefined,
+    errorMessage: error instanceof Error ? error.message : String(error),
+  });
+}
+
 type RentalAvailabilityRow = {
   vehicle_id: string | null;
   status: string | null;
@@ -1076,7 +1093,7 @@ async function toFranchizeConfigInput(crew: UnknownRecord, slug: string): Promis
   };
   const menuLinks = readArrayPath<UnknownRecord>(franchize, ["header", "menuLinks"], fallbackMenuLinks(slug));
 
-  const crewSecrets = await getCrewSensitiveData(slug);
+  const crewSecrets = await getCrewSensitiveDataOrDefault(slug, { source: "toFranchizeConfigInput" });
   const contractDefaults = (crewSecrets.contractDefaults ?? {}) as UnknownRecord;
   const defaults = (readPath(contractDefaults, ["defaults"], {}) ?? {}) as UnknownRecord;
   const docTemplates = (crewSecrets.docTemplates ?? {}) as UnknownRecord;
@@ -1601,7 +1618,7 @@ type FranchizeOrderNotifyPayload = z.infer<typeof franchizeOrderInvoiceSchema> &
 type FranchizeOrderFlowType = "rental" | "sale" | "mixed";
 
 async function loadFranchizeDealTemplate(slug: string, flowType: FranchizeOrderFlowType): Promise<string> {
-  const crewSensitive = await getCrewSensitiveData(slug);
+  const crewSensitive = await getCrewSensitiveDataOrDefault(slug, { source: "loadFranchizeDealTemplate" });
   const secureTemplateKey = flowType === "rental" ? "rentalDealTemplate" : "saleDealTemplate";
   const secureTemplate = readPath(crewSensitive.docTemplates ?? {}, [secureTemplateKey], "");
   if (typeof secureTemplate === "string" && secureTemplate.trim().length > 0) {
@@ -1710,8 +1727,9 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
     const dailyPriceRub = firstLine?.pricePerDay || Math.round(payload.subtotal / Math.max(1, rentDays));
 
     const template = await loadFranchizeDealTemplate(payload.slug, flowType);
-    const userSensitive = await getUserSensitiveData(payload.telegramUserId);
-    const crewSensitive = await getCrewSensitiveData(payload.slug);
+    const privateReadContext = { source: "buildFranchizeOrderDocAndNotify", orderId: payload.orderId };
+    const userSensitive = await getUserSensitiveDataOrDefault(payload.telegramUserId, privateReadContext);
+    const crewSensitive = await getCrewSensitiveDataOrDefault(payload.slug, privateReadContext);
     const contractDefaults = (crewSensitive.contractDefaults ?? {}) as UnknownRecord;
     const defaults = (readPath(contractDefaults, ["defaults"], {}) ?? {}) as UnknownRecord;
 
@@ -1875,6 +1893,13 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
     return { renderedMarkdown, docFileName };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to submit order notification";
+    logger.error("[franchize] buildFranchizeOrderDocAndNotify failed", {
+      slug: payload.slug,
+      orderId: payload.orderId,
+      failureSource: "buildFranchizeOrderDocAndNotify",
+      errorName: error instanceof Error ? error.name : undefined,
+      errorMessage: message,
+    });
     await updateFranchizeOrderNotificationLog(logId, {
       send_status: "failed",
       last_error: message,
@@ -2046,8 +2071,8 @@ export async function submitFranchizeOrderNotification(input: unknown): Promise<
     await buildFranchizeOrderDocAndNotify({ ...validatedPayload, totalAmount: effectiveTotal, subtotal: payload.subtotal, extrasTotal: payload.extrasTotal });
     return { success: true };
   } catch (error) {
-    logger.error("[franchize] submitFranchizeOrderNotification failed", error);
-    return { success: false, error: error instanceof Error ? error.message : "Failed to submit order notification" };
+    logFranchizeCheckoutFailure("submitFranchizeOrderNotification", { slug: payload.slug, orderId: payload.orderId }, error);
+    return { success: false, error: FRANCHIZE_RENTAL_DOCS_SAFE_ERROR };
   }
 }
 
@@ -2912,10 +2937,10 @@ export async function createFranchizeOrderCheckout(
 
     return { success: true };
   } catch (error) {
-    logger.error("[franchize] createFranchizeOrderCheckout failed", error);
+    logFranchizeCheckoutFailure("createFranchizeOrderCheckout", { slug: payload.slug, orderId: payload.orderId }, error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : "Unexpected checkout error",
+      error: FRANCHIZE_RENTAL_DOCS_SAFE_ERROR,
     };
   }
 }

--- a/app/lib/private-secrets.ts
+++ b/app/lib/private-secrets.ts
@@ -3,6 +3,7 @@
 import "server-only";
 
 import { supabaseAdmin } from "@/lib/supabase-server";
+import { logger } from "@/lib/logger";
 
 const MAX_SECRET_JSON_BYTES = 256 * 1024;
 const RESERVED_JSON_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -37,6 +38,16 @@ type SupabaseSchemaClient = {
 export type CrewSensitiveData = {
   contractDefaults: Record<string, unknown>;
   docTemplates: Record<string, unknown>;
+};
+
+export type UserSensitiveData = {
+  driverLicense: string;
+  passport: string;
+};
+
+type PrivateReadFallbackContext = {
+  source: string;
+  orderId?: string;
 };
 
 function privateSchema() {
@@ -169,7 +180,42 @@ function serializeCrewSecretRecord(value: Record<string, unknown>, fieldName: st
   return serialized;
 }
 
-export async function getUserSensitiveData(userId: string) {
+function mapUserSensitiveRow(data: { driver_license?: unknown; passport?: unknown } | null | undefined): UserSensitiveData {
+  return {
+    driverLicense: typeof data?.driver_license === "string" ? data.driver_license : "",
+    passport: typeof data?.passport === "string" ? data.passport : "",
+  };
+}
+
+function emptyUserSensitiveData(): UserSensitiveData {
+  return { driverLicense: "", passport: "" };
+}
+
+function logPrivateReadFallback(
+  subject: "crew" | "user",
+  identifier: string,
+  context: PrivateReadFallbackContext,
+  error: unknown,
+) {
+  const supabaseError = error as { code?: unknown; status?: unknown; name?: unknown; message?: unknown };
+
+  logger.warn(`[private-secrets] ${subject} sensitive read fallback`, {
+    subject,
+    identifier,
+    source: context.source,
+    orderId: context.orderId,
+    errorCode: typeof supabaseError.code === "string" ? supabaseError.code : undefined,
+    errorStatus: typeof supabaseError.status === "number" || typeof supabaseError.status === "string" ? supabaseError.status : undefined,
+    errorName: error instanceof Error ? error.name : typeof supabaseError.name === "string" ? supabaseError.name : undefined,
+    errorMessage: error instanceof Error
+      ? error.message
+      : typeof supabaseError.message === "string"
+        ? supabaseError.message
+        : String(error),
+  });
+}
+
+export async function getUserSensitiveData(userId: string): Promise<UserSensitiveData> {
   const normalizedUserId = normalizePrivateId(userId, "userId");
   const { data, error } = await privateSchema()
     .from("user_secrets")
@@ -181,10 +227,32 @@ export async function getUserSensitiveData(userId: string) {
     throw new Error("Failed to read user private data.");
   }
 
-  return {
-    driverLicense: data?.driver_license ?? "",
-    passport: data?.passport ?? "",
-  };
+  return mapUserSensitiveRow(data);
+}
+
+export async function getUserSensitiveDataOrDefault(
+  userId: string,
+  context: PrivateReadFallbackContext = { source: "getUserSensitiveDataOrDefault" },
+): Promise<UserSensitiveData> {
+  const normalizedUserId = normalizePrivateId(userId, "userId");
+
+  try {
+    const { data, error } = await privateSchema()
+      .from("user_secrets")
+      .select("driver_license, passport")
+      .eq("user_id", normalizedUserId)
+      .maybeSingle();
+
+    if (error) {
+      logPrivateReadFallback("user", normalizedUserId, context, error);
+      return emptyUserSensitiveData();
+    }
+
+    return mapUserSensitiveRow(data);
+  } catch (error) {
+    logPrivateReadFallback("user", normalizedUserId, context, error);
+    return emptyUserSensitiveData();
+  }
 }
 
 export async function saveUserSensitiveData(userId: string, data: {
@@ -210,6 +278,20 @@ export async function saveUserSensitiveData(userId: string, data: {
 // Payment provider credentials/tokens must stay in deployment secrets or a
 // dedicated encrypted vault, never in editable crew JSON blobs.
 // ──────────────────────────────────────────────────────────────
+function emptyCrewSensitiveData(): CrewSensitiveData {
+  return {
+    contractDefaults: {},
+    docTemplates: {},
+  };
+}
+
+function mapCrewSensitiveRow(data: { contract_defaults?: unknown; doc_templates?: unknown } | null | undefined): CrewSensitiveData {
+  return {
+    contractDefaults: parseJsonRecord(data?.contract_defaults),
+    docTemplates: parseJsonRecord(data?.doc_templates),
+  };
+}
+
 export async function getCrewSensitiveData(crewSlug: string): Promise<CrewSensitiveData> {
   const normalizedCrewSlug = normalizePrivateId(crewSlug, "crewSlug");
   const { data, error } = await privateSchema()
@@ -222,10 +304,32 @@ export async function getCrewSensitiveData(crewSlug: string): Promise<CrewSensit
     throw new Error("Failed to read crew private data.");
   }
 
-  return {
-    contractDefaults: parseJsonRecord(data?.contract_defaults),
-    docTemplates: parseJsonRecord(data?.doc_templates),
-  };
+  return mapCrewSensitiveRow(data);
+}
+
+export async function getCrewSensitiveDataOrDefault(
+  crewSlug: string,
+  context: PrivateReadFallbackContext = { source: "getCrewSensitiveDataOrDefault" },
+): Promise<CrewSensitiveData> {
+  const normalizedCrewSlug = normalizePrivateId(crewSlug, "crewSlug");
+
+  try {
+    const { data, error } = await privateSchema()
+      .from("crew_secrets")
+      .select("contract_defaults, doc_templates")
+      .eq("crew_slug", normalizedCrewSlug)
+      .maybeSingle();
+
+    if (error) {
+      logPrivateReadFallback("crew", normalizedCrewSlug, context, error);
+      return emptyCrewSensitiveData();
+    }
+
+    return mapCrewSensitiveRow(data);
+  } catch (error) {
+    logPrivateReadFallback("crew", normalizedCrewSlug, context, error);
+    return emptyCrewSensitiveData();
+  }
 }
 
 export async function saveCrewSensitiveData(crewSlug: string, data: {

--- a/docs/README_TLDR.md
+++ b/docs/README_TLDR.md
@@ -4,7 +4,7 @@
 1. Fork репозитория в свой GitHub.
 2. Подключение к Codex.
 3. Деплой fork в Vercel.
-4. Применить `supabase/migrations/20240101000000_init.sql`.
+4. Применить `supabase/migrations/20240101000000_init.sql`, `supabase/migrations/20260304_private_scheme.sql` и repair guard `supabase/migrations/20260508090000_repair_private_crew_secrets.sql`.
 5. Поставить env из `.env.example`.
 
 ## 2) Синхронизация с upstream (коротко)

--- a/supabase/migrations/20260508090000_repair_private_crew_secrets.sql
+++ b/supabase/migrations/20260508090000_repair_private_crew_secrets.sql
@@ -1,0 +1,24 @@
+-- Repair/bootstrap guard for rental checkout document defaults.
+-- Keeps private.crew_secrets available for service-role reads/writes even when
+-- an older environment missed 20260304_private_scheme.sql or has a partial table.
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE IF NOT EXISTS private.crew_secrets (
+  crew_slug            TEXT PRIMARY KEY,
+  contract_defaults    TEXT,
+  doc_templates        TEXT,
+  price_lists          TEXT,
+  sensitive_metadata   JSONB DEFAULT '{}'::jsonb,
+  updated_at           TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE private.crew_secrets
+  ADD COLUMN IF NOT EXISTS contract_defaults TEXT,
+  ADD COLUMN IF NOT EXISTS doc_templates TEXT,
+  ADD COLUMN IF NOT EXISTS price_lists TEXT,
+  ADD COLUMN IF NOT EXISTS sensitive_metadata JSONB DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+
+REVOKE ALL ON SCHEMA private FROM anon, authenticated;
+GRANT USAGE ON SCHEMA private TO service_role;
+GRANT ALL ON TABLE private.crew_secrets TO service_role;


### PR DESCRIPTION
### Motivation
- Prevent runtime failures when `private` schema rows are missing or Supabase read errors occur by returning safe defaults instead of throwing. 
- Avoid leaking internal error details to end users during franchize checkout and order submission flows. 
- Ensure deployments that missed an earlier migration still have the `private.crew_secrets` table and correct grants.

### Description
- Add a repair migration `supabase/migrations/20260508090000_repair_private_crew_secrets.sql` to create `private.crew_secrets` (and columns) and set schema/table grants for the service role. 
- Extend `app/lib/private-secrets.ts` with typed models, safe mappers, `getCrewSensitiveDataOrDefault` and `getUserSensitiveDataOrDefault` that return empty defaults on errors, plus structured fallback logging via `logger`. 
- Keep existing `getCrewSensitiveData`/`getUserSensitiveData` behavior but add the `OrDefault` variants and helper utilities (`map*`, `empty*`, `logPrivateReadFallback`). 
- Replace several callers to use the safe-read variants and add safer error behavior in franchize flows by introducing `FRANCHIZE_RENTAL_DOCS_SAFE_ERROR` and `logFranchizeCheckoutFailure`, which logs detailed errors while returning a user-friendly message. 
- Update `README.MD` and `docs/README_TLDR.md` to include the new migration and migration order for startup instructions.

### Testing
- Ran a full TypeScript project build/type-check (`npm run build` / `tsc`) and it completed successfully. 
- Ran project linter (`npm run lint`) and it passed with no new issues. 
- No new unit tests were added for this change and existing test suites (if present) were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde2126d208324a54a6182fac6273f)