### PR TITLE
test: align franchize doc-flow private secret mocks

### DIFF
--- a/tests/franchize/doc-flow.spec.ts
+++ b/tests/franchize/doc-flow.spec.ts
@@ -40,7 +40,9 @@ vi.mock('@/app/franchize/lib/docx-capability', () => ({
 
 vi.mock('@/app/lib/private-secrets', () => ({
   getUserSensitiveData: mocks.getUserSensitiveData,
+  getUserSensitiveDataOrDefault: mocks.getUserSensitiveData,
   getCrewSensitiveData: mocks.getCrewSensitiveData,
+  getCrewSensitiveDataOrDefault: mocks.getCrewSensitiveData,
   saveCrewSensitiveData: vi.fn(),
 }));
 
@@ -168,7 +170,7 @@ describe('franchize checkout doc-flow', () => {
     const result = await createFranchizeOrderCheckout(buildPayload('telegram_xtr', 'order-2'));
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('docx render failed');
+    expect(result.error).toContain('Не удалось подготовить документы аренды');
     expect(mocks.createInvoice).not.toHaveBeenCalled();
     expect(mocks.sendTelegramInvoice).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
### Motivation
- The checkout runtime was changed to import `getUserSensitiveDataOrDefault` / `getCrewSensitiveDataOrDefault`, but the Vitest mock only exported the old helper names causing undefined imports and test failures.
- The checkout flow surfaces a safe, localized user-facing error on DOCX failures, so the test should assert the public message rather than the raw internal exception.

### Description
- Exported `getUserSensitiveDataOrDefault` and `getCrewSensitiveDataOrDefault` from the `@/app/lib/private-secrets` mock and mapped them to the existing sensitive-data mocks in `tests/franchize/doc-flow.spec.ts`.
- Updated the DOCX-failure assertion in `tests/franchize/doc-flow.spec.ts` to expect the safe error string (`Не удалось подготовить документы аренды`) returned by the runtime instead of the internal `docx render failed` message.
- Change is scoped to `tests/franchize/doc-flow.spec.ts` only.

### Testing
- Ran `npm test -- tests/franchize/doc-flow.spec.ts` and all tests in that file passed (`3 passed`).
- No other automated test suites were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf1e48fa88324ab429798139f8930)