### PR TITLE
Polish Telegram buy print/share flow and fix native back guard

### DIFF
--- a/app/franchize/TELEGRAM_CAPABILITY.md
+++ b/app/franchize/TELEGRAM_CAPABILITY.md
@@ -1,0 +1,34 @@
+# Franchize Telegram capability
+
+Franchize uses Telegram as the primary operator/customer handoff layer.
+
+## Native WebApp UX
+
+- Use native Telegram controls only through the shared hooks/context.
+- Keep same-origin navigation on Next.js router/`Link`; do not replace internal route changes with hard reloads.
+- Native BackButton guard behavior is intentionally conservative: while a back tap is pending, visibility/auth dependency refreshes must not clear the pending state until `currentRoute` changes.
+
+## Deep-link payloads
+
+- Buy card: `buy_<bikeId>` → `/franchize/<slug>/market/<bikeId>/buy`.
+- Rental legacy payloads currently support `rental-*`, `rentals-*`, and `rental_*`.
+- MapRiders payloads support `mapriders_<slug>` / `mapriders-<slug>`.
+
+Use the repo helper in `app/franchize/lib/telegram-links.ts` for WebApp URLs so bot usernames and payload separators stay consistent.
+
+## Notifications + invoices
+
+- Customer/operator notifications should use Telegram server transport, never client-side bot tokens.
+- XTR/test-drive invoices should be created from franchize server actions and recorded to the franchize intent ledger when possible.
+- Recovery/closer flows should include enough metadata for the dashboard: bike id/title, contact channel, selected option, payment state, and source route.
+
+## Printable sale sheets
+
+The sale buy page exposes owner/admin-only **Распечатать**:
+
+1. Client checks operator dashboard access for display only.
+2. Server action revalidates admin/owner access from the signed Telegram actor cookie.
+3. PDF is generated server-side with bike details, image, and a QR code to `https://t.me/oneBikePlsBot/app?startapp=buy_<bikeId>`.
+4. PDF is delivered with `sendTelegramDocument` to the current Telegram actor.
+
+This pattern is the recommended template for future franchize documents: contracts, inspection sheets, pickup labels, and printed sale tags.

--- a/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
+++ b/app/franchize/[slug]/market/[bike_id]/buy/page.tsx
@@ -7,10 +7,7 @@ import { CrewHeader } from "@/app/franchize/components/CrewHeader";
 import { FranchizeFloatingCart } from "@/app/franchize/components/FranchizeFloatingCart";
 import { FranchizeHero } from "@/app/franchize/components/FranchizeHero";
 import { FranchizePageShell } from "@/app/franchize/components/FranchizePageShell";
-import {
-  getTelegramHandleHref,
-  getTelegramWebAppFallbackHref,
-} from "@/app/franchize/lib/telegram-links";
+import { getTelegramHandleHref } from "@/app/franchize/lib/telegram-links";
 import { getFranchizeRouteCtaPolicy, shouldShowFloatingCart } from "@/app/franchize/lib/route-cta-policy";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
 import { SaleBikeLanding } from "@/app/franchize/components/SaleBikeLanding";
@@ -82,7 +79,6 @@ export default async function BuyBikePage({
   const catalogHref = `/franchize/${resolvedSlug}`;
   const profileHref = `/franchize/${resolvedSlug}/profile`;
   const telegramHref = getTelegramHandleHref(crew.contacts.telegram);
-  const telegramFallbackHref = getTelegramWebAppFallbackHref("sale", bike_id, crew.contacts.telegramBotUsername);
 
   if (!item) notFound();
   const buySectionId = buildSaleBuySectionId(item.id);
@@ -218,18 +214,6 @@ export default async function BuyBikePage({
                 }}
               >
                 Написать оператору в Telegram
-              </a>
-              <a
-                href={telegramFallbackHref}
-                target="_blank"
-                rel="noreferrer"
-                className="flex justify-center rounded-xl border px-4 py-3"
-                style={{
-                  borderColor: crew.theme.palette.borderSoft,
-                  color: crew.theme.palette.textPrimary,
-                }}
-              >
-                Открыть WebApp fallback
               </a>
               <Link
                 href={contactHref}

--- a/app/franchize/actions.ts
+++ b/app/franchize/actions.ts
@@ -32,6 +32,7 @@ import {
   recordFranchizeCheckoutRecoverySnapshot as recordFranchizeCheckoutRecoverySnapshotAction,
   submitFranchizeOrderNotification as submitFranchizeOrderNotificationAction,
 } from "@/app/franchize/server-actions/orders";
+import { sendFranchizeBuyPrintPdf as sendFranchizeBuyPrintPdfAction } from "@/app/franchize/server-actions/buy-print";
 import {
   getFranchizeCloserIntents as getFranchizeCloserIntentsAction,
   getFranchizeOperatorDashboardAccess as getFranchizeOperatorDashboardAccessAction,
@@ -114,6 +115,12 @@ export async function recordFranchizeCheckoutRecoverySnapshot(
   ...args: Parameters<typeof recordFranchizeCheckoutRecoverySnapshotAction>
 ) {
   return recordFranchizeCheckoutRecoverySnapshotAction(...args);
+}
+
+export async function sendFranchizeBuyPrintPdf(
+  ...args: Parameters<typeof sendFranchizeBuyPrintPdfAction>
+) {
+  return sendFranchizeBuyPrintPdfAction(...args);
 }
 
 export async function getFranchizeRentalReviewsForModeration(

--- a/app/franchize/components/SaleBikeLandingClient.tsx
+++ b/app/franchize/components/SaleBikeLandingClient.tsx
@@ -13,10 +13,12 @@ import {
   CalendarCheck,
   CreditCard,
   PhoneCall,
+  Printer,
   Repeat2,
   ShieldCheck,
   ShoppingBag,
   Sparkles,
+  Share2,
   Swords,
   Star,
   Tag,
@@ -28,6 +30,8 @@ import {
 import type { CatalogItemVM, FranchizeCrewVM } from "@/app/franchize/actions";
 import {
   createFranchizeOrderInvoice,
+  getFranchizeOperatorDashboardAccess,
+  sendFranchizeBuyPrintPdf,
   upsertFranchizeIntent,
 } from "@/app/franchize/actions";
 import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
@@ -43,6 +47,7 @@ import {
   type PrebuyIntentType,
 } from "@/app/franchize/lib/sale-config";
 import { buildCandidateImageUrls } from "@/app/franchize/lib/media";
+import { getTelegramWebAppFallbackHref } from "@/app/franchize/lib/telegram-links";
 import { useFranchizeCart } from "@/app/franchize/hooks/useFranchizeCart";
 import { useAppContext } from "@/contexts/AppContext";
 import {
@@ -106,7 +111,7 @@ export function SaleBikeLandingClient({
   otherSaleBikes = [],
 }: SaleBikeLandingClientProps) {
   const router = useRouter();
-  const { user, dbUser } = useAppContext();
+  const { user, dbUser, tg, isInTelegramContext } = useAppContext();
   const resolvedSlug = crew.slug || "vip-bike";
   const surface = crewPaletteForSurface(crew.theme);
   const gallery = useMemo(() => {
@@ -222,6 +227,8 @@ export function SaleBikeLandingClient({
   const [reservationState, setReservationState] =
     useState<SaleActionState>("idle");
   const [purchaseState, setPurchaseState] = useState<SaleActionState>("idle");
+  const [printState, setPrintState] = useState<SaleActionState>("idle");
+  const [canPrintBuySheet, setCanPrintBuySheet] = useState(false);
   const [intentActionStates, setIntentActionStates] = useState<
     Partial<Record<string, SaleActionState>>
   >({});
@@ -245,7 +252,19 @@ export function SaleBikeLandingClient({
       ? String(dbUser.user_id)
       : undefined;
   const telegramFirstContinuation = Boolean(telegramUserId);
+  const hasTelegramRuntime = Boolean(
+    isInTelegramContext ||
+      tg?.initData ||
+      tg?.initDataUnsafe?.user ||
+      (typeof window !== "undefined" && window.Telegram?.WebApp),
+  );
   const sourceRoute = `/franchize/${resolvedSlug}/market/${item.id}/buy`;
+  const buyWebAppHref = getTelegramWebAppFallbackHref(
+    "buy",
+    item.id,
+    crew.contacts.telegramBotUsername,
+    "_",
+  );
   const bikeCondition = readSpecText(
     specs,
     ["condition", "state", "bike_condition"],
@@ -267,6 +286,25 @@ export function SaleBikeLandingClient({
   const contactHint = telegramFirstContinuation
     ? "Продолжим в Telegram: оператор пришлёт подтверждение прямо в чат."
     : "Оставьте телефон или Telegram @handle — оператор продолжит без лишних шагов.";
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getFranchizeOperatorDashboardAccess({ slug: resolvedSlug })
+      .then((result) => {
+        if (cancelled) return;
+        const role = String(result.role || "").toLowerCase();
+        setCanPrintBuySheet(Boolean(result.canOpen && ["admin", "owner"].includes(role)));
+      })
+      .catch(() => {
+        if (!cancelled) setCanPrintBuySheet(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [resolvedSlug]);
+
   const monthlyPaymentEstimate = useMemo(() => {
     if (finalPrice <= 0) return 0;
     return Math.ceil((finalPrice * 1.08) / financeMonths / 100) * 100;
@@ -486,6 +524,55 @@ export function SaleBikeLandingClient({
       console.error("buy/add-to-cart failed", error);
       setPurchaseState("error");
       setCartMessage("Не удалось добавить конфигурацию. Попробуйте ещё раз.");
+    }
+  };
+
+
+  const handleShareBuyLink = () => {
+    const shareText = `Карточка ${item.title}: ${buyWebAppHref}`;
+
+    if (tg?.switchInlineQuery) {
+      tg.switchInlineQuery(shareText, ["users", "groups", "channels"]);
+      return;
+    }
+
+    const shareUrl = `https://t.me/share/url?url=${encodeURIComponent(buyWebAppHref)}&text=${encodeURIComponent(`Карточка ${item.title}`)}`;
+    if (tg?.openTelegramLink) {
+      tg.openTelegramLink(shareUrl);
+      return;
+    }
+    if (tg?.openLink) {
+      tg.openLink(shareUrl);
+      return;
+    }
+
+    window.open(shareUrl, "_blank", "noopener,noreferrer");
+  };
+
+  const handlePrintBuySheet = async () => {
+    setPrintState("loading");
+    setCartMessage("");
+
+    try {
+      const result = await sendFranchizeBuyPrintPdf({
+        slug: resolvedSlug,
+        bikeId: item.id,
+      });
+
+      if (!result.success) {
+        throw new Error(result.error || "Не удалось отправить PDF.");
+      }
+
+      setPrintState("success");
+      setCartMessage(`PDF ${result.fileName || "карточки"} отправлен вам в Telegram.`);
+    } catch (error) {
+      console.error("buy/print-pdf failed", error);
+      setPrintState("error");
+      setCartMessage(
+        error instanceof Error
+          ? error.message
+          : "Не удалось отправить PDF в Telegram.",
+      );
     }
   };
 
@@ -737,6 +824,51 @@ export function SaleBikeLandingClient({
                   <ShieldCheck className="h-3.5 w-3.5" />
                   Официальная сделка + документы
                 </p>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  {!hasTelegramRuntime ? (
+                    <a
+                      href={buyWebAppHref}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm font-semibold transition hover:brightness-110"
+                      style={surface.subtleCard}
+                    >
+                      <Sparkles className="h-4 w-4" />
+                      Открыть в Telegram
+                    </a>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={handleShareBuyLink}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm font-semibold transition hover:brightness-110"
+                      style={surface.subtleCard}
+                    >
+                      <Share2 className="h-4 w-4" />
+                      Поделиться
+                    </button>
+                  )}
+                  {canPrintBuySheet ? (
+                    <button
+                      type="button"
+                      onClick={handlePrintBuySheet}
+                      disabled={printState === "loading"}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm font-semibold transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+                      style={{
+                        ...surface.subtleCard,
+                        borderColor: crew.theme.palette.accentMain,
+                      }}
+                    >
+                      <Printer className="h-4 w-4" />
+                      {printState === "loading"
+                        ? "Готовим PDF..."
+                        : printState === "success"
+                          ? "PDF отправлен"
+                          : printState === "error"
+                            ? "Повторить печать"
+                            : "Распечатать"}
+                    </button>
+                  ) : null}
+                </div>
               </div>
 
               <div

--- a/app/franchize/lib/telegram-links.ts
+++ b/app/franchize/lib/telegram-links.ts
@@ -18,6 +18,7 @@ export function getTelegramWebAppFallbackHref(
   prefix: string,
   value: string,
   botUsername?: string | null,
+  separator: "-" | "_" = "-",
 ): string {
   const normalizedBot =
     sanitizeTelegramUsername(botUsername) || DEFAULT_TELEGRAM_BOT_USERNAME;
@@ -26,5 +27,5 @@ export function getTelegramWebAppFallbackHref(
   const safeValue =
     value.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 40) || "open";
 
-  return `https://t.me/${normalizedBot}/app?startapp=${safePrefix}-${safeValue}`;
+  return `https://t.me/${normalizedBot}/app?startapp=${safePrefix}${separator}${safeValue}`;
 }

--- a/app/franchize/server-actions/buy-print.ts
+++ b/app/franchize/server-actions/buy-print.ts
@@ -1,0 +1,288 @@
+"use server";
+
+import { cookies } from "next/headers";
+import fs from "fs";
+import path from "path";
+import { PDFDocument, rgb } from "pdf-lib";
+import fontkit from "@pdf-lib/fontkit";
+
+import { sendTelegramDocument } from "@/app/actions";
+import { getFranchizeBySlug } from "@/app/franchize/server-actions/catalog";
+import { DEFAULT_TELEGRAM_BOT_USERNAME } from "@/app/franchize/lib/telegram-links";
+import { logger } from "@/lib/logger";
+import {
+  TELEGRAM_ACTOR_COOKIE,
+  verifyTelegramActorCookieValue,
+} from "@/lib/telegram-actor-cookie";
+import { supabaseAdmin } from "@/lib/supabase-server";
+
+type UnknownRecord = Record<string, unknown>;
+
+function normalizeSlug(value: string) {
+  return (value || "vip-bike").trim().toLowerCase() || "vip-bike";
+}
+
+function readString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : "";
+}
+
+async function resolveActorUserId() {
+  const actorUserId = verifyTelegramActorCookieValue(
+    cookies().get(TELEGRAM_ACTOR_COOKIE)?.value,
+  );
+  if (actorUserId) return actorUserId;
+
+  if (
+    process.env.NODE_ENV !== "production" &&
+    process.env.NEXT_PUBLIC_USE_MOCK_USER === "true"
+  ) {
+    return process.env.NEXT_PUBLIC_MOCK_USER_ID || "413553377";
+  }
+
+  return "";
+}
+
+async function resolvePrintAccess(actorUserId: string, slug: string) {
+  if (!actorUserId) return { allowed: false, reason: "Нужна Telegram-сессия." };
+
+  const { data: crew, error: crewError } = await supabaseAdmin
+    .from("crews")
+    .select("id, owner_id")
+    .eq("slug", normalizeSlug(slug))
+    .maybeSingle();
+
+  if (crewError) return { allowed: false, reason: crewError.message };
+  if (!crew?.id) return { allowed: false, reason: "Экипаж не найден." };
+
+  const { data: user } = await supabaseAdmin
+    .from("users")
+    .select("role, status")
+    .eq("user_id", actorUserId)
+    .maybeSingle();
+
+  const role = readString(user?.role).toLowerCase();
+  const status = readString(user?.status).toLowerCase();
+  const isAdmin = role === "admin" || role === "vpradmin" || status === "admin";
+  const isOwner = crew.owner_id === actorUserId;
+
+  if (isAdmin || isOwner) {
+    return { allowed: true, reason: isAdmin ? "admin" : "owner" };
+  }
+
+  return {
+    allowed: false,
+    reason: "PDF-печать доступна только админам и владельцу экипажа.",
+  };
+}
+
+function safeFilePart(value: string) {
+  return value
+    .trim()
+    .replace(/[^a-zA-Z0-9а-яА-ЯёЁ_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "bike";
+}
+
+function formatRub(value: number | null | undefined) {
+  return value && value > 0 ? `${value.toLocaleString("ru-RU")} ₽` : "по запросу";
+}
+
+function buildWebAppBuyLink(botUsername: string, bikeId: string) {
+  const normalizedBot =
+    botUsername.trim().replace(/^@+/, "").replace(/[^a-zA-Z0-9_]/g, "") ||
+    DEFAULT_TELEGRAM_BOT_USERNAME;
+  const safeBikeId = bikeId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 64) || "bike";
+  return `https://t.me/${normalizedBot}/app?startapp=buy_${safeBikeId}`;
+}
+
+async function embedImage(pdfDoc: PDFDocument, url: string) {
+  if (!url) return null;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const bytes = await response.arrayBuffer();
+    const contentType = response.headers.get("content-type") || "";
+    return contentType.includes("png") || url.toLowerCase().includes(".png")
+      ? await pdfDoc.embedPng(bytes)
+      : await pdfDoc.embedJpg(bytes);
+  } catch (error) {
+    logger.warn("[franchize] failed to embed buy PDF image", error);
+    return null;
+  }
+}
+
+async function generateBuyPdf(input: {
+  slug: string;
+  brandName: string;
+  botUsername: string;
+  item: {
+    id: string;
+    title: string;
+    description: string;
+    imageUrl: string;
+    salePrice: number | null;
+    pricePerDay: number;
+    availabilityLabel: string;
+    rawSpecs?: UnknownRecord;
+  };
+}) {
+  const pdfDoc = await PDFDocument.create();
+  pdfDoc.registerFontkit(fontkit);
+
+  const fontPath = path.join(process.cwd(), "server-assets", "fonts", "DejaVuSans.ttf");
+  const fontBytes = fs.readFileSync(fontPath);
+  const font = await pdfDoc.embedFont(fontBytes);
+
+  const page = pdfDoc.addPage([595.28, 841.89]);
+  const { width, height } = page.getSize();
+  const dark = rgb(0.05, 0.06, 0.07);
+  const accent = rgb(0.95, 0.75, 0.22);
+  const muted = rgb(0.35, 0.37, 0.4);
+  const line = rgb(0.82, 0.84, 0.86);
+  const specs = input.item.rawSpecs || {};
+  const buyLink = buildWebAppBuyLink(input.botUsername, input.item.id);
+
+  page.drawRectangle({ x: 0, y: height - 92, width, height: 92, color: dark });
+  page.drawText(input.brandName || input.slug, {
+    x: 36,
+    y: height - 42,
+    size: 20,
+    font,
+    color: rgb(1, 1, 1),
+  });
+  page.drawText("Карточка байка для печати / sale handoff", {
+    x: 36,
+    y: height - 66,
+    size: 10,
+    font,
+    color: accent,
+  });
+
+  page.drawText(input.item.title, { x: 36, y: height - 130, size: 24, font, color: dark });
+  page.drawText(`ID: ${input.item.id}`, { x: 36, y: height - 152, size: 10, font, color: muted });
+  page.drawText(`Цена: ${formatRub(input.item.salePrice || Number(specs.price_rub || specs.sale_price || 0))}`, {
+    x: 36,
+    y: height - 180,
+    size: 16,
+    font,
+    color: dark,
+  });
+  page.drawText(`Статус: ${input.item.availabilityLabel || "уточнить у оператора"}`, {
+    x: 36,
+    y: height - 204,
+    size: 11,
+    font,
+    color: muted,
+  });
+
+  const hero = await embedImage(pdfDoc, input.item.imageUrl);
+  if (hero) {
+    page.drawImage(hero, { x: 330, y: height - 300, width: 220, height: 165 });
+  } else {
+    page.drawRectangle({ x: 330, y: height - 300, width: 220, height: 165, borderColor: line, borderWidth: 1 });
+    page.drawText("Фото недоступно", { x: 390, y: height - 220, size: 11, font, color: muted });
+  }
+
+  const qrBytes = await fetch(
+    `https://api.qrserver.com/v1/create-qr-code/?size=420x420&data=${encodeURIComponent(buyLink)}&color=000000&bgcolor=ffffff&margin=1`,
+  ).then((res) => res.arrayBuffer());
+  const qr = await pdfDoc.embedPng(qrBytes);
+  page.drawImage(qr, { x: 390, y: 72, width: 135, height: 135 });
+  page.drawText("Скан → Telegram WebApp", { x: 382, y: 52, size: 9, font, color: muted });
+
+  const desc = input.item.description || "Описание не заполнено.";
+  const wrappedDesc = desc.match(/.{1,78}(?:\s|$)/g)?.slice(0, 5) || [desc];
+  let y = height - 245;
+  page.drawText("Описание", { x: 36, y, size: 13, font, color: dark });
+  y -= 20;
+  wrappedDesc.forEach((lineText) => {
+    page.drawText(lineText.trim(), { x: 36, y, size: 10, font, color: muted });
+    y -= 14;
+  });
+
+  y -= 12;
+  page.drawText("Характеристики", { x: 36, y, size: 13, font, color: dark });
+  y -= 22;
+  const rows = [
+    ["Категория", readString(specs.category) || "—"],
+    ["Мощность", readString(specs.power_kw || specs.motor_peak_kw) || "—"],
+    ["Батарея", readString(specs.battery) || "—"],
+    ["Запас хода", readString(specs.range_km) ? `${specs.range_km} км` : "—"],
+    ["Вес", readString(specs.weight_kg) ? `${specs.weight_kg} кг` : "—"],
+    ["Состояние", readString(specs.condition || specs.state) || "operator_checked"],
+  ];
+  rows.forEach(([label, value], index) => {
+    const rowY = y - index * 28;
+    page.drawRectangle({ x: 36, y: rowY - 8, width: 300, height: 24, borderColor: line, borderWidth: 0.5 });
+    page.drawText(label, { x: 46, y: rowY, size: 8, font, color: muted });
+    page.drawText(String(value), { x: 150, y: rowY, size: 10, font, color: dark });
+  });
+
+  page.drawRectangle({ x: 36, y: 76, width: 315, height: 88, color: rgb(0.98, 0.96, 0.88), borderColor: accent, borderWidth: 1 });
+  page.drawText("Ссылка на карточку", { x: 52, y: 136, size: 11, font, color: dark });
+  page.drawText(buyLink, { x: 52, y: 116, size: 8.5, font, color: dark });
+  page.drawText("Распечатайте лист и прикрепите к байку / стойке продаж.", { x: 52, y: 94, size: 9, font, color: muted });
+
+  page.drawText(`Generated: ${new Date().toLocaleString("ru-RU")}`, {
+    x: 36,
+    y: 32,
+    size: 8,
+    font,
+    color: muted,
+  });
+
+  return pdfDoc.save();
+}
+
+export async function sendFranchizeBuyPrintPdf(input: unknown): Promise<{
+  success: boolean;
+  error?: string;
+  fileName?: string;
+}> {
+  const payload = input && typeof input === "object" ? (input as UnknownRecord) : {};
+  const slug = normalizeSlug(readString(payload.slug));
+  const bikeId = readString(payload.bikeId);
+  if (!bikeId) return { success: false, error: "bikeId is required." };
+
+  const actorUserId = await resolveActorUserId();
+  const access = await resolvePrintAccess(actorUserId, slug);
+  if (!access.allowed) return { success: false, error: access.reason };
+
+  try {
+    const { crew, items } = await getFranchizeBySlug(slug);
+    const item = items.find((candidate) => candidate.id === bikeId);
+    if (!item) return { success: false, error: "Байк не найден." };
+
+    const bytes = await generateBuyPdf({
+      slug,
+      brandName: crew.header.brandName || crew.name,
+      botUsername: crew.contacts.telegramBotUsername,
+      item: {
+        id: item.id,
+        title: item.title,
+        description: item.description,
+        imageUrl: item.imageUrl,
+        salePrice: item.salePrice,
+        pricePerDay: item.pricePerDay,
+        availabilityLabel: item.availabilityLabel,
+        rawSpecs: item.rawSpecs,
+      },
+    });
+    const fileName = `BUY_${safeFilePart(item.title)}_${safeFilePart(item.id)}.pdf`;
+    const fileBlob = new Blob([bytes], { type: "application/pdf" });
+    const sendResult = await sendTelegramDocument(actorUserId, fileBlob, fileName);
+    if (!sendResult.success) {
+      return { success: false, error: sendResult.error || "Telegram sendDocument failed." };
+    }
+
+    return { success: true, fileName };
+  } catch (error) {
+    logger.error("[franchize] sendFranchizeBuyPrintPdf failed", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Не удалось отправить PDF.",
+    };
+  }
+}

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,0 +1,43 @@
+# Project capabilities map
+
+This repo now treats reusable integration powers as **capabilities** instead of one-off code hidden inside a route.
+
+## Telegram capability
+
+**Purpose:** one Telegram-first surface for native WebApp UX, bot notifications, Telegram Stars invoices, printable/shareable documents, and deep links.
+
+**Runtime pieces**
+- WebApp context + native controls live in `hooks/telegram/*` and are re-exported by legacy compatibility hooks where needed.
+- Native BackButton must stay SPA-safe: a pending native-back navigation keeps its guard until the committed route changes, so async auth/context refreshes cannot recreate same-URL stale history guards.
+- Deep links use `https://t.me/<bot>/app?startapp=<payload>`; franchize buy cards use `buy_<bikeId>` and are routed by `hooks/useStartParamRouter.ts`.
+
+**Server/bot pieces**
+- Telegram transport lives in `app/core/telegram_actions.ts` and is re-exported by `app/actions.ts`.
+- `sendTelegramMessage` is for chat/admin notifications and recovery nudges.
+- `sendTelegramDocument` is for generated docs/PDFs that should land in a user or operator chat.
+- Telegram Stars invoices are created through domain server actions (for example franchize order/test-drive invoices) and handled by webhook handlers after payment.
+
+**Integration guidance**
+- Client code may call server actions, but it must not import service-role Supabase clients or bot secrets directly.
+- Always re-check permissions server-side before sending Telegram documents or invoices.
+- Prefer capability payloads that are stable and domain-readable, e.g. `buy_sequence-zero`, `mapriders_vip-bike`, `lobby_<id>`.
+
+## PDF + QR capability
+
+**Purpose:** generate a printable artifact with human-readable data plus a QR/deep-link back into the Telegram WebApp.
+
+**Current examples**
+- Strikeball tactical PDFs generate lobby/operator sheets and QR codes from `app/strikeball/actions/service.ts`.
+- Franchize buy pages generate a sale handoff PDF with bike data, image, and a `buy_<bikeId>` QR link via `app/franchize/server-actions/buy-print.ts`.
+
+**Default recipe**
+1. Collect domain data on the server.
+2. Generate PDF with `pdf-lib` + embedded DejaVu font for RU text.
+3. Generate QR as a PNG image from a stable Telegram WebApp deep link.
+4. Attach the QR and any product image to the PDF.
+5. Send the PDF through `sendTelegramDocument`.
+6. Keep the client button visible only to authorized users; enforce the same policy again in the server action.
+
+**Franchize reuse pattern**
+- Buy page printable sheet: owner/admin presses **Распечатать** → PDF is sent to their Telegram DM → operator prints and attaches it to the sale bike.
+- Share path: inside Telegram WebApp, **Поделиться** forwards the same `buy_<bikeId>` WebApp link; outside Telegram, **Открыть в Telegram** is the fallback.

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -49,6 +49,16 @@ This root file stays intentionally compact so operators and agents can load it q
 ## 2) Mini execution diary
 
 
+### 2026-05-14 — Telegram buy print/share capability polish
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-14T00:00:00Z
+- `owner`: codex
+- `notes`: Executed explicit operator scope: fixed Telegram native back pending-guard reset so async auth/context visibility refreshes cannot recreate stale same-URL guards; documented Telegram and PDF/QR capabilities; added franchize buy-page `buy_<bikeId>` WebApp links, Telegram share/fallback behavior, and owner/admin-only PDF print delivery with bike info, image, and QR deep link.
+- `next_step`: Smoke `/franchize/vip-bike/market/<bike_id>/buy` in Telegram WebApp as owner/admin and in a regular browser to verify share/fallback visibility plus PDF delivery.
+- `risks`: PDF delivery depends on `TELEGRAM_BOT_TOKEN`, signed Telegram actor cookie, external image/QR fetch reachability, and live crew/catalog rows.
+
+
 ### 2026-05-08 — Issue 4 operator surface visual consistency self-review
 
 - `status`: ready_for_pr

--- a/hooks/telegram/useTelegramBackButton.ts
+++ b/hooks/telegram/useTelegramBackButton.ts
@@ -60,6 +60,7 @@ export function useTelegramBackButton() {
   const searchParams = useSearchParams();
   const backHandlerRef = useRef<() => void>(() => {});
   const isHandlingBackRef = useRef(false);
+  const previousRouteRef = useRef<string | null>(null);
 
   const currentRoute = useMemo(() => {
     const query = searchParams?.toString();
@@ -118,7 +119,13 @@ export function useTelegramBackButton() {
   };
 
   useEffect(() => {
-    isHandlingBackRef.current = false;
+    if (previousRouteRef.current !== currentRoute) {
+      previousRouteRef.current = currentRoute;
+      isHandlingBackRef.current = false;
+    }
+  }, [currentRoute]);
+
+  useEffect(() => {
     syncButtonVisibility();
   }, [currentRoute, syncButtonVisibility]);
 

--- a/hooks/useStartParamRouter.ts
+++ b/hooks/useStartParamRouter.ts
@@ -239,6 +239,12 @@ export function useStartParamRouter() {
           if (lobbyId) {
             targetPath = `/strikeball/lobbies/${lobbyId}`;
           }
+        } else if (paramToProcess.startsWith("buy_")) {
+          const bikeId = paramToProcess.substring(4);
+          const franchizeSlug = searchParams.get("slug") || userCrewInfo?.slug || "vip-bike";
+          if (bikeId) {
+            targetPath = `/franchize/${franchizeSlug}/market/${bikeId}/buy`;
+          }
         } else if (paramToProcess.startsWith("rental-") || paramToProcess.startsWith("rentals-") || paramToProcess.startsWith("sale-")) {
           const rentalId = paramToProcess.split("-").at(-1);
           const franchizeSlug = searchParams.get("slug") || "vip-bike";

--- a/types/telegram.d.ts
+++ b/types/telegram.d.ts
@@ -14,6 +14,8 @@ export interface TelegramWebApp {
     user?: WebAppUser
   }
   openLink: (url: string) => void;
+  openTelegramLink?: (url: string) => void;
+  switchInlineQuery?: (query: string, choose_chat_types?: string[]) => void;
   close: () => void;
   showPopup: (params: { title?: string; message: string; buttons?: Array<{ id?: string; type?: string; text?: string }> }) => void;
   BackButton?: {


### PR DESCRIPTION
### Motivation
- Prevent a stale same-URL Telegram back guard from being recreated when async auth/context visibility changes, which caused a repeated old-route guard on slow `router.push` flows. 
- Make franchize buy UX Telegram-first and reusable: shareable WebApp links, reliable fallback for non-Telegram clients, and an operator print path (PDF+QR) for sale handoff.
- Surface Telegram + PDF/QR integration as first-class capabilities to simplify future integrations (franchize, strikeball, etc.).

### Description
- Fix native back handling by resetting the `isHandlingBackRef` only when the `currentRoute` actually changes and by tracking a `previousRouteRef` to avoid clearing the pending-back flag on transient visibility/auth updates (`hooks/telegram/useTelegramBackButton.ts`).
- Add `buy_<bikeId>` WebApp deep-link routing and support underscore separators by extending `getTelegramWebAppFallbackHref` and wiring `hooks/useStartParamRouter.ts` to open `/franchize/<slug>/market/<bikeId>/buy` for `buy_` startparams.
- Polish the buy page UI and actions: show `Открыть в Telegram` fallback when outside WebApp, show `Поделиться` inside Telegram (using native inline/share APIs when available), and show an owner/admin-only `Распечатать` button with loading/success/error states (`app/franchize/components/SaleBikeLandingClient.tsx`).
- Add a server action `sendFranchizeBuyPrintPdf` that revalidates admin/owner access via the signed Telegram actor cookie, generates a PDF with bike details, embedded image and QR linking back to the WebApp, and sends it with `sendTelegramDocument` (`app/franchize/server-actions/buy-print.ts`).
- Re-export the server action on the franchize compatibility surface (`app/franchize/actions.ts`), and add capability docs describing Telegram and PDF/QR reuse patterns (`docs/CAPABILITIES.md`, `app/franchize/TELEGRAM_CAPABILITY.md`) and update the plan diary (`docs/THE_FRANCHEEZEPLAN.md`).

### Testing
- Ran `npm run typecheck:franchize` — franchize allowlisted slice passed and the script reported one existing transitive debt outside the slice (`hooks/telegram/useTelegramClosingBehavior.ts`).
- Ran linting: `npm run lint:target` and `npx eslint --max-warnings=0 hooks/telegram/useTelegramBackButton.ts hooks/useStartParamRouter.ts types/telegram.d.ts` — these passed for the modified files.
- Ran `npx tsc --noEmit` — full repo TypeScript check fails due to pre-existing, unrelated legacy type debt across many files (this is not caused by these changes).
- Started local dev server (`npm run dev`) and attempted a visual capture; screenshot generation was blocked by missing Playwright system libraries on the host (Playwright engines failed with missing GTK/libatk dependencies), so the visual smoke check could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ce453368832490064acc34a5de4b)