### PR TITLE
Improve Telegram integration: full-URL navigation tracking, safer auth, and robust viewport/closing behavior

### DIFF
--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -306,7 +306,9 @@ export default function ClientLayoutWrapper({ children }: { children: React.Reac
   return (
     <ErrorOverlayProvider>
       <AppProvider>
-        <AppInitializers />
+        <Suspense fallback={null}>
+          <AppInitializers />
+        </Suspense>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <TooltipProvider>
             <ErrorBoundaryForOverlay>

--- a/components/telegram/TelegramNavigationTracker.tsx
+++ b/components/telegram/TelegramNavigationTracker.tsx
@@ -1,27 +1,41 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { navigationStore } from "@/stores/navigationStore";
-
-const TELEGRAM_NAV_MARKER = "__tg_nav__";
 
 export function TelegramNavigationTracker() {
   const pathname = usePathname();
-  const previousPathRef = useRef<string | null>(null);
+  const searchParams = useSearchParams();
+  const previousUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!pathname || typeof window === "undefined") return;
 
-    navigationStore.push(pathname);
+    const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    navigationStore.push(currentUrl);
 
-    const previousPath = previousPathRef.current;
-    if (previousPath && previousPath !== pathname) {
-      window.history.pushState({ [TELEGRAM_NAV_MARKER]: true, path: pathname }, "", pathname);
-    }
+    previousUrlRef.current = currentUrl;
+  }, [pathname, searchParams]);
 
-    previousPathRef.current = pathname;
-  }, [pathname]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleHashOrSearchChange = () => {
+      const nextUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (previousUrlRef.current === nextUrl) return;
+      previousUrlRef.current = nextUrl;
+      navigationStore.push(nextUrl);
+    };
+
+    window.addEventListener("hashchange", handleHashOrSearchChange);
+    window.addEventListener("popstate", handleHashOrSearchChange);
+
+    return () => {
+      window.removeEventListener("hashchange", handleHashOrSearchChange);
+      window.removeEventListener("popstate", handleHashOrSearchChange);
+    };
+  }, []);
 
   return null;
 }

--- a/components/telegram/TelegramNavigationTracker.tsx
+++ b/components/telegram/TelegramNavigationTracker.tsx
@@ -21,19 +21,27 @@ export function TelegramNavigationTracker() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const handleHashOrSearchChange = () => {
-      const nextUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    const currentUrl = () => `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+    const handleHashChange = () => {
+      const nextUrl = currentUrl();
       if (previousUrlRef.current === nextUrl) return;
       previousUrlRef.current = nextUrl;
       navigationStore.push(nextUrl);
     };
 
-    window.addEventListener("hashchange", handleHashOrSearchChange);
-    window.addEventListener("popstate", handleHashOrSearchChange);
+    const handlePopState = () => {
+      // Back/forward traversal is popped by useTelegramBackButton. The tracker only
+      // refreshes its ref here so it does not re-push the route that was just popped.
+      previousUrlRef.current = currentUrl();
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+    window.addEventListener("popstate", handlePopState);
 
     return () => {
-      window.removeEventListener("hashchange", handleHashOrSearchChange);
-      window.removeEventListener("popstate", handleHashOrSearchChange);
+      window.removeEventListener("hashchange", handleHashChange);
+      window.removeEventListener("popstate", handlePopState);
     };
   }, []);
 

--- a/hooks/telegram/useTelegramAuth.ts
+++ b/hooks/telegram/useTelegramAuth.ts
@@ -100,10 +100,17 @@ export function useTelegramAuth() {
         if (!candidate && webApp?.initDataUnsafe?.user?.id && process.env.NODE_ENV === "development") candidate = webApp.initDataUnsafe.user;
         if (!candidate && MOCK_USER && isAllowedMockContext()) candidate = MOCK_USER;
 
-        const realTg = Boolean(initData && candidate && candidate !== MOCK_USER);
+        const realTg = Boolean(initData);
         if (can()) setIsInTelegramContext(realTg);
 
-        if (!candidate) throw new Error("No user data available for authentication.");
+        if (!candidate) {
+          if (can()) {
+            setError(new Error("Telegram authentication failed. User data is unavailable."));
+            setIsAuthenticated(false);
+          }
+          return;
+        }
+
         const persisted = await handleAuthentication(candidate);
         if (can()) {
           setUser(candidate);

--- a/hooks/telegram/useTelegramClosingBehavior.ts
+++ b/hooks/telegram/useTelegramClosingBehavior.ts
@@ -5,12 +5,13 @@ import type { TelegramWebApp } from "@/types/telegram";
 
 export function useTelegramClosingBehavior(tg: TelegramWebApp | null, enabled: boolean) {
   useEffect(() => {
-    if (!tg || !enabled || typeof tg.enableClosingConfirmation !== "function") return;
-    tg.enableClosingConfirmation();
+    if (!tg || !enabled) return;
+    tg.enableClosingConfirmation?.();
+    tg.expand?.();
+    tg.requestFullscreen?.();
+
     return () => {
-      if (typeof tg.disableClosingConfirmation === "function") {
-        tg.disableClosingConfirmation();
-      }
+      tg.disableClosingConfirmation?.();
     };
   }, [tg, enabled]);
 }

--- a/hooks/telegram/useTelegramViewport.ts
+++ b/hooks/telegram/useTelegramViewport.ts
@@ -9,12 +9,17 @@ export function useTelegramViewport(tg: TelegramWebApp | null, enabled: boolean)
     if (!tg || !enabled) return;
     safeReady(tg);
     let detach: (() => void) | undefined;
+    let isActive = true;
     (async () => {
       if (tg.expand) {
         await safeExpand(tg, { attempts: 3, delayMs: 120 });
+        if (!isActive) return;
         detach = attachVisibilityExpandRecovery(tg, { attempts: 2, delayMs: 150 });
       }
     })();
-    return () => detach?.();
+    return () => {
+      isActive = false;
+      detach?.();
+    };
   }, [tg, enabled]);
 }

--- a/hooks/todo.md
+++ b/hooks/todo.md
@@ -1547,3 +1547,15 @@ The app behaves like a real mobile Telegram Mini App, not a browser page pretend
 - ✅ Добавлено самопроверочное правило: back-навигация и close-confirmation считаются разными слоями защиты, оба обязательны.
 
 Если появятся новые edge-cases (например, экраны с heavy `router.replace`), добавлять сюда отдельный пункт с repro + фикс.
+
+## Execution audit (2026-05-14)
+
+Build-regression review after the Telegram navigation refactor:
+
+- ✅ Root cause confirmed: the global `TelegramNavigationTracker` uses `useSearchParams()` and was mounted through `AppInitializers` outside a Suspense boundary, so static prerendering failed globally starting at `/_not-found` (`/404` in build logs).
+- ✅ Fixed by wrapping `AppInitializers` in a null-fallback Suspense boundary inside `ClientLayout`; this keeps the Telegram runtime client-only without forcing every static page into the same CSR bailout error.
+- ✅ Reviewed the recent navigation stack implementation against this todo: explicit route stack, Telegram BackButton, native `popstate`, full URL tracking, close-confirmation, viewport unmount guard, and auth/context decoupling are present.
+- ✅ Additional review fix: `TelegramNavigationTracker` no longer re-pushes URLs during `popstate`; `useTelegramBackButton` remains the owner of stack popping, while the tracker only refreshes its internal URL ref on browser history traversal.
+- ✅ `npm run build` now completes `Generating static pages (168/168)` without the missing-Suspense CSR bailout.
+
+Follow-up watch item: if future hash-only navigation becomes user-critical, validate Telegram Android event ordering for `hashchange` + `popstate` on a real device and add a tiny route-stack unit test around that sequence.

--- a/hooks/todo.md
+++ b/hooks/todo.md
@@ -1528,3 +1528,22 @@ Both are needed.
 ## Done means
 
 The app behaves like a real mobile Telegram Mini App, not a browser page pretending to be one.
+
+---
+
+## Execution audit (2026-05-13)
+
+Проверка по mega-плану из этого файла:
+
+- ✅ `navigationStore` есть и используется для явного стека маршрутов.
+- ✅ `TelegramNavigationTracker` смонтирован глобально через `ClientLayout` (`AppInitializers`).
+- ✅ Telegram BackButton подключен глобально через `useTelegramBackButton`.
+- ✅ Native `popstate` обработка есть в `hooks/telegram/useTelegramBackButton.ts`.
+- ✅ Убраны дублирующие `history.pushState` на каждом route change (чтобы не плодить duplicate history entries).
+- ✅ Трекер теперь учитывает **полный URL state** (`pathname + search + hash`), включая query/hash-only переходы.
+- ✅ Close-protection включается при наличии `tg` (не ждет успешной auth-валидации).
+- ✅ `useTelegramViewport` защищен от утечки listener после unmount (guard после `await safeExpand`).
+- ✅ Telegram runtime-context (`isInTelegramContext`) отделен от успеха auth: context определяется по `initData`, а провал auth больше не бросает hard-throw.
+- ✅ Добавлено самопроверочное правило: back-навигация и close-confirmation считаются разными слоями защиты, оба обязательны.
+
+Если появятся новые edge-cases (например, экраны с heavy `router.replace`), добавлять сюда отдельный пункт с repro + фикс.

--- a/hooks/useTelegram.ts
+++ b/hooks/useTelegram.ts
@@ -23,8 +23,8 @@ export function useTelegram() {
     startParam,
   } = auth;
 
-  useTelegramViewport(auth.tg, auth.isInTelegramContext);
-  useTelegramClosingBehavior(auth.tg, auth.isInTelegramContext);
+  useTelegramViewport(auth.tg, Boolean(auth.tg));
+  useTelegramClosingBehavior(auth.tg, Boolean(auth.tg));
   const theme = useTelegramTheme(auth.tg);
 
   const safeWebAppCall = useCallback(<T extends (...args: any[]) => any>(


### PR DESCRIPTION
### Motivation

- Make navigation tracking aware of the full URL (path + query + hash) and avoid creating duplicate history entries when interacting inside Telegram. 
- Harden Telegram auth initialization so the app can detect Telegram runtime context independently of DB auth success and avoid hard-throwing when user data is missing.
- Prevent lifecycle leaks and make closing/viewport behavior calls safe across different Telegram runtimes.

### Description

- Update `TelegramNavigationTracker` to push the full URL (`pathname + search + hash`) to `navigationStore`, remove per-route `history.pushState`, and add `hashchange`/`popstate` listeners to handle query/hash-only transitions while tracking previous URL in `previousUrlRef`.
- Change `useTelegramAuth` to compute `realTg` from `initData` only, handle missing `candidate` without throwing by setting `error` and `isAuthenticated` appropriately, and avoid hard failures during init.
- Adjust `useTelegramClosingBehavior` to call `enableClosingConfirmation`, `expand`, and `requestFullscreen` using optional chaining and always call `disableClosingConfirmation` on cleanup.
- Improve `useTelegramViewport` by adding an `isActive` guard around the async expand flow and ensuring `detach` handlers are cleaned up after unmount to prevent listener leaks.
- Update `useTelegram` to drive viewport and closing behavior based on the presence of `tg` (`Boolean(auth.tg)`) rather than `isInTelegramContext`.
- Add `useSearchParams` import usage and minor housekeeping in `todo.md` with an execution audit note.

### Testing

- Ran project typecheck and linting (`tsc` and linter) and they completed successfully. 
- Ran the existing unit test suite and all tests passed. 
- Performed automated dev-server smoke check (compiled and loaded in browser environment) and no runtime errors were observed during navigation and Telegram simulation flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0465b9e47c832aa9e05c9dc9d32737)