### PR TITLE
fix: restore static build for Telegram runtime (Suspense AppInitializers + navigation tracker popstate fix)

### DIFF
--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -306,7 +306,9 @@ export default function ClientLayoutWrapper({ children }: { children: React.Reac
   return (
     <ErrorOverlayProvider>
       <AppProvider>
-        <AppInitializers />
+        <Suspense fallback={null}>
+          <AppInitializers />
+        </Suspense>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <TooltipProvider>
             <ErrorBoundaryForOverlay>

--- a/components/telegram/TelegramNavigationTracker.tsx
+++ b/components/telegram/TelegramNavigationTracker.tsx
@@ -21,19 +21,27 @@ export function TelegramNavigationTracker() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const handleHashOrSearchChange = () => {
-      const nextUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    const currentUrl = () => `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+    const handleHashChange = () => {
+      const nextUrl = currentUrl();
       if (previousUrlRef.current === nextUrl) return;
       previousUrlRef.current = nextUrl;
       navigationStore.push(nextUrl);
     };
 
-    window.addEventListener("hashchange", handleHashOrSearchChange);
-    window.addEventListener("popstate", handleHashOrSearchChange);
+    const handlePopState = () => {
+      // Back/forward traversal is popped by useTelegramBackButton. The tracker only
+      // refreshes its ref here so it does not re-push the route that was just popped.
+      previousUrlRef.current = currentUrl();
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+    window.addEventListener("popstate", handlePopState);
 
     return () => {
-      window.removeEventListener("hashchange", handleHashOrSearchChange);
-      window.removeEventListener("popstate", handleHashOrSearchChange);
+      window.removeEventListener("hashchange", handleHashChange);
+      window.removeEventListener("popstate", handlePopState);
     };
   }, []);
 

--- a/hooks/todo.md
+++ b/hooks/todo.md
@@ -1547,3 +1547,15 @@ The app behaves like a real mobile Telegram Mini App, not a browser page pretend
 - ✅ Добавлено самопроверочное правило: back-навигация и close-confirmation считаются разными слоями защиты, оба обязательны.
 
 Если появятся новые edge-cases (например, экраны с heavy `router.replace`), добавлять сюда отдельный пункт с repro + фикс.
+
+## Execution audit (2026-05-14)
+
+Build-regression review after the Telegram navigation refactor:
+
+- ✅ Root cause confirmed: the global `TelegramNavigationTracker` uses `useSearchParams()` and was mounted through `AppInitializers` outside a Suspense boundary, so static prerendering failed globally starting at `/_not-found` (`/404` in build logs).
+- ✅ Fixed by wrapping `AppInitializers` in a null-fallback Suspense boundary inside `ClientLayout`; this keeps the Telegram runtime client-only without forcing every static page into the same CSR bailout error.
+- ✅ Reviewed the recent navigation stack implementation against this todo: explicit route stack, Telegram BackButton, native `popstate`, full URL tracking, close-confirmation, viewport unmount guard, and auth/context decoupling are present.
+- ✅ Additional review fix: `TelegramNavigationTracker` no longer re-pushes URLs during `popstate`; `useTelegramBackButton` remains the owner of stack popping, while the tracker only refreshes its internal URL ref on browser history traversal.
+- ✅ `npm run build` now completes `Generating static pages (168/168)` without the missing-Suspense CSR bailout.
+
+Follow-up watch item: if future hash-only navigation becomes user-critical, validate Telegram Android event ordering for `hashchange` + `popstate` on a real device and add a tiny route-stack unit test around that sequence.


### PR DESCRIPTION
### Motivation

- A recent Telegram navigation refactor caused a CSR bailout during static page generation because `TelegramNavigationTracker` (which uses `useSearchParams`) was mounted outside a Suspense boundary and forced client-only behavior into static prerender paths such as `/404`.
- The navigation tracker also re-pushed URLs on browser `popstate`, which conflicted with the back-button stack ownership in `useTelegramBackButton` and risked duplicate stack entries.

### Description

- Wrap the global app initializers in a null-fallback `Suspense` inside `components/layout/ClientLayout.tsx` so Telegram runtime hooks (`useSearchParams`) remain client-only and do not force CSR bailout for static pages.
- Update `components/telegram/TelegramNavigationTracker.tsx` to avoid re-pushing routes during `popstate` by refreshing the tracker’s current URL ref on history traversal and only pushing on actual pathname/search/hash changes.
- Add an execution audit note to `hooks/todo.md` documenting the root cause, the fix, coverage of the navigation plan, and a follow-up watch item for hash-only navigation ordering on real devices.
- Files changed: `components/layout/ClientLayout.tsx`, `components/telegram/TelegramNavigationTracker.tsx`, and `hooks/todo.md`.

### Testing

- Ran `npm run build` and verified Next build completed static generation ("Generating static pages (168/168)") successfully.
- Ran `npm run lint` and observed no ESLint warnings or errors.
- Ran `npx tsc --noEmit` which fails due to existing repo-wide TypeScript type debt unrelated to this patch, and this is a known project-wide issue (Next build in CI skips full type validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b0f095ac832498449864565a840f)