### PR TITLE
Fix Telegram BackButton visibility guard

### DIFF
--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -252,11 +252,21 @@ This root file stays intentionally compact so operators and agents can load it q
 ## 3) Active ad-hoc task — `/vipbikerental` interactive landing
 
 - status: `ready_for_pr`
-- updated_at: `2026-05-07T00:00:00Z`
+- updated_at: `2026-05-14T00:00:00Z`
 - owner: `codex`
-- notes: `Polished /vipbikerental copy density, removed the duplicated partner-link audit block, improved hero-tab contrast over video, moved VIP Bike catalog hydration behind client-side skeleton cards, russified the newest loader/landing labels, brightened the MapRiders preview map, and replaced the invalid FaShieldAlt marker with FaShieldCat.`
-- next_step: `Production-smoke /vipbikerental and /franchize/vip-bike with real catalog latency; confirm skeleton-to-card transition on mobile Telegram WebApp.`
-- risks: `Catalog API still depends on server Supabase env; production QA should verify live item hydration and fallback behavior when Supabase is slow.`
+- notes: `Polished /vipbikerental copy density, removed the duplicated partner-link audit block, improved hero-tab contrast over video, moved VIP Bike catalog hydration behind client-side skeleton cards, russified the newest loader/landing labels, brightened the MapRiders preview map, replaced the invalid FaShieldAlt marker with FaShieldCat, and followed up on Telegram native BackButton visibility for the /vipbikerental → /franchize/vip-bike flow.`
+- next_step: `Production-smoke /vipbikerental → /franchize/vip-bike inside Telegram WebApp; confirm native header switches from X to BackButton and Android back returns to /vipbikerental without stale franchize bounce.`
+- risks: `Catalog API still depends on server Supabase env; Telegram BackButton visibility must be verified on a real Android/iOS client because browser/devtools cannot render the native Telegram header.`
+
+
+### 2026-05-14 — Telegram native BackButton visibility follow-up
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-14T00:00:00Z
+- `owner`: codex
+- `notes`: Addressed the automated review finding by preventing `backTarget()` from emitting while a Telegram back navigation is still pending, so the same-URL Android guard is not re-created for the old `/franchize/vip-bike` URL. Also made BackButton visibility depend on the actual Telegram WebApp BackButton runtime instead of waiting for async auth context, and added real-device visibility logs.
+- `next_step`: Deploy and smoke the production bot flow `/vipbikerental` → `/franchize/vip-bike` → native Telegram BackButton/Android back.
+- `risks`: Native Telegram chrome cannot be screenshotted from local browser QA; final proof requires Telegram Android/iOS.
 
 
 ### 2026-05-06 — SupaPlan franchize maintenance pair

--- a/hooks/telegram/useTelegramBackButton.ts
+++ b/hooks/telegram/useTelegramBackButton.ts
@@ -59,6 +59,7 @@ export function useTelegramBackButton() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const backHandlerRef = useRef<() => void>(() => {});
+  const isHandlingBackRef = useRef(false);
 
   const currentRoute = useMemo(() => {
     const query = searchParams?.toString();
@@ -68,15 +69,32 @@ export function useTelegramBackButton() {
   const syncButtonVisibility = useCallback(() => {
     if (!tg?.BackButton) return;
 
-    if (!isInTelegramContext) {
+    // The native BackButton is only exposed by Telegram's WebApp runtime.
+    // `isInTelegramContext` depends on async auth/initData validation, so do not
+    // let a delayed/failed auth pass hide an otherwise available native button.
+    const hasTelegramRuntime = Boolean(tg.initData || tg.initDataUnsafe?.user || (typeof window !== "undefined" && window.Telegram?.WebApp));
+    if (!hasTelegramRuntime) {
       tg.BackButton.hide();
       return;
     }
 
     const browserPath = currentBrowserPath();
-    if (hasAppBackTarget(browserPath)) {
+    const canShow = hasAppBackTarget(browserPath);
+
+    logger.info("[Telegram BackButton] visibility sync", {
+      browserPath,
+      canShow,
+      isInTelegramContext,
+      stack: navigationStore.getState().stack,
+      nativeVisible: tg.BackButton.isVisible,
+    });
+
+    if (canShow) {
+      tg.ready?.();
       tg.BackButton.show();
-      markTelegramBackGuard(browserPath);
+      if (!isHandlingBackRef.current) {
+        markTelegramBackGuard(browserPath);
+      }
       return;
     }
 
@@ -85,7 +103,8 @@ export function useTelegramBackButton() {
 
   backHandlerRef.current = () => {
     const currentPath = currentBrowserPath();
-    const targetPath = navigationStore.backTarget(currentPath) ?? fallbackPathFor(currentPath);
+    isHandlingBackRef.current = true;
+    const targetPath = navigationStore.backTarget(currentPath, { emit: false }) ?? fallbackPathFor(currentPath);
 
     if (targetPath && targetPath !== currentPath) {
       logger.info(`[Telegram BackButton] Navigating back to "${targetPath}" from "${currentPath}".`);
@@ -93,16 +112,18 @@ export function useTelegramBackButton() {
       return;
     }
 
+    isHandlingBackRef.current = false;
     logger.info("[Telegram BackButton] No app-level back target, closing Telegram WebApp.");
     tg?.close();
   };
 
   useEffect(() => {
+    isHandlingBackRef.current = false;
     syncButtonVisibility();
   }, [currentRoute, syncButtonVisibility]);
 
   useEffect(() => {
-    if (!isInTelegramContext || !tg?.BackButton || typeof window === "undefined") return;
+    if (!tg?.BackButton || typeof window === "undefined") return;
     const backButton = tg.BackButton;
 
     const stableClick = () => backHandlerRef.current();
@@ -122,5 +143,5 @@ export function useTelegramBackButton() {
       backButton.offClick(stableClick);
       window.removeEventListener("popstate", handlePopState);
     };
-  }, [isInTelegramContext, tg, syncButtonVisibility]);
+  }, [tg, syncButtonVisibility]);
 }

--- a/hooks/todo.md
+++ b/hooks/todo.md
@@ -1571,3 +1571,14 @@ Operator production repro: Mini App starts on `/vipbikerental`, then users route
 - ✅ Back clicks use SPA `router.push`, preserving the Next.js navigation oath and avoiding hard reloads.
 
 Real-device watch item: Telegram Desktop/iOS/Android can order history events differently; smoke `/vipbikerental` → `/franchize/vip-bike` → `/franchize/vip-bike/cart` inside the production bot after deploy.
+
+## Execution audit (2026-05-14) — native BackButton visibility follow-up
+
+Automated review found the Android guard could be re-armed for the old `/franchize/*` URL while a back navigation was still pending. Production symptom remained: Telegram header stayed on native `X` instead of showing app BackButton.
+
+- ✅ `navigationStore.backTarget()` now supports silent stack popping so the hook can avoid emitting before `router.push(targetPath)` reaches the destination.
+- ✅ `useTelegramBackButton` suppresses same-URL guard marking during active back handling, preventing stale `/franchize/vip-bike` guard resurrection before returning to `/vipbikerental`.
+- ✅ BackButton visibility no longer waits on async `isInTelegramContext` auth state when `window.Telegram.WebApp.BackButton` is already available; delayed auth can no longer hide a valid native Telegram button.
+- ✅ Added visibility sync logging with current path, app stack, target decision, and native `isVisible` so real-device Telegram debugging can confirm whether `show()` is being called.
+
+Real-device watch item: after deploy, open the production bot at `/vipbikerental`, navigate to `/franchize/vip-bike`, verify the header switches from `X` to native back, then press Android back and confirm it lands on `/vipbikerental` without bouncing back to franchize.

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -6,6 +6,10 @@ type NavigationState = {
 
 type Listener = (state: NavigationState) => void;
 
+type BackTargetOptions = {
+  emit?: boolean;
+};
+
 const state: NavigationState = {
   stack: [],
 };
@@ -46,7 +50,7 @@ export const navigationStore = {
     emit();
     return next;
   },
-  backTarget(currentPath: string) {
+  backTarget(currentPath: string, options: BackTargetOptions = {}) {
     const normalizedCurrentPath = normalize(currentPath);
     let changed = false;
 
@@ -56,7 +60,7 @@ export const navigationStore = {
     }
 
     const next = state.stack[state.stack.length - 1] || null;
-    if (changed) emit();
+    if (changed && options.emit !== false) emit();
     return next;
   },
   canGoBack() {


### PR DESCRIPTION
### Motivation
- Users reported the Telegram header never switching to the native Back button for franchize pages and Android back collapsing the Mini App instead of navigating internally. 
- Investigation showed the same-URL Android history guard could be re-armed while a back navigation was still pending and the BackButton visibility relied on async auth state, hiding a valid native control.

### Description
- Added an optional silent mode to `navigationStore.backTarget()` via an `emit` option so callers can pop the stack without emitting a state change (`backTarget(currentPath, { emit: false })`).
- Prevented guard re-arming during active back handling by introducing `isHandlingBackRef` in `hooks/telegram/useTelegramBackButton.ts` and skipping `markTelegramBackGuard()` while handling a back navigation.
- Changed BackButton visibility logic to check for the actual Telegram WebApp runtime (e.g. `tg.initData` / `tg.initDataUnsafe?.user` / `window.Telegram?.WebApp`) so a delayed `isInTelegramContext` does not hide an available native BackButton, and added visibility sync logging for real-device debugging.
- Updated docs and execution diary entries in `hooks/todo.md` and `docs/THE_FRANCHEEZEPLAN.md` to record the follow-up and reproduction steps for `/vipbikerental` → `/franchize/vip-bike` flow.

### Testing
- Ran lint targeting the changed files with `npm run lint -- --file hooks/telegram/useTelegramBackButton.ts --file stores/navigationStore.ts` and it passed (`✔ No ESLint warnings or errors`).
- Ran repository typecheck with `npx tsc --noEmit` which surfaced pre-existing, repo-wide TypeScript errors unrelated to this change; those baseline failures remain and did not block this focused fix.
- Created a commit and PR metadata for the change (`Fix Telegram BackButton visibility guard`) to enable real-device smoke testing in Telegram Android/iOS as the final verification step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c5d9c9b08324be26c21ea2fff1d3)