### PR TITLE
Operator surface: unify franchize admin/dashboard/profile UI and server-side crew hydration

### DIFF
--- a/app/franchize/[slug]/admin/page.tsx
+++ b/app/franchize/[slug]/admin/page.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from "next";
 import { FranchizeAdminClient } from "@/app/franchize/components/FranchizeAdminClient";
+import { CrewFooter } from "../../components/CrewFooter";
+import { CrewHeader } from "../../components/CrewHeader";
+import { FranchizePageShell } from "../../components/FranchizePageShell";
+import { getFranchizeBySlug } from "../../actions";
+import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
 interface FranchizeSlugAdminPageProps {
@@ -7,19 +12,46 @@ interface FranchizeSlugAdminPageProps {
   searchParams: Promise<{ edit?: string }>;
 }
 
-
-export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
   const { slug } = await params;
   return buildFranchizeSectionMetadata(slug, {
     sectionTitle: "Админ-панель экипажа",
-    sectionDescription: "Операторская панель настройки франшизной витрины, каталога, заказов и отзывов.",
+    sectionDescription:
+      "Операторская панель настройки франшизной витрины, каталога, заказов и отзывов.",
     pathSuffix: "/admin",
   });
 }
 
-export default async function FranchizeSlugAdminPage({ params, searchParams }: FranchizeSlugAdminPageProps) {
+export default async function FranchizeSlugAdminPage({
+  params,
+  searchParams,
+}: FranchizeSlugAdminPageProps) {
   const { slug } = await params;
   const { edit } = await searchParams;
+  const { crew, items } = await getFranchizeBySlug(slug);
+  const resolvedSlug = crew.slug || slug;
+  const activePath = `/franchize/${resolvedSlug}/admin`;
+  const surface = crewPaletteForSurface(crew.theme);
 
-  return <FranchizeAdminClient initialSlug={slug} editId={edit} />;
+  return (
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader
+        crew={crew}
+        activePath={activePath}
+        groupLinks={items.map((item) => item.category)}
+      />
+      <FranchizePageShell theme={crew.theme} contentClassName="space-y-4">
+        <FranchizeAdminClient
+          initialSlug={resolvedSlug}
+          editId={edit}
+          initialCrew={crew}
+        />
+      </FranchizePageShell>
+      <CrewFooter crew={crew} />
+    </main>
+  );
 }

--- a/app/franchize/[slug]/dashboard/page.tsx
+++ b/app/franchize/[slug]/dashboard/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from "next";
 
 import { FranchizeCloserDashboardClient } from "@/app/franchize/components/FranchizeCloserDashboardClient";
+import { CrewFooter } from "../../components/CrewFooter";
+import { CrewHeader } from "../../components/CrewHeader";
+import { FranchizePageShell } from "../../components/FranchizePageShell";
+import { getFranchizeBySlug } from "../../actions";
+import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 
 interface FranchizeSlugDashboardPageProps {
@@ -12,7 +17,7 @@ export async function generateMetadata({
 }: FranchizeSlugDashboardPageProps): Promise<Metadata> {
   const { slug } = await params;
   return buildFranchizeSectionMetadata(slug, {
-    sectionTitle: "Operator closer dashboard",
+    sectionTitle: "Панель заявок",
     sectionDescription:
       "Отдельная панель горячих franchize leads, Telegram replies и ручных closing actions.",
     pathSuffix: "/dashboard",
@@ -23,5 +28,29 @@ export default async function FranchizeSlugDashboardPage({
   params,
 }: FranchizeSlugDashboardPageProps) {
   const { slug } = await params;
-  return <FranchizeCloserDashboardClient initialSlug={slug} />;
+  const { crew, items } = await getFranchizeBySlug(slug);
+  const resolvedSlug = crew.slug || slug;
+  const activePath = `/franchize/${resolvedSlug}/dashboard`;
+  const surface = crewPaletteForSurface(crew.theme);
+
+  return (
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader
+        crew={crew}
+        activePath={activePath}
+        groupLinks={items.map((item) => item.category)}
+      />
+      <FranchizePageShell
+        theme={crew.theme}
+        width="wide"
+        contentClassName="space-y-4"
+      >
+        <FranchizeCloserDashboardClient
+          initialSlug={resolvedSlug}
+          initialCrew={crew}
+        />
+      </FranchizePageShell>
+      <CrewFooter crew={crew} />
+    </main>
+  );
 }

--- a/app/franchize/[slug]/profile/ProfileClient.tsx
+++ b/app/franchize/[slug]/profile/ProfileClient.tsx
@@ -3,13 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import VibeContentRenderer from "@/components/VibeContentRenderer";
 import { useAppContext } from "@/contexts/AppContext";
@@ -25,12 +18,83 @@ import {
   getFranchizeFormPrefillAction,
   saveFranchizeFormPrefillAction,
 } from "@/app/franchize/profile-actions";
-import { getFranchizeOperatorDashboardAccess } from "@/app/franchize/actions";
+import {
+  getFranchizeOperatorDashboardAccess,
+  type FranchizeCrewVM,
+} from "@/app/franchize/actions";
+import { readablePaletteTextOnColor } from "@/app/franchize/lib/theme";
+import {
+  FranchizeOperatorLinkButton,
+  FranchizeOperatorPanel,
+  FranchizeOperatorStatCard,
+  franchizeOperatorInputClassName,
+  franchizeOperatorInputStyle,
+} from "../../components/FranchizeOperatorSurface";
 
-export function FranchizeProfileClient() {
+const fallbackCrew: FranchizeCrewVM = {
+  id: "",
+  slug: "vip-bike",
+  name: "VIP BIKE",
+  description: "Crew profile",
+  logoUrl: "",
+  hqLocation: "",
+  isFound: false,
+  theme: {
+    mode: "pepperolli_dark",
+    palette: {
+      bgBase: "#0B0C10",
+      bgCard: "#111217",
+      accentMain: "#D99A00",
+      accentMainHover: "#E2A812",
+      textPrimary: "#F2F2F3",
+      textSecondary: "#A7ABB4",
+      borderSoft: "#24262E",
+    },
+  },
+  header: {
+    brandName: "VIP BIKE",
+    tagline: "Ride the vibe",
+    logoUrl: "",
+    logoHref: "",
+    menuLinks: [],
+  },
+  contacts: {
+    phone: "",
+    email: "",
+    address: "",
+    telegram: "",
+    workingHours: "",
+    map: {
+      gps: "",
+      publicTransport: "",
+      carDirections: "",
+      imageUrl: "",
+      bounds: { top: 0, bottom: 0, left: 0, right: 0 },
+    },
+  },
+  catalog: {
+    categories: [],
+    quickLinks: [],
+    tickerItems: [],
+    promoBanners: [],
+    adCards: [],
+    showcaseGroups: [],
+  },
+  ratingSummary: { average: 0, count: 0 },
+  footer: { socialLinks: [], textColor: "#16130A" },
+};
+
+type FranchizeProfileClientProps = {
+  initialCrew?: FranchizeCrewVM;
+};
+
+export function FranchizeProfileClient({
+  initialCrew,
+}: FranchizeProfileClientProps) {
   const { dbUser } = useAppContext();
   const params = useParams<{ slug: string }>();
-  const slug = params?.slug || "vip-bike";
+  const slug = params?.slug || initialCrew?.slug || "vip-bike";
+  const crew = initialCrew || fallbackCrew;
   const [catalog, setCatalog] = useState<FranchizeAchievementDefinition[]>([]);
   const [profile, setProfile] = useState<FranchizeProfileState | null>(null);
   const [capabilityContract, setCapabilityContract] = useState<
@@ -81,7 +145,7 @@ export function FranchizeProfileClient() {
         incrementCounters: { profileOpenCount: 1 },
       });
     };
-    run();
+    void run();
   }, [dbUser?.user_id, slug]);
 
   const unlockedSet = useMemo(
@@ -91,6 +155,11 @@ export function FranchizeProfileClient() {
   const unlockedCount = catalog.filter((item) =>
     unlockedSet.has(item.id),
   ).length;
+  const accentOn = readablePaletteTextOnColor(
+    crew.theme.palette.accentMain,
+    crew.theme.palette,
+  );
+
   const handlePrefillSave = async () => {
     if (!dbUser?.user_id) return;
     const res = await saveFranchizeFormPrefillAction({
@@ -102,208 +171,212 @@ export function FranchizeProfileClient() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-dark-bg via-black to-dark-card text-light-text p-4 pb-16">
-      <div className="container mx-auto max-w-4xl space-y-4">
-        <Card className="border-brand-cyan/40 bg-dark-card/80">
-          <CardHeader>
-            <CardTitle className="font-orbitron text-brand-cyan flex items-center gap-2">
-              <VibeContentRenderer content="::FaIdBadge::" /> Franchize Identity
-              — {profile?.crewName || slug}
-            </CardTitle>
-            <CardDescription className="font-mono text-xs">
-              Персональная страница достижений франшизы: slug-фильтр,
-              capability-треки и интеграционные триггеры.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <div className="rounded-lg border border-brand-green/30 bg-black/20 p-3">
-              <p className="font-orbitron text-brand-green text-sm">
-                Разблокировано
-              </p>
-              <p className="font-mono text-xs text-muted-foreground mt-1">
-                {unlockedCount}/{catalog.length} достижений для slug `{slug}`
-              </p>
-            </div>
-            <div className="rounded-lg border border-brand-purple/30 bg-black/20 p-3">
-              <p className="font-orbitron text-brand-purple text-sm">
-                Счётчики
-              </p>
-              <p className="font-mono text-xs text-muted-foreground mt-1">
-                Открытий профиля: {profile?.counters?.profileOpenCount || 0}
-              </p>
-            </div>
-            <div className="rounded-lg border border-brand-yellow/30 bg-black/20 p-3">
-              <p className="font-orbitron text-brand-yellow text-sm">
-                Последняя активность
-              </p>
-              <p className="font-mono text-xs text-muted-foreground mt-1">
-                {profile?.lastActivityAt || "—"}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="border-brand-pink/30 bg-dark-card/70">
-          <CardHeader>
-            <CardTitle className="font-orbitron text-brand-pink flex items-center gap-2">
-              <VibeContentRenderer content="::FaUserSecret::" /> Достижения
-              франшизы (filtered by slug)
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            {catalog.map((achievement) => {
-              const unlocked = unlockedSet.has(achievement.id);
-              return (
-                <div
-                  key={achievement.id}
-                  className={`rounded-lg border bg-black/20 p-3 ${unlocked ? "border-brand-green/40" : "border-brand-pink/20"}`}
-                >
-                  <p
-                    className={`font-orbitron text-sm ${unlocked ? "text-brand-green" : "text-brand-pink"}`}
-                  >
-                    {achievement.title}
-                  </p>
-                  <p className="font-mono text-xs text-muted-foreground mt-1">
-                    {achievement.description}
-                  </p>
-                  <p className="font-mono text-2xs text-brand-yellow mt-1">
-                    Источник: {achievement.triggerSources.join(", ")}
-                  </p>
-                  <p className="font-mono text-2xs mt-1">
-                    {unlocked ? "✅ Разблокировано" : "🔒 Заблокировано"}
-                  </p>
-                </div>
-              );
-            })}
-            {!!error && (
-              <p className="text-xs font-mono text-red-400">{error}</p>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card className="border-brand-cyan/20 bg-dark-card/60">
-          <CardHeader>
-            <CardTitle className="font-orbitron text-brand-cyan text-base">
-              Capability contract (для интеграций)
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-1">
-            {Object.entries(capabilityContract).map(([key, value]) => (
-              <p key={key} className="font-mono text-xs text-muted-foreground">
-                <span className="text-brand-cyan">{key}:</span> {value}
-              </p>
-            ))}
-          </CardContent>
-        </Card>
-        <Card className="border-brand-green/30 bg-dark-card/70">
-          <CardHeader>
-            <CardTitle className="font-orbitron text-brand-green text-base">
-              Префилл данных для аренды/покупки
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="grid grid-cols-1 gap-2 md:grid-cols-2">
-            <input
-              className="rounded border bg-black/20 p-2 text-sm"
-              placeholder="ФИО"
-              value={prefill.fullName}
-              onChange={(e) =>
-                setPrefill((p) => ({ ...p, fullName: e.target.value }))
-              }
-            />
-            <input
-              className="rounded border bg-black/20 p-2 text-sm"
-              placeholder="Телефон"
-              value={prefill.phone}
-              onChange={(e) =>
-                setPrefill((p) => ({ ...p, phone: e.target.value }))
-              }
-            />
-            <input
-              className="rounded border bg-black/20 p-2 text-sm"
-              placeholder="Удобное время"
-              value={prefill.preferredTime}
-              onChange={(e) =>
-                setPrefill((p) => ({ ...p, preferredTime: e.target.value }))
-              }
-            />
-            <input
-              className="rounded border bg-black/20 p-2 text-sm"
-              placeholder="Комментарий по умолчанию"
-              value={prefill.comment}
-              onChange={(e) =>
-                setPrefill((p) => ({ ...p, comment: e.target.value }))
-              }
-            />
-            <Button className="md:col-span-2" onClick={handlePrefillSave}>
-              Сохранить профильные поля
-            </Button>
-          </CardContent>
-        </Card>
-        <Card className="border-brand-yellow/30 bg-dark-card/70">
-          <CardHeader>
-            <CardTitle className="font-orbitron text-brand-yellow text-base">
-              Аренды и покупки
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-xs text-muted-foreground">Текущие аренды</p>
-            {(digest?.rentals || []).slice(0, 5).map((r) => (
-              <Link
-                key={r.rentalId}
-                href={r.docLink}
-                className="block rounded border p-2 text-sm"
-              >
-                <span className="font-semibold">{r.vehicleLabel}</span> ·{" "}
-                <span className="opacity-80">{r.status}</span>
-              </Link>
-            ))}
-            <p className="pt-2 text-xs text-muted-foreground">
-              Планируемые покупки (sale)
+    <div
+      className="space-y-4"
+      style={{
+        ["--fr-profile-accent" as string]: crew.theme.palette.accentMain,
+        ["--fr-profile-border" as string]: crew.theme.palette.borderSoft,
+        ["--fr-profile-text" as string]: crew.theme.palette.textPrimary,
+        ["--fr-profile-muted" as string]: crew.theme.palette.textSecondary,
+      }}
+    >
+      <FranchizeOperatorPanel muted={false}>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="flex items-center gap-2 text-xs font-medium tracking-wide text-[var(--fr-profile-accent)]">
+              <VibeContentRenderer content="::FaIdBadge::" /> Профиль райдера
             </p>
-            {(digest?.buyOrders || []).slice(0, 5).map((o) => (
-              <Link
-                key={o.orderId}
-                href={o.docLink}
-                className="block rounded border p-2 text-sm"
-              >
-                Заказ #{o.orderId} · {o.status} · {o.vehicleIds.join(", ")}
-                {o.docFileName ? (
-                  <span className="mt-1 block text-xs text-muted-foreground">
-                    Документ: {o.docFileName}
-                  </span>
-                ) : null}
-              </Link>
-            ))}
-          </CardContent>
-        </Card>
+            <h1 className="mt-2 break-words text-2xl font-semibold text-[var(--fr-profile-text)]">
+              {profile?.crewName || crew.header.brandName || slug}
+            </h1>
+            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-[var(--fr-profile-muted)]">
+              Персональная страница достижений, сохранённых данных и быстрых
+              возвратов в аренды экипажа.
+            </p>
+          </div>
+          <FranchizeOperatorLinkButton href={`/franchize/${slug}`}>
+            В каталог
+          </FranchizeOperatorLinkButton>
+        </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-          {canOpenCloserDashboard && (
-            <Button
-              asChild
-              className="bg-brand-yellow text-black hover:bg-brand-yellow/80 font-orbitron"
-            >
-              <Link href={`/franchize/${slug}/dashboard`}>
-                Открыть closer dashboard
-              </Link>
-            </Button>
-          )}
+        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+          <FranchizeOperatorStatCard
+            label="Достижения"
+            value={`${unlockedCount}/${catalog.length}`}
+            detail={`slug: ${slug}`}
+          />
+          <FranchizeOperatorStatCard
+            label="Открытия профиля"
+            value={profile?.counters?.profileOpenCount || 0}
+          />
+          <FranchizeOperatorStatCard
+            label="Последняя активность"
+            value={profile?.lastActivityAt || "—"}
+          />
+        </div>
+      </FranchizeOperatorPanel>
+
+      <FranchizeOperatorPanel>
+        <h2 className="flex items-center gap-2 text-base font-semibold text-[var(--fr-profile-text)]">
+          <VibeContentRenderer content="::FaUserSecret::" /> Достижения
+        </h2>
+        <div className="mt-3 space-y-2">
+          {catalog.map((achievement) => {
+            const unlocked = unlockedSet.has(achievement.id);
+            return (
+              <div
+                key={achievement.id}
+                className="rounded-2xl border p-3"
+                style={{
+                  borderColor: unlocked
+                    ? "var(--fr-profile-accent)"
+                    : "var(--fr-profile-border)",
+                  backgroundColor: unlocked
+                    ? "color-mix(in srgb, var(--franchize-shell-accent) 9%, transparent)"
+                    : "color-mix(in srgb, var(--franchize-shell-card) 70%, transparent)",
+                }}
+              >
+                <p className="text-sm font-semibold text-[var(--fr-profile-text)]">
+                  {achievement.title}
+                </p>
+                <p className="mt-1 text-xs text-[var(--fr-profile-muted)]">
+                  {achievement.description}
+                </p>
+                <p className="mt-1 text-[11px] text-[var(--fr-profile-accent)]">
+                  Источник: {achievement.triggerSources.join(", ")}
+                </p>
+                <p className="mt-1 text-[11px] text-[var(--fr-profile-muted)]">
+                  {unlocked ? "✅ Разблокировано" : "🔒 Заблокировано"}
+                </p>
+              </div>
+            );
+          })}
+          {!!error && <p className="text-xs text-red-400">{error}</p>}
+        </div>
+      </FranchizeOperatorPanel>
+
+      <FranchizeOperatorPanel>
+        <h2 className="text-base font-semibold text-[var(--fr-profile-text)]">
+          Контракт интеграций
+        </h2>
+        <div className="mt-3 space-y-1">
+          {Object.entries(capabilityContract).map(([key, value]) => (
+            <p key={key} className="text-xs text-[var(--fr-profile-muted)]">
+              <span className="font-semibold text-[var(--fr-profile-accent)]">
+                {key}:
+              </span>{" "}
+              {value}
+            </p>
+          ))}
+        </div>
+      </FranchizeOperatorPanel>
+
+      <FranchizeOperatorPanel>
+        <h2 className="text-base font-semibold text-[var(--fr-profile-text)]">
+          Данные для заявок
+        </h2>
+        <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-2">
+          <input
+            className={franchizeOperatorInputClassName}
+            style={franchizeOperatorInputStyle}
+            placeholder="ФИО"
+            value={prefill.fullName}
+            onChange={(e) =>
+              setPrefill((p) => ({ ...p, fullName: e.target.value }))
+            }
+          />
+          <input
+            className={franchizeOperatorInputClassName}
+            style={franchizeOperatorInputStyle}
+            placeholder="Телефон"
+            value={prefill.phone}
+            onChange={(e) =>
+              setPrefill((p) => ({ ...p, phone: e.target.value }))
+            }
+          />
+          <input
+            className={franchizeOperatorInputClassName}
+            style={franchizeOperatorInputStyle}
+            placeholder="Удобное время"
+            value={prefill.preferredTime}
+            onChange={(e) =>
+              setPrefill((p) => ({ ...p, preferredTime: e.target.value }))
+            }
+          />
+          <input
+            className={franchizeOperatorInputClassName}
+            style={franchizeOperatorInputStyle}
+            placeholder="Комментарий по умолчанию"
+            value={prefill.comment}
+            onChange={(e) =>
+              setPrefill((p) => ({ ...p, comment: e.target.value }))
+            }
+          />
           <Button
-            asChild
-            className="bg-brand-cyan text-black hover:bg-brand-cyan/80 font-orbitron"
+            className="md:col-span-2 rounded-full font-semibold"
+            onClick={handlePrefillSave}
+            style={{
+              backgroundColor: "var(--fr-profile-accent)",
+              color: accentOn,
+            }}
           >
-            <Link href={`/franchize/${slug}/map-riders`}>
-              Открыть Map Riders
-            </Link>
-          </Button>
-          <Button
-            asChild
-            variant="outline"
-            className="border-brand-yellow text-brand-yellow hover:bg-brand-yellow/10"
-          >
-            <Link href="/profile">Вернуться в главный профиль</Link>
+            Сохранить данные
           </Button>
         </div>
+      </FranchizeOperatorPanel>
+
+      <FranchizeOperatorPanel>
+        <h2 className="text-base font-semibold text-[var(--fr-profile-text)]">
+          Аренды и покупки
+        </h2>
+        <div className="mt-3 space-y-3">
+          <p className="text-xs text-[var(--fr-profile-muted)]">
+            Текущие аренды
+          </p>
+          {(digest?.rentals || []).slice(0, 5).map((r) => (
+            <Link
+              key={r.rentalId}
+              href={r.docLink}
+              className="block rounded-2xl border p-3 text-sm transition hover:opacity-90"
+              style={{ borderColor: "var(--fr-profile-border)" }}
+            >
+              <span className="font-semibold">{r.vehicleLabel}</span> ·{" "}
+              <span className="opacity-80">{r.status}</span>
+            </Link>
+          ))}
+          <p className="pt-2 text-xs text-[var(--fr-profile-muted)]">
+            Планируемые покупки
+          </p>
+          {(digest?.buyOrders || []).slice(0, 5).map((o) => (
+            <Link
+              key={o.orderId}
+              href={o.docLink}
+              className="block rounded-2xl border p-3 text-sm transition hover:opacity-90"
+              style={{ borderColor: "var(--fr-profile-border)" }}
+            >
+              Заказ #{o.orderId} · {o.status} · {o.vehicleIds.join(", ")}
+              {o.docFileName ? (
+                <span className="mt-1 block text-xs text-[var(--fr-profile-muted)]">
+                  Документ: {o.docFileName}
+                </span>
+              ) : null}
+            </Link>
+          ))}
+        </div>
+      </FranchizeOperatorPanel>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        {canOpenCloserDashboard && (
+          <FranchizeOperatorLinkButton href={`/franchize/${slug}/dashboard`}>
+            Заявки
+          </FranchizeOperatorLinkButton>
+        )}
+        <FranchizeOperatorLinkButton href={`/franchize/${slug}/map-riders`}>
+          Map Riders
+        </FranchizeOperatorLinkButton>
+        <FranchizeOperatorLinkButton href="/profile" variant="secondary">
+          Главный профиль
+        </FranchizeOperatorLinkButton>
       </div>
     </div>
   );

--- a/app/franchize/[slug]/profile/page.tsx
+++ b/app/franchize/[slug]/profile/page.tsx
@@ -1,4 +1,9 @@
 import type { Metadata } from "next";
+import { getFranchizeBySlug } from "../../actions";
+import { CrewFooter } from "../../components/CrewFooter";
+import { CrewHeader } from "../../components/CrewHeader";
+import { FranchizePageShell } from "../../components/FranchizePageShell";
+import { crewPaletteForSurface } from "../../lib/theme";
 import { buildFranchizeSectionMetadata } from "../metadata";
 import { FranchizeProfileClient } from "./ProfileClient";
 
@@ -6,15 +11,38 @@ interface FranchizeProfilePageProps {
   params: Promise<{ slug: string }>;
 }
 
-export async function generateMetadata({ params }: FranchizeProfilePageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: FranchizeProfilePageProps): Promise<Metadata> {
   const { slug } = await params;
   return buildFranchizeSectionMetadata(slug, {
     sectionTitle: "Профиль райдера",
-    sectionDescription: "Персональный профиль франшизы: достижения, активность, сохранённые данные и быстрые переходы к арендам.",
+    sectionDescription:
+      "Персональный профиль франшизы: достижения, активность, сохранённые данные и быстрые переходы к арендам.",
     pathSuffix: "/profile",
   });
 }
 
-export default function FranchizeProfilePage() {
-  return <FranchizeProfileClient />;
+export default async function FranchizeProfilePage({
+  params,
+}: FranchizeProfilePageProps) {
+  const { slug } = await params;
+  const { crew, items } = await getFranchizeBySlug(slug);
+  const resolvedSlug = crew.slug || slug;
+  const activePath = `/franchize/${resolvedSlug}/profile`;
+  const surface = crewPaletteForSurface(crew.theme);
+
+  return (
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader
+        crew={crew}
+        activePath={activePath}
+        groupLinks={items.map((item) => item.category)}
+      />
+      <FranchizePageShell theme={crew.theme} contentClassName="space-y-4">
+        <FranchizeProfileClient initialCrew={crew} />
+      </FranchizePageShell>
+      <CrewFooter crew={crew} />
+    </main>
+  );
 }

--- a/app/franchize/components/FranchizeAdminClient.tsx
+++ b/app/franchize/components/FranchizeAdminClient.tsx
@@ -8,7 +8,6 @@ import { Loading } from "@/components/Loading";
 import { useAppContext } from "@/contexts/AppContext";
 import { getEditableVehiclesForUser } from "@/app/rentals/actions";
 import {
-  getFranchizeBySlug,
   getFranchizeOrderNotificationFailures,
   getFranchizeRentalReviewsForModeration,
   moderateRentalReview,
@@ -19,6 +18,8 @@ import {
 import {
   crewPaletteForSurface,
   focusRingOutlineStyle,
+  readablePaletteTextOnColor,
+  withAlpha,
 } from "@/app/franchize/lib/theme";
 import { CarSubmissionForm } from "@/components/CarSubmissionForm";
 import {
@@ -29,6 +30,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { Database } from "@/types/database.types";
+import {
+  FranchizeOperatorLinkButton,
+  FranchizeOperatorPanel,
+  FranchizeOperatorStatCard,
+} from "./FranchizeOperatorSurface";
 
 type Vehicle = Database["public"]["Tables"]["cars"]["Row"];
 
@@ -108,14 +114,16 @@ const fallbackCrew: FranchizeCrewVM = {
 interface FranchizeAdminClientProps {
   initialSlug: string;
   editId?: string;
+  initialCrew?: FranchizeCrewVM;
 }
 
 export function FranchizeAdminClient({
   initialSlug,
   editId,
+  initialCrew,
 }: FranchizeAdminClientProps) {
   const { dbUser, isLoading } = useAppContext();
-  const [crew, setCrew] = useState<FranchizeCrewVM>(fallbackCrew);
+  const crew = initialCrew || fallbackCrew;
   const [fleet, setFleet] = useState<Vehicle[]>([]);
   const [selectedVehicle, setSelectedVehicle] = useState<Vehicle | null>(null);
   const [filterType, setFilterType] = useState<"all" | "bike" | "car">("all");
@@ -136,11 +144,6 @@ export function FranchizeAdminClient({
   );
 
   const slug = initialSlug?.trim() || "vip-bike";
-
-  const loadCrewTheme = useCallback(async () => {
-    const { crew: loaded } = await getFranchizeBySlug(slug);
-    setCrew(loaded || fallbackCrew);
-  }, [slug]);
 
   const loadFleet = useCallback(async () => {
     if (!dbUser?.user_id) return;
@@ -173,10 +176,6 @@ export function FranchizeAdminClient({
       }
     }
   }, [crew.id, dbUser?.user_id, editId]);
-
-  useEffect(() => {
-    loadCrewTheme();
-  }, [loadCrewTheme]);
 
   useEffect(() => {
     loadFleet();
@@ -306,15 +305,17 @@ export function FranchizeAdminClient({
 
   const surface = crewPaletteForSurface(crew.theme);
   const buttonFocus = focusRingOutlineStyle(crew.theme);
-  const accentOn = "#16130A";
+  const accentOn = readablePaletteTextOnColor(
+    crew.theme.palette.accentMain,
+    crew.theme.palette,
+  );
 
-  if (isLoading) return <Loading text="FRANCHIZE ADMIN INIT..." />;
+  if (isLoading) return <Loading text="Загружаем гараж экипажа..." />;
 
   return (
-    <section
-      className="min-h-screen overflow-x-hidden px-3 pb-10 pt-24 sm:px-4"
+    <div
+      className="space-y-4"
       style={{
-        ...surface.page,
         ["--fr-admin-accent" as string]: crew.theme.palette.accentMain,
         ["--fr-admin-accent-hover" as string]:
           crew.theme.palette.accentMainHover,
@@ -323,393 +324,313 @@ export function FranchizeAdminClient({
         ["--fr-admin-muted" as string]: crew.theme.palette.textSecondary,
       }}
     >
-      <div
-        className="mx-auto max-w-5xl overflow-hidden rounded-3xl border p-4 sm:p-6"
-        style={surface.card}
-      >
-        <p className="text-xs uppercase tracking-[0.2em] text-[var(--fr-admin-accent)]">
-          crew owner console
-        </p>
-        <h1 className="mt-2 break-words text-2xl font-semibold text-[var(--fr-admin-text)]">
-          {(crew.header.brandName || crew.name || slug).toUpperCase()} — ADMIN
-          GARAGE
-        </h1>
-        <p className="mt-2 max-w-3xl break-words text-sm leading-relaxed text-[var(--fr-admin-muted)]">
-          Переключатель экипажа:{" "}
-          <span className="font-semibold text-[var(--fr-admin-accent)]">
-            {slug}
-          </span>
-          . Редактируй bike/car карточки, добавляй VIN и формируй корректные
-          checkout документы без контрастных артефактов темы.
-        </p>
+      <p className="text-xs font-medium tracking-wide text-[var(--fr-admin-accent)]">
+        Консоль экипажа
+      </p>
+      <h1 className="mt-2 break-words text-2xl font-semibold text-[var(--fr-admin-text)]">
+        {crew.header.brandName || crew.name || slug}: гараж
+      </h1>
+      <p className="mt-2 max-w-3xl break-words text-sm leading-relaxed text-[var(--fr-admin-muted)]">
+        Переключатель экипажа:{" "}
+        <span className="font-semibold text-[var(--fr-admin-accent)]">
+          {slug}
+        </span>
+        . Редактируй технику, добавляй VIN и проверяй документы в той же
+        визуальной системе, что каталог и аренды.
+      </p>
 
-        <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-3">
-          {[
-            { id: "all", label: `Все (${fleet.length})` },
-            {
-              id: "bike",
-              label: `Байки (${fleet.filter((v) => v.type === "bike").length})`,
-            },
-            {
-              id: "car",
-              label: `Авто (${fleet.filter((v) => v.type === "car").length})`,
-            },
-          ].map((filter) => {
-            const active = filterType === filter.id;
-            return (
-              <Button
-                key={filter.id}
-                type="button"
-                onClick={() =>
-                  setFilterType(filter.id as "all" | "bike" | "car")
-                }
-                className="h-10 border text-sm font-semibold"
-                style={{
-                  borderColor: "var(--fr-admin-border)",
-                  color: active ? accentOn : "var(--fr-admin-text)",
-                  backgroundColor: active
-                    ? "var(--fr-admin-accent)"
-                    : "transparent",
-                  ...buttonFocus,
-                }}
-              >
-                {filter.label}
-              </Button>
-            );
-          })}
-        </div>
-
-        <div className="mt-4 grid gap-3 sm:grid-cols-3">
-          <div
-            className="min-w-0 rounded-2xl border p-3"
-            style={{
-              ...surface.subtleCard,
-              borderColor: "var(--fr-admin-border)",
-            }}
-          >
-            <p className="text-xs uppercase tracking-[0.16em] text-[var(--fr-admin-muted)]">
-              Всего в scope
-            </p>
-            <p className="mt-2 text-2xl font-semibold text-[var(--fr-admin-text)]">
-              {fleet.length}
-            </p>
-          </div>
-          <div
-            className="min-w-0 rounded-2xl border p-3"
-            style={{
-              ...surface.subtleCard,
-              borderColor: "var(--fr-admin-border)",
-            }}
-          >
-            <p className="text-xs uppercase tracking-[0.16em] text-[var(--fr-admin-muted)]">
-              Байки
-            </p>
-            <p className="mt-2 text-2xl font-semibold text-[var(--fr-admin-text)]">
-              {fleet.filter((v) => v.type === "bike").length}
-            </p>
-          </div>
-          <div
-            className="min-w-0 rounded-2xl border p-3"
-            style={{
-              ...surface.subtleCard,
-              borderColor: "var(--fr-admin-border)",
-            }}
-          >
-            <p className="text-xs uppercase tracking-[0.16em] text-[var(--fr-admin-muted)]">
-              Авто
-            </p>
-            <p className="mt-2 text-2xl font-semibold text-[var(--fr-admin-text)]">
-              {fleet.filter((v) => v.type === "car").length}
-            </p>
-          </div>
-        </div>
-        <div
-          className="mt-4 rounded-2xl border p-3 text-sm leading-relaxed"
-          style={{
-            ...surface.subtleCard,
-            borderColor: "var(--fr-admin-border)",
-          }}
-        >
-          <p className="break-words text-[var(--fr-admin-text)]">
-            Для doc-шаблона используй specs: <code>vin</code>,{" "}
-            <code>plate</code>, <code>frame</code>.
-          </p>
-          <p className="mt-1 text-xs text-[var(--fr-admin-muted)]">
-            Доступно записей по фильтру:{" "}
-            <span className="font-semibold text-[var(--fr-admin-accent)]">
-              {visible.length}
-            </span>
-            .{loadingFleet ? " Обновляем список..." : ""}
-          </p>
-          <div
-            className="mt-2 rounded-xl border px-3 py-2"
-            style={{
-              borderColor: "var(--fr-admin-border)",
-              backgroundColor: "rgba(217,154,0,0.08)",
-            }}
-          >
-            <p className="text-xs text-[var(--fr-admin-text)]">
-              VIN аудит:{" "}
-              <span className="font-semibold">{vinAudit.withVin}</span> /{" "}
-              {vinAudit.total} заполнено
-            </p>
-            {vinAudit.missing.length > 0 && (
-              <p className="mt-1 text-xs text-amber-300">
-                Пустых VIN: {vinAudit.missing.length}
-              </p>
-            )}
-            {vinAudit.missing.length > 0 && (
-              <Button
-                type="button"
-                variant="outline"
-                className="mt-2 h-8 text-xs"
-                onClick={() => void handleBulkFillVin()}
-                disabled={isBulkFillingVin}
-              >
-                {isBulkFillingVin ? "Заполняю VIN…" : "Bulk-fill VIN"}
-              </Button>
-            )}
-          </div>
-        </div>
-
-        <div
-          className="mt-4 rounded-2xl border p-3"
-          style={{
-            ...surface.subtleCard,
-            borderColor: "var(--fr-admin-border)",
-          }}
-        >
-          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr),auto] sm:items-center">
-            <div>
-              <p className="text-sm font-semibold text-[var(--fr-admin-text)]">
-                Operator closer dashboard moved
-              </p>
-              <p className="mt-1 text-xs leading-relaxed text-[var(--fr-admin-muted)]">
-                Garage admin остаётся для техники, VIN, отзывов и документов.
-                Горячие лиды, Telegram replies и closing actions теперь живут на
-                отдельной dashboard page.
-              </p>
-            </div>
+      <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-3">
+        {[
+          { id: "all", label: `Все (${fleet.length})` },
+          {
+            id: "bike",
+            label: `Байки (${fleet.filter((v) => v.type === "bike").length})`,
+          },
+          {
+            id: "car",
+            label: `Авто (${fleet.filter((v) => v.type === "car").length})`,
+          },
+        ].map((filter) => {
+          const active = filterType === filter.id;
+          return (
             <Button
-              asChild
-              className="h-9 text-xs font-semibold"
+              key={filter.id}
+              type="button"
+              onClick={() => setFilterType(filter.id as "all" | "bike" | "car")}
+              className="h-10 border text-sm font-semibold"
               style={{
+                borderColor: "var(--fr-admin-border)",
+                color: active ? accentOn : "var(--fr-admin-text)",
+                backgroundColor: active
+                  ? "var(--fr-admin-accent)"
+                  : "transparent",
                 ...buttonFocus,
-                backgroundColor: "var(--fr-admin-accent)",
-                color: accentOn,
               }}
             >
-              <Link href={`/franchize/${slug}/dashboard`}>
-                Open closer dashboard
-              </Link>
+              {filter.label}
             </Button>
-          </div>
-        </div>
+          );
+        })}
+      </div>
 
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <FranchizeOperatorStatCard label="Всего в зоне" value={fleet.length} />
+        <FranchizeOperatorStatCard
+          label="Байки"
+          value={fleet.filter((v) => v.type === "bike").length}
+        />
+        <FranchizeOperatorStatCard
+          label="Авто"
+          value={fleet.filter((v) => v.type === "car").length}
+        />
+      </div>
+      <FranchizeOperatorPanel className="mt-4 text-sm leading-relaxed">
+        <p className="break-words text-[var(--fr-admin-text)]">
+          Для doc-шаблона используй specs: <code>vin</code>, <code>plate</code>,{" "}
+          <code>frame</code>.
+        </p>
+        <p className="mt-1 text-xs text-[var(--fr-admin-muted)]">
+          Доступно записей по фильтру:{" "}
+          <span className="font-semibold text-[var(--fr-admin-accent)]">
+            {visible.length}
+          </span>
+          .{loadingFleet ? " Обновляем список..." : ""}
+        </p>
         <div
-          className="mt-4 rounded-2xl border p-3"
+          className="mt-2 rounded-xl border px-3 py-2"
           style={{
-            ...surface.subtleCard,
             borderColor: "var(--fr-admin-border)",
+            backgroundColor: withAlpha(crew.theme.palette.accentMain, 0.08),
           }}
         >
-          <div className="mb-3 grid gap-2 sm:grid-cols-[minmax(0,1fr),auto]">
-            <Select
-              value={selectedVehicle?.id ?? "new"}
-              onValueChange={(value) =>
-                setSelectedVehicle(
-                  value === "new"
-                    ? null
-                    : (visible.find((vehicle) => vehicle.id === value) ?? null),
-                )
-              }
-            >
-              <SelectTrigger
-                className="w-full border text-left"
-                style={{
-                  borderColor: "var(--fr-admin-border)",
-                  color: "var(--fr-admin-text)",
-                  backgroundColor: surface.page.backgroundColor,
-                }}
-              >
-                <SelectValue placeholder="Выбери запись для редактирования" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="new">Создать новую запись</SelectItem>
-                {visible.map((vehicle) => (
-                  <SelectItem key={vehicle.id} value={vehicle.id}>
-                    {vehicle.type === "car" ? "🚗" : "🏍️"} {vehicle.make}{" "}
-                    {vehicle.model}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          <p className="text-xs text-[var(--fr-admin-text)]">
+            VIN аудит: <span className="font-semibold">{vinAudit.withVin}</span>{" "}
+            / {vinAudit.total} заполнено
+          </p>
+          {vinAudit.missing.length > 0 && (
+            <p className="mt-1 text-xs text-amber-300">
+              Пустых VIN: {vinAudit.missing.length}
+            </p>
+          )}
+          {vinAudit.missing.length > 0 && (
             <Button
               type="button"
               variant="outline"
-              onClick={() => setSelectedVehicle(null)}
-              className="w-full sm:w-auto"
+              className="mt-2 h-8 text-xs"
+              onClick={() => void handleBulkFillVin()}
+              disabled={isBulkFillingVin}
             >
-              Новая запись
+              {isBulkFillingVin ? "Заполняю VIN…" : "Bulk-fill VIN"}
             </Button>
-          </div>
-          <div className="mb-3 flex flex-wrap gap-2">
-            {visible.slice(0, 8).map((vehicle) => (
-              <button
-                key={vehicle.id}
-                type="button"
-                onClick={() => setSelectedVehicle(vehicle)}
-                className="max-w-full rounded-full border px-3 py-1 text-xs font-medium transition hover:opacity-90"
-                style={{
-                  borderColor:
-                    selectedVehicle?.id === vehicle.id
-                      ? "var(--fr-admin-accent)"
-                      : "var(--fr-admin-border)",
-                  color:
-                    selectedVehicle?.id === vehicle.id
-                      ? accentOn
-                      : "var(--fr-admin-text)",
-                  backgroundColor:
-                    selectedVehicle?.id === vehicle.id
-                      ? "var(--fr-admin-accent)"
-                      : "transparent",
-                }}
-              >
-                <span className="block max-w-[220px] truncate">
-                  {vehicle.make} {vehicle.model}
-                </span>
-              </button>
-            ))}
-          </div>
-          <CarSubmissionForm
-            ownerId={dbUser?.user_id}
-            vehicleToEdit={selectedVehicle}
-            onSuccess={() => loadFleet()}
-          />
-        </div>
-
-        <div
-          className="mt-4 rounded-2xl border p-3"
-          style={{
-            ...surface.subtleCard,
-            borderColor: "var(--fr-admin-border)",
-          }}
-        >
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-sm font-semibold text-[var(--fr-admin-text)]">
-              Модерация отзывов аренды
-            </p>
-            <span
-              className="rounded-full border px-2 py-1 text-xs text-[var(--fr-admin-muted)]"
-              style={{ borderColor: "var(--fr-admin-border)" }}
-            >
-              {reviews.length}
-            </span>
-          </div>
-          {!reviews.length ? (
-            <p className="mt-2 text-xs text-[var(--fr-admin-muted)]">
-              Отзывов пока нет.
-            </p>
-          ) : (
-            <div className="mt-3 space-y-2">
-              {reviews.slice(0, 8).map((review) => (
-                <div
-                  key={review.id}
-                  className="rounded-xl border p-2"
-                  style={{
-                    borderColor: "var(--fr-admin-border)",
-                    opacity: review.hiddenAt ? 0.62 : 1,
-                  }}
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <p className="text-xs font-semibold text-[var(--fr-admin-accent)]">
-                      ★ {review.rating} / 5
-                    </p>
-                    <Button
-                      type="button"
-                      className="h-8 text-xs"
-                      variant="outline"
-                      onClick={() =>
-                        handleModerateReview(review.id, !review.hiddenAt)
-                      }
-                      disabled={moderatingReviewId === review.id}
-                    >
-                      {review.hiddenAt ? "Показать" : "Скрыть"}
-                    </Button>
-                  </div>
-                  <p className="mt-1 text-xs text-[var(--fr-admin-muted)]">
-                    байк: {review.bikeId} · пользователь: {review.userId}
-                  </p>
-                  {review.text && (
-                    <p className="mt-2 text-sm text-[var(--fr-admin-text)]">
-                      {review.text}
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
           )}
         </div>
+      </FranchizeOperatorPanel>
 
-        <div
-          className="mt-4 rounded-2xl border p-3"
-          style={{
-            ...surface.subtleCard,
-            borderColor: "var(--fr-admin-border)",
-          }}
-        >
-          <p className="text-sm font-semibold text-[var(--fr-admin-text)]">
-            Failed doc notifications
-          </p>
-          {!failedNotifications.length ? (
-            <p className="mt-2 text-xs text-[var(--fr-admin-muted)]">
-              Сбоев отправки не найдено.
+      <FranchizeOperatorPanel className="mt-4">
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr),auto] sm:items-center">
+          <div>
+            <p className="text-sm font-semibold text-[var(--fr-admin-text)]">
+              Панель заявок вынесена
             </p>
-          ) : (
-            <div className="mt-3 space-y-2">
-              {failedNotifications.map((item) => (
-                <div
-                  key={`${item.orderId}-${item.sendTo}-${item.createdAt}`}
-                  className="rounded-xl border p-2"
-                  style={{ borderColor: "var(--fr-admin-border)" }}
-                >
-                  <p className="text-xs text-[var(--fr-admin-text)]">
-                    Заказ #{item.orderId} → {item.sendTo || "unknown"}
-                  </p>
-                  <p className="mt-1 text-xs text-rose-300">
-                    {item.lastError || "unknown error"}
+            <p className="mt-1 text-xs leading-relaxed text-[var(--fr-admin-muted)]">
+              Гараж остаётся для техники, VIN, отзывов и документов. Горячие
+              заявки, ответы в Telegram и closing actions вынесены в отдельную
+              панель.
+            </p>
+          </div>
+          <Button
+            asChild
+            className="h-9 text-xs font-semibold"
+            style={{
+              ...buttonFocus,
+              backgroundColor: "var(--fr-admin-accent)",
+              color: accentOn,
+            }}
+          >
+            <Link href={`/franchize/${slug}/dashboard`}>Открыть заявки</Link>
+          </Button>
+        </div>
+      </FranchizeOperatorPanel>
+
+      <FranchizeOperatorPanel className="mt-4">
+        <div className="mb-3 grid gap-2 sm:grid-cols-[minmax(0,1fr),auto]">
+          <Select
+            value={selectedVehicle?.id ?? "new"}
+            onValueChange={(value) =>
+              setSelectedVehicle(
+                value === "new"
+                  ? null
+                  : (visible.find((vehicle) => vehicle.id === value) ?? null),
+              )
+            }
+          >
+            <SelectTrigger
+              className="w-full border text-left"
+              style={{
+                borderColor: "var(--fr-admin-border)",
+                color: "var(--fr-admin-text)",
+                backgroundColor: surface.page.backgroundColor,
+              }}
+            >
+              <SelectValue placeholder="Выбери запись для редактирования" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="new">Создать новую запись</SelectItem>
+              {visible.map((vehicle) => (
+                <SelectItem key={vehicle.id} value={vehicle.id}>
+                  {vehicle.type === "car" ? "🚗" : "🏍️"} {vehicle.make}{" "}
+                  {vehicle.model}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setSelectedVehicle(null)}
+            className="w-full sm:w-auto"
+          >
+            Новая запись
+          </Button>
+        </div>
+        <div className="mb-3 flex flex-wrap gap-2">
+          {visible.slice(0, 8).map((vehicle) => (
+            <button
+              key={vehicle.id}
+              type="button"
+              onClick={() => setSelectedVehicle(vehicle)}
+              className="max-w-full rounded-full border px-3 py-1 text-xs font-medium transition hover:opacity-90"
+              style={{
+                borderColor:
+                  selectedVehicle?.id === vehicle.id
+                    ? "var(--fr-admin-accent)"
+                    : "var(--fr-admin-border)",
+                color:
+                  selectedVehicle?.id === vehicle.id
+                    ? accentOn
+                    : "var(--fr-admin-text)",
+                backgroundColor:
+                  selectedVehicle?.id === vehicle.id
+                    ? "var(--fr-admin-accent)"
+                    : "transparent",
+              }}
+            >
+              <span className="block max-w-[220px] truncate">
+                {vehicle.make} {vehicle.model}
+              </span>
+            </button>
+          ))}
+        </div>
+        <CarSubmissionForm
+          ownerId={dbUser?.user_id}
+          vehicleToEdit={selectedVehicle}
+          onSuccess={() => loadFleet()}
+        />
+      </FranchizeOperatorPanel>
+
+      <FranchizeOperatorPanel className="mt-4">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-semibold text-[var(--fr-admin-text)]">
+            Модерация отзывов аренды
+          </p>
+          <span
+            className="rounded-full border px-2 py-1 text-xs text-[var(--fr-admin-muted)]"
+            style={{ borderColor: "var(--fr-admin-border)" }}
+          >
+            {reviews.length}
+          </span>
+        </div>
+        {!reviews.length ? (
+          <p className="mt-2 text-xs text-[var(--fr-admin-muted)]">
+            Отзывов пока нет.
+          </p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {reviews.slice(0, 8).map((review) => (
+              <div
+                key={review.id}
+                className="rounded-xl border p-2"
+                style={{
+                  borderColor: "var(--fr-admin-border)",
+                  opacity: review.hiddenAt ? 0.62 : 1,
+                }}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="text-xs font-semibold text-[var(--fr-admin-accent)]">
+                    ★ {review.rating} / 5
                   </p>
                   <Button
                     type="button"
-                    className="mt-2 h-8 text-xs"
-                    onClick={() => handleRetryNotification(item.orderId)}
-                    disabled={retryingOrderId === item.orderId}
+                    className="h-8 text-xs"
+                    variant="outline"
+                    onClick={() =>
+                      handleModerateReview(review.id, !review.hiddenAt)
+                    }
+                    disabled={moderatingReviewId === review.id}
                   >
-                    {retryingOrderId === item.orderId
-                      ? "Retry..."
-                      : "Retry send"}
+                    {review.hiddenAt ? "Показать" : "Скрыть"}
                   </Button>
                 </div>
-              ))}
-            </div>
-          )}
-        </div>
+                <p className="mt-1 text-xs text-[var(--fr-admin-muted)]">
+                  байк: {review.bikeId} · пользователь: {review.userId}
+                </p>
+                {review.text && (
+                  <p className="mt-2 text-sm text-[var(--fr-admin-text)]">
+                    {review.text}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </FranchizeOperatorPanel>
 
-        <div className="mt-4 flex flex-wrap gap-3 text-sm">
-          <Link
-            className="underline underline-offset-4 text-[var(--fr-admin-accent)]"
-            href="/admin"
-          >
-            ← Общий admin
-          </Link>
-          <Link
-            className="underline underline-offset-4 text-[var(--fr-admin-accent)]"
-            href={`/franchize/${slug}`}
-          >
-            Открыть storefront
-          </Link>
-        </div>
+      <FranchizeOperatorPanel className="mt-4">
+        <p className="text-sm font-semibold text-[var(--fr-admin-text)]">
+          Сбои отправки документов
+        </p>
+        {!failedNotifications.length ? (
+          <p className="mt-2 text-xs text-[var(--fr-admin-muted)]">
+            Сбоев отправки не найдено.
+          </p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {failedNotifications.map((item) => (
+              <div
+                key={`${item.orderId}-${item.sendTo}-${item.createdAt}`}
+                className="rounded-xl border p-2"
+                style={{ borderColor: "var(--fr-admin-border)" }}
+              >
+                <p className="text-xs text-[var(--fr-admin-text)]">
+                  Заказ #{item.orderId} → {item.sendTo || "unknown"}
+                </p>
+                <p className="mt-1 text-xs text-rose-300">
+                  {item.lastError || "unknown error"}
+                </p>
+                <Button
+                  type="button"
+                  className="mt-2 h-8 text-xs"
+                  onClick={() => handleRetryNotification(item.orderId)}
+                  disabled={retryingOrderId === item.orderId}
+                >
+                  {retryingOrderId === item.orderId
+                    ? "Повторяем..."
+                    : "Повторить отправку"}
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </FranchizeOperatorPanel>
+
+      <div className="mt-4 flex flex-wrap gap-3 text-sm">
+        <FranchizeOperatorLinkButton href="/admin" variant="secondary">
+          ← Общий админ
+        </FranchizeOperatorLinkButton>
+        <FranchizeOperatorLinkButton href={`/franchize/${slug}`}>
+          Открыть витрину
+        </FranchizeOperatorLinkButton>
       </div>
-    </section>
+    </div>
   );
 }

--- a/app/franchize/components/FranchizeCloserDashboardClient.tsx
+++ b/app/franchize/components/FranchizeCloserDashboardClient.tsx
@@ -1,32 +1,36 @@
 "use client";
 
-import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import {
-  getFranchizeBySlug,
   getFranchizeCloserIntents,
   updateFranchizeCloserIntentStage,
   type FranchizeCrewVM,
 } from "@/app/franchize/actions";
 import {
-  crewPaletteForSurface,
   focusRingOutlineStyle,
+  readablePaletteTextOnColor,
+  withAlpha,
 } from "@/app/franchize/lib/theme";
 import { Loading } from "@/components/Loading";
 import { Button } from "@/components/ui/button";
 import { useAppContext } from "@/contexts/AppContext";
+import {
+  FranchizeOperatorLinkButton,
+  FranchizeOperatorPanel,
+  FranchizeOperatorStatCard,
+} from "./FranchizeOperatorSurface";
 
 type CloserIntent = NonNullable<
   Awaited<ReturnType<typeof getFranchizeCloserIntents>>["items"]
 >[number];
 
 const closerActionLabels = {
-  send_offer: "Send offer",
-  reserve_manually: "Reserve manually",
-  offer_alternative_bike: "Offer alternative bike",
-  mark_closed: "Mark closed",
+  send_offer: "Отправить оффер",
+  reserve_manually: "Резерв вручную",
+  offer_alternative_bike: "Предложить замену",
+  mark_closed: "Закрыть",
 } as const;
 
 type CloserAction = keyof typeof closerActionLabels;
@@ -86,13 +90,15 @@ const fallbackCrew: FranchizeCrewVM = {
 
 interface FranchizeCloserDashboardClientProps {
   initialSlug: string;
+  initialCrew?: FranchizeCrewVM;
 }
 
 export function FranchizeCloserDashboardClient({
   initialSlug,
+  initialCrew,
 }: FranchizeCloserDashboardClientProps) {
   const { dbUser, isLoading } = useAppContext();
-  const [crew, setCrew] = useState<FranchizeCrewVM>(fallbackCrew);
+  const crew = initialCrew || fallbackCrew;
   const [closerIntents, setCloserIntents] = useState<CloserIntent[]>([]);
   const [loadingCloserIntents, setLoadingCloserIntents] = useState(false);
   const [closerActionIntentId, setCloserActionIntentId] = useState<
@@ -101,15 +107,6 @@ export function FranchizeCloserDashboardClient({
   const closerLoadRequestRef = useRef(0);
 
   const slug = initialSlug?.trim() || "vip-bike";
-
-  const loadCrewTheme = useCallback(async () => {
-    try {
-      const { crew: loaded } = await getFranchizeBySlug(slug);
-      setCrew(loaded || fallbackCrew);
-    } catch {
-      setCrew(fallbackCrew);
-    }
-  }, [slug]);
 
   const loadCloserIntents = useCallback(async () => {
     if (!dbUser?.user_id) return;
@@ -138,10 +135,6 @@ export function FranchizeCloserDashboardClient({
       }
     }
   }, [dbUser?.user_id, slug]);
-
-  useEffect(() => {
-    void loadCrewTheme();
-  }, [loadCrewTheme]);
 
   useEffect(() => {
     void loadCloserIntents();
@@ -188,258 +181,212 @@ export function FranchizeCloserDashboardClient({
     [dbUser?.user_id, loadCloserIntents, slug],
   );
 
-  const surface = crewPaletteForSurface(crew.theme);
   const buttonFocus = focusRingOutlineStyle(crew.theme);
-  const accentOn = "#16130A";
+  const accentOn = readablePaletteTextOnColor(
+    crew.theme.palette.accentMain,
+    crew.theme.palette,
+  );
   const brandName = crew.header.brandName || crew.name || slug;
 
-  if (isLoading) return <Loading text="FRANCHIZE DASHBOARD INIT..." />;
+  if (isLoading) return <Loading text="Загружаем заявки экипажа..." />;
 
   return (
-    <section
-      className="min-h-screen overflow-x-hidden px-3 pb-10 pt-24 sm:px-4"
+    <div
+      className="space-y-4"
       style={{
-        ...surface.page,
         ["--fr-dashboard-accent" as string]: crew.theme.palette.accentMain,
         ["--fr-dashboard-border" as string]: crew.theme.palette.borderSoft,
         ["--fr-dashboard-text" as string]: crew.theme.palette.textPrimary,
         ["--fr-dashboard-muted" as string]: crew.theme.palette.textSecondary,
       }}
     >
-      <div
-        className="mx-auto max-w-6xl overflow-hidden rounded-3xl border p-4 sm:p-6"
-        style={surface.card}
-      >
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <p className="text-xs uppercase tracking-[0.2em] text-[var(--fr-dashboard-accent)]">
-              operator closer dashboard
-            </p>
-            <h1 className="mt-2 break-words text-2xl font-semibold text-[var(--fr-dashboard-text)]">
-              {brandName.toUpperCase()} — HOT LEADS
-            </h1>
-            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-[var(--fr-dashboard-muted)]">
-              Отдельная franchize dashboard page для sales/closer работы. Лиды
-              читаются из server-only intent ledger, ранжируются по urgency
-              score и сохраняют историю действий в metadata.
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              asChild
-              variant="outline"
-              className="h-9 text-xs"
-              style={buttonFocus}
-            >
-              <Link href={`/franchize/${slug}/admin`}>Garage admin</Link>
-            </Button>
-            <Button
-              asChild
-              variant="outline"
-              className="h-9 text-xs"
-              style={buttonFocus}
-            >
-              <Link href={`/franchize/${slug}`}>Storefront</Link>
-            </Button>
-          </div>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium tracking-wide text-[var(--fr-dashboard-accent)]">
+            Панель заявок
+          </p>
+          <h1 className="mt-2 break-words text-2xl font-semibold text-[var(--fr-dashboard-text)]">
+            {brandName}: горячие лиды
+          </h1>
+          <p className="mt-2 max-w-3xl text-sm leading-relaxed text-[var(--fr-dashboard-muted)]">
+            Единая рабочая очередь для продаж: заявки читаются из server-only
+            ledger, сортируются по срочности и сохраняют историю действий.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <FranchizeOperatorLinkButton
+            href={`/franchize/${slug}/admin`}
+            variant="secondary"
+          >
+            Гараж
+          </FranchizeOperatorLinkButton>
+          <FranchizeOperatorLinkButton href={`/franchize/${slug}`}>
+            Витрина
+          </FranchizeOperatorLinkButton>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <FranchizeOperatorStatCard
+          label="Горячие заявки"
+          value={hotCloserCount}
+        />
+        <FranchizeOperatorStatCard
+          label="Всего сигналов"
+          value={closerIntents.length}
+        />
+        <FranchizeOperatorStatCard
+          label="Режим"
+          value="Копия + ручное закрытие"
+        />
+      </div>
+      <FranchizeOperatorPanel className="mt-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm font-semibold text-[var(--fr-dashboard-text)]">
+            Очередь заявок
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-8 text-xs"
+            onClick={() => void loadCloserIntents()}
+            disabled={loadingCloserIntents}
+            style={buttonFocus}
+          >
+            {loadingCloserIntents ? "Обновляем…" : "Обновить"}
+          </Button>
         </div>
 
-        <div className="mt-4 grid gap-3 sm:grid-cols-3">
-          <div
-            className="rounded-2xl border p-3"
-            style={{
-              ...surface.subtleCard,
-              borderColor: "var(--fr-dashboard-border)",
-            }}
+        {!closerIntents.length ? (
+          <p
+            className="mt-3 rounded-xl border px-3 py-2 text-xs text-[var(--fr-dashboard-muted)]"
+            style={{ borderColor: "var(--fr-dashboard-border)" }}
           >
-            <p className="text-xs uppercase tracking-[0.16em] text-[var(--fr-dashboard-muted)]">
-              hot leads
-            </p>
-            <p className="mt-2 text-3xl font-semibold text-[var(--fr-dashboard-text)]">
-              {hotCloserCount}
-            </p>
-          </div>
-          <div
-            className="rounded-2xl border p-3"
-            style={{
-              ...surface.subtleCard,
-              borderColor: "var(--fr-dashboard-border)",
-            }}
-          >
-            <p className="text-xs uppercase tracking-[0.16em] text-[var(--fr-dashboard-muted)]">
-              all intents
-            </p>
-            <p className="mt-2 text-3xl font-semibold text-[var(--fr-dashboard-text)]">
-              {closerIntents.length}
-            </p>
-          </div>
-          <div
-            className="rounded-2xl border p-3"
-            style={{
-              ...surface.subtleCard,
-              borderColor: "var(--fr-dashboard-border)",
-            }}
-          >
-            <p className="text-xs uppercase tracking-[0.16em] text-[var(--fr-dashboard-muted)]">
-              mode
-            </p>
-            <p className="mt-2 text-sm font-semibold text-[var(--fr-dashboard-text)]">
-              copy-first · manual close
-            </p>
-          </div>
-        </div>
-
-        <div
-          className="mt-4 rounded-2xl border p-3"
-          style={{
-            ...surface.subtleCard,
-            borderColor: "var(--fr-dashboard-border)",
-          }}
-        >
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <p className="text-sm font-semibold text-[var(--fr-dashboard-text)]">
-              Ranked closer queue
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              className="h-8 text-xs"
-              onClick={() => void loadCloserIntents()}
-              disabled={loadingCloserIntents}
-              style={buttonFocus}
-            >
-              {loadingCloserIntents ? "Loading…" : "Refresh"}
-            </Button>
-          </div>
-
-          {!closerIntents.length ? (
-            <p
-              className="mt-3 rounded-xl border px-3 py-2 text-xs text-[var(--fr-dashboard-muted)]"
-              style={{ borderColor: "var(--fr-dashboard-border)" }}
-            >
-              Hot leads пока не найдены. После checkout/recovery/prebuy сигналов
-              здесь появятся карточки для закрытия.
-            </p>
-          ) : (
-            <div className="mt-3 space-y-3">
-              {closerIntents.map((intent) => (
-                <article
-                  key={intent.id}
-                  className="rounded-2xl border p-3"
-                  style={{
-                    borderColor:
-                      intent.stage === "closed"
-                        ? "var(--fr-dashboard-border)"
-                        : "var(--fr-dashboard-accent)",
-                    backgroundColor:
-                      intent.stage === "closed"
-                        ? "rgba(255,255,255,0.02)"
-                        : "rgba(217,154,0,0.07)",
-                  }}
-                >
-                  <div className="grid gap-3 lg:grid-cols-[minmax(0,1.15fr),minmax(0,1fr)]">
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span
-                          className="rounded-full bg-[var(--fr-dashboard-accent)] px-2 py-1 text-xs font-bold"
-                          style={{ color: accentOn }}
-                        >
-                          {intent.urgencyScore}
-                        </span>
-                        <span
-                          className="rounded-full border px-2 py-1 text-xs text-[var(--fr-dashboard-text)]"
-                          style={{ borderColor: "var(--fr-dashboard-border)" }}
-                        >
-                          {intent.intentType} · {intent.stage}
-                        </span>
-                        <span className="text-xs text-[var(--fr-dashboard-muted)]">
-                          updated{" "}
-                          {intent.updatedAt
-                            ? new Date(intent.updatedAt).toLocaleString()
-                            : "—"}
-                        </span>
-                      </div>
-                      <p className="mt-2 break-words text-base font-semibold text-[var(--fr-dashboard-text)]">
-                        {intent.bikeLabel}
-                      </p>
-                      <dl className="mt-2 grid gap-2 text-xs sm:grid-cols-2">
-                        <div>
-                          <dt className="uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
-                            dates
-                          </dt>
-                          <dd className="mt-1 break-words text-[var(--fr-dashboard-text)]">
-                            {intent.selectedDates}
-                          </dd>
-                        </div>
-                        <div>
-                          <dt className="uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
-                            contact
-                          </dt>
-                          <dd className="mt-1 break-words text-[var(--fr-dashboard-text)]">
-                            {intent.contactChannel}
-                            {intent.telegramUsername
-                              ? ` · @${intent.telegramUsername}`
-                              : ""}
-                            {intent.telegramUserId
-                              ? ` · tg:${intent.telegramUserId}`
-                              : ""}
-                          </dd>
-                        </div>
-                        <div>
-                          <dt className="uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
-                            last blocker
-                          </dt>
-                          <dd className="mt-1 break-words text-[var(--fr-dashboard-text)]">
-                            {intent.lastBlocker}
-                          </dd>
-                        </div>
-                        <div>
-                          <dt className="uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
-                            payment
-                          </dt>
-                          <dd className="mt-1 break-words text-[var(--fr-dashboard-text)]">
-                            {intent.paymentState}
-                          </dd>
-                        </div>
-                      </dl>
-                    </div>
-                    <div
-                      className="min-w-0 rounded-xl border p-3"
-                      style={{
-                        borderColor: "var(--fr-dashboard-border)",
-                        backgroundColor: "rgba(0,0,0,0.16)",
-                      }}
-                    >
-                      <p className="text-xs uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
-                        suggested next action
-                      </p>
-                      <p className="mt-1 text-sm text-[var(--fr-dashboard-text)]">
-                        {intent.suggestedNextAction}
-                      </p>
-                      <div
-                        className="mt-3 rounded-lg border p-2"
+            Заявок пока нет. После checkout, recovery или prebuy сигналов здесь
+            появятся карточки для закрытия.
+          </p>
+        ) : (
+          <div className="mt-3 space-y-3">
+            {closerIntents.map((intent) => (
+              <article
+                key={intent.id}
+                className="rounded-2xl border p-3"
+                style={{
+                  borderColor:
+                    intent.stage === "closed"
+                      ? "var(--fr-dashboard-border)"
+                      : "var(--fr-dashboard-accent)",
+                  backgroundColor:
+                    intent.stage === "closed"
+                      ? withAlpha(crew.theme.palette.bgCard, 0.72)
+                      : withAlpha(crew.theme.palette.accentMain, 0.07),
+                }}
+              >
+                <div className="grid gap-3 lg:grid-cols-[minmax(0,1.15fr),minmax(0,1fr)]">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span
+                        className="rounded-full bg-[var(--fr-dashboard-accent)] px-2 py-1 text-xs font-bold"
+                        style={{ color: accentOn }}
+                      >
+                        {intent.urgencyScore}
+                      </span>
+                      <span
+                        className="rounded-full border px-2 py-1 text-xs text-[var(--fr-dashboard-text)]"
                         style={{ borderColor: "var(--fr-dashboard-border)" }}
                       >
-                        <p className="text-xs text-[var(--fr-dashboard-muted)]">
-                          Telegram reply
-                        </p>
-                        <p className="mt-1 break-words text-xs leading-relaxed text-[var(--fr-dashboard-text)]">
-                          {intent.suggestedTelegramReply}
-                        </p>
+                        {intent.intentType} · {intent.stage}
+                      </span>
+                      <span className="text-xs text-[var(--fr-dashboard-muted)]">
+                        обновлено{" "}
+                        {intent.updatedAt
+                          ? new Date(intent.updatedAt).toLocaleString()
+                          : "—"}
+                      </span>
+                    </div>
+                    <p className="mt-2 break-words text-base font-semibold text-[var(--fr-dashboard-text)]">
+                      {intent.bikeLabel}
+                    </p>
+                    <dl className="mt-2 grid gap-2 text-xs sm:grid-cols-2">
+                      <div>
+                        <dt className="uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
+                          Даты
+                        </dt>
+                        <dd className="mt-1 break-words text-[var(--fr-dashboard-text)]">
+                          {intent.selectedDates}
+                        </dd>
                       </div>
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        <Button
-                          type="button"
-                          variant="outline"
-                          className="h-8 text-xs"
-                          onClick={() => void handleCopyTelegramReply(intent)}
-                          style={buttonFocus}
-                        >
-                          Copy Telegram reply
-                        </Button>
-                        {(
-                          Object.keys(closerActionLabels) as CloserAction[]
-                        ).map((action) => (
+                      <div>
+                        <dt className="uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
+                          Контакт
+                        </dt>
+                        <dd className="mt-1 break-words text-[var(--fr-dashboard-text)]">
+                          {intent.contactChannel}
+                          {intent.telegramUsername
+                            ? ` · @${intent.telegramUsername}`
+                            : ""}
+                          {intent.telegramUserId
+                            ? ` · tg:${intent.telegramUserId}`
+                            : ""}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
+                          Стоп-фактор
+                        </dt>
+                        <dd className="mt-1 break-words text-[var(--fr-dashboard-text)]">
+                          {intent.lastBlocker}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
+                          Оплата
+                        </dt>
+                        <dd className="mt-1 break-words text-[var(--fr-dashboard-text)]">
+                          {intent.paymentState}
+                        </dd>
+                      </div>
+                    </dl>
+                  </div>
+                  <div
+                    className="min-w-0 rounded-xl border p-3"
+                    style={{
+                      borderColor: "var(--fr-dashboard-border)",
+                      backgroundColor: withAlpha(
+                        crew.theme.palette.bgBase,
+                        0.22,
+                      ),
+                    }}
+                  >
+                    <p className="text-xs uppercase tracking-[0.14em] text-[var(--fr-dashboard-muted)]">
+                      Следующий шаг
+                    </p>
+                    <p className="mt-1 text-sm text-[var(--fr-dashboard-text)]">
+                      {intent.suggestedNextAction}
+                    </p>
+                    <div
+                      className="mt-3 rounded-lg border p-2"
+                      style={{ borderColor: "var(--fr-dashboard-border)" }}
+                    >
+                      <p className="text-xs text-[var(--fr-dashboard-muted)]">
+                        Ответ в Telegram
+                      </p>
+                      <p className="mt-1 break-words text-xs leading-relaxed text-[var(--fr-dashboard-text)]">
+                        {intent.suggestedTelegramReply}
+                      </p>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="h-8 text-xs"
+                        onClick={() => void handleCopyTelegramReply(intent)}
+                        style={buttonFocus}
+                      >
+                        Скопировать ответ
+                      </Button>
+                      {(Object.keys(closerActionLabels) as CloserAction[]).map(
+                        (action) => (
                           <Button
                             key={action}
                             type="button"
@@ -455,16 +402,16 @@ export function FranchizeCloserDashboardClient({
                           >
                             {closerActionLabels[action]}
                           </Button>
-                        ))}
-                      </div>
+                        ),
+                      )}
                     </div>
                   </div>
-                </article>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-    </section>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </FranchizeOperatorPanel>
+    </div>
   );
 }

--- a/app/franchize/components/FranchizeOperatorSurface.tsx
+++ b/app/franchize/components/FranchizeOperatorSurface.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+type OperatorPanelProps = {
+  children: ReactNode;
+  className?: string;
+  muted?: boolean;
+};
+
+export function FranchizeOperatorPanel({
+  children,
+  className = "",
+  muted = true,
+}: OperatorPanelProps) {
+  return (
+    <section
+      className={`rounded-2xl border p-3 sm:p-4 ${className}`}
+      style={{
+        borderColor: "var(--franchize-shell-border)",
+        backgroundColor: muted
+          ? "color-mix(in srgb, var(--franchize-shell-card) 86%, transparent)"
+          : "var(--franchize-shell-card)",
+        color: "var(--franchize-shell-text)",
+      }}
+    >
+      {children}
+    </section>
+  );
+}
+
+type OperatorStatCardProps = {
+  label: string;
+  value: ReactNode;
+  detail?: ReactNode;
+  className?: string;
+};
+
+export function FranchizeOperatorStatCard({
+  label,
+  value,
+  detail,
+  className = "",
+}: OperatorStatCardProps) {
+  return (
+    <FranchizeOperatorPanel className={`min-w-0 ${className}`}>
+      <p
+        className="text-xs font-medium tracking-wide"
+        style={{ color: "var(--franchize-shell-muted)" }}
+      >
+        {label}
+      </p>
+      <p className="mt-2 break-words text-2xl font-semibold sm:text-3xl">
+        {value}
+      </p>
+      {detail ? (
+        <p
+          className="mt-1 break-words text-xs leading-relaxed"
+          style={{ color: "var(--franchize-shell-muted)" }}
+        >
+          {detail}
+        </p>
+      ) : null}
+    </FranchizeOperatorPanel>
+  );
+}
+
+type OperatorLinkButtonProps = {
+  href: string;
+  children: ReactNode;
+  variant?: "primary" | "secondary";
+  className?: string;
+};
+
+export function FranchizeOperatorLinkButton({
+  href,
+  children,
+  variant = "primary",
+  className = "",
+}: OperatorLinkButtonProps) {
+  const isPrimary = variant === "primary";
+
+  return (
+    <Link
+      href={href}
+      className={`inline-flex min-h-11 items-center justify-center rounded-2xl border px-5 py-3 text-sm font-semibold transition focus:outline-none focus:ring-2 ${
+        isPrimary ? "hover:opacity-90" : "hover:opacity-80"
+      } ${className}`}
+      style={
+        isPrimary
+          ? {
+              backgroundColor: "var(--franchize-shell-accent)",
+              borderColor: "var(--franchize-shell-accent)",
+              color: "var(--franchize-shell-primary-contrast)",
+              boxShadow:
+                "0 12px 30px color-mix(in srgb, var(--franchize-shell-accent) 24%, transparent)",
+            }
+          : {
+              backgroundColor:
+                "color-mix(in srgb, var(--franchize-shell-card) 58%, transparent)",
+              borderColor: "var(--franchize-shell-border)",
+              color: "var(--franchize-shell-text)",
+            }
+      }
+    >
+      {children}
+    </Link>
+  );
+}
+
+export const franchizeOperatorInputClassName =
+  "rounded-2xl border px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--franchize-shell-accent)]";
+
+export const franchizeOperatorInputStyle = {
+  borderColor: "var(--franchize-shell-border)",
+  backgroundColor:
+    "color-mix(in srgb, var(--franchize-shell-card) 78%, transparent)",
+  color: "var(--franchize-shell-text)",
+};

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -49,6 +49,16 @@ This root file stays intentionally compact so operators and agents can load it q
 ## 2) Mini execution diary
 
 
+### 2026-05-08 — Issue 4 operator surface visual consistency self-review
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-08T13:55:00Z
+- `owner`: codex
+- `notes`: Self-reviewed the Issue 4 surface pass: removed unnecessary client-side crew refetches after server hydration, tightened the shared operator CTA to match FranchizeHero/catalog button rhythm, and kept the docs diff scoped to this diary entry.
+- `next_step`: Review with live `vip-bike` data in preview; local smoke still validates shell/routing when Supabase is unavailable.
+- `risks`: Admin/profile/dashboard runtime data remains auth/Supabase dependent; visual shell falls back safely when data fetches fail.
+
+
 ### 2026-05-08 — SEC-04 crew sensitive storage audit
 
 - `status`: ready_for_pr


### PR DESCRIPTION
### Motivation

- Provide a consistent operator-facing visual shell and CTA rhythm across franchize admin, dashboard and profile pages. 
- Avoid redundant client-side crew refetches by hydrating clients from server-side `getFranchizeBySlug` calls and passing `initialCrew`. 
- Improve readability and theme fidelity by exposing palette-driven CSS vars and small helper utilities for accessible contrast.

### Description

- Added a new operator UI primitive `FranchizeOperatorSurface` (`FranchizeOperatorPanel`, `FranchizeOperatorStatCard`, `FranchizeOperatorLinkButton`, and shared input styles) and replaced many ad-hoc operator blocks with these components. 
- Changed page-level routing to fetch crew and nav items server-side via `getFranchizeBySlug` and render `CrewHeader`, `FranchizePageShell`, and `CrewFooter` around client components (`FranchizeAdminClient`, `FranchizeCloserDashboardClient`, `FranchizeProfileClient`), passing `initialCrew`/`initialSlug` so clients no longer refetch theme data. 
- Updated client components to accept `initialCrew`, removed unnecessary client-side crew refetches, and wired theme helpers (`crewPaletteForSurface`, `readablePaletteTextOnColor`, `withAlpha`) into inline CSS vars for consistent visual surfaces. 
- Localized and refreshed copy for operator surfaces (Russian), tightened interactions (bulk VIN fill, closer actions, copy Telegram reply), and added a short diary entry in `docs/THE_FRANCHEEZEPLAN.md` describing the visual/behavioral pass.

### Testing

- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde26d339c832494973ef1af4b5e80)