### PR TITLE
feat: centralize Telegram back button navigation stack handling

### DIFF
--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -43,7 +43,8 @@ import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { checkAndUnlockFeatureAchievement } from "@/lib/cyberFitnessSupabase-server";
 import { useAppToast } from "@/hooks/useAppToast";
-import { useTelegramBackButton } from "@/hooks/useTelegramBackButton";
+import { useTelegramBackButton } from "@/hooks/telegram/useTelegramBackButton";
+import { TelegramNavigationTracker } from "@/components/telegram/TelegramNavigationTracker";
 import { Loading } from "@/components/Loading";
 import { cn } from "@/lib/utils";
 import { useStartParamRouter } from "@/hooks/useStartParamRouter";
@@ -154,7 +155,7 @@ function AppInitializers() {
         };
     }, [isAuthenticated, dbUser, handleScrollForAchievement]);
 
-    return null;
+    return <TelegramNavigationTracker />;
 }
 
 function useBio30ThemeFix() {

--- a/components/telegram/TelegramNavigationTracker.tsx
+++ b/components/telegram/TelegramNavigationTracker.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { navigationStore } from "@/stores/navigationStore";
+
+const TELEGRAM_NAV_MARKER = "__tg_nav__";
+
+export function TelegramNavigationTracker() {
+  const pathname = usePathname();
+  const previousPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!pathname || typeof window === "undefined") return;
+
+    navigationStore.push(pathname);
+
+    const previousPath = previousPathRef.current;
+    if (previousPath && previousPath !== pathname) {
+      window.history.pushState({ [TELEGRAM_NAV_MARKER]: true, path: pathname }, "", pathname);
+    }
+
+    previousPathRef.current = pathname;
+  }, [pathname]);
+
+  return null;
+}

--- a/hooks/telegram/useTelegramBackButton.ts
+++ b/hooks/telegram/useTelegramBackButton.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAppContext } from "@/contexts/AppContext";
+import { debugLogger as logger } from "@/lib/debugLogger";
+import { navigationStore } from "@/stores/navigationStore";
+
+export function useTelegramBackButton() {
+  const { tg, isInTelegramContext } = useAppContext();
+
+  useEffect(() => {
+    if (!isInTelegramContext || !tg?.BackButton || typeof window === "undefined") {
+      return;
+    }
+
+    const backButton = tg.BackButton;
+
+    const syncButtonVisibility = () => {
+      if (navigationStore.canGoBack()) {
+        backButton.show();
+      } else {
+        backButton.hide();
+      }
+    };
+
+    const handleBack = () => {
+      if (navigationStore.canGoBack()) {
+        window.history.back();
+        return;
+      }
+
+      logger.info("[Telegram BackButton] No internal navigation stack, closing Telegram WebApp.");
+      tg.close();
+    };
+
+    const handlePopState = () => {
+      navigationStore.pop();
+      syncButtonVisibility();
+    };
+
+    const unsubscribe = navigationStore.subscribe(syncButtonVisibility);
+
+    syncButtonVisibility();
+    backButton.onClick(handleBack);
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      unsubscribe();
+      backButton.offClick(handleBack);
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [isInTelegramContext, tg]);
+}

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -1,0 +1,52 @@
+"use client";
+
+type NavigationState = {
+  stack: string[];
+};
+
+type Listener = (state: NavigationState) => void;
+
+const state: NavigationState = {
+  stack: [],
+};
+
+const listeners = new Set<Listener>();
+
+function emit() {
+  const snapshot = { ...state, stack: [...state.stack] };
+  listeners.forEach((listener) => listener(snapshot));
+}
+
+function normalize(path: string) {
+  return path || "/";
+}
+
+export const navigationStore = {
+  getState(): NavigationState {
+    return { ...state, stack: [...state.stack] };
+  },
+  subscribe(listener: Listener) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  push(path: string) {
+    const normalizedPath = normalize(path);
+    const latest = state.stack[state.stack.length - 1];
+    if (latest === normalizedPath) return;
+    state.stack.push(normalizedPath);
+    emit();
+  },
+  pop() {
+    if (state.stack.length <= 1) {
+      return state.stack[state.stack.length - 1] || null;
+    }
+
+    state.stack.pop();
+    const next = state.stack[state.stack.length - 1] || null;
+    emit();
+    return next;
+  },
+  canGoBack() {
+    return state.stack.length > 1;
+  },
+};


### PR DESCRIPTION
### Motivation
- Provide a single, predictable handler for Telegram WebApp back navigation so in-app SPA navigation, Android back-chain, and Telegram BackButton behavior stay consistent across the app.
- Avoid accidental WebApp closes by using an explicit internal navigation stack and only calling `tg.close()` when the internal stack depth is `<= 1`.

### Description
- Added a lightweight client navigation store `stores/navigationStore.ts` with `stack`, `push(path)`, `pop()`, `canGoBack()`, `getState()` and `subscribe()` for simple reactive usage.
- Implemented `components/telegram/TelegramNavigationTracker.tsx` which pushes each `usePathname()` change into the store and mirrors navigations into browser history via `window.history.pushState(...)` to support Android back chaining inside Telegram WebApp.
- Introduced `hooks/telegram/useTelegramBackButton.ts` that centralizes `tg.BackButton.onClick(...)`, listens for `popstate`, synchronizes BackButton visibility with `navigationStore.canGoBack()`, and falls back to `tg.close()` only when the internal stack indicates there is no app-level back target.
- Mounted `TelegramNavigationTracker` and wired `useTelegramBackButton` from the runtime shell in `components/layout/ClientLayout.tsx` so the behavior is globally active without scattering logic across components.

### Testing
- Ran targeted lint on the changed files via `npm run -s lint -- --file components/layout/ClientLayout.tsx --file hooks/telegram/useTelegramBackButton.ts --file components/telegram/TelegramNavigationTracker.tsx --file stores/navigationStore.ts` and it passed with no ESLint warnings or errors.
- Audited `router.replace(` usages across the codebase with `rg "router\.replace\("` to verify that `router.push` remains the primary user navigation method and that existing `router.replace` calls are intentional technical redirects, and the audit showed only expected technical cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02c80c42d483259db9fac2cd0ce720)