### PR TITLE
bckbtnfix2

### DIFF
--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -109,12 +109,11 @@ const getThemeForPath = (pathname: string) => {
  * AppInitializers
  *
  * Mounts the Telegram BackButton hook and the navigation tracker.
- * These are placed inside AppProvider so they have access to the tg context.
  *
- * IMPORTANT: useTelegramBackButton is called here (not in LayoutLogicController)
- * because it needs to be inside AppProvider but doesn't need to be inside
- * ThemeProvider. The Suspense boundary wrapping this component is fine —
- * the hook will re-initialize when the Suspense resolves.
+ * NOTE: useTelegramBackButton no longer depends on `tg` from React context.
+ * It reads `window.Telegram.WebApp` directly, which is injected by the
+ * Telegram client BEFORE any JavaScript runs. This means the hook works
+ * correctly even on first mount, without waiting for async auth validation.
  */
 function AppInitializers() {
     const { dbUser, isAuthenticated } = useAppContext();
@@ -125,10 +124,11 @@ function AppInitializers() {
     // This hook handles:
     // - Showing/hiding the native Telegram BackButton based on navigation state
     // - Handling BackButton clicks to navigate in-app
-    // - Intercepting Android system back button (popstate)
     //
-    // NOTE: isInTelegramContext is intentionally NOT used here anymore.
-    // The hook now checks for the real Telegram runtime directly.
+    // NOTE: This hook does NOT use `tg` from React context at all.
+    // It reads `window.Telegram.WebApp` directly to avoid timing issues
+    // with async auth validation (which was the root cause of the
+    // BackButton not appearing on first navigation).
     useTelegramBackButton();
 
     useFocusTimeTracker({

--- a/hooks/telegram/useTelegramBackButton.ts
+++ b/hooks/telegram/useTelegramBackButton.ts
@@ -216,6 +216,11 @@ export function useTelegramBackButton() {
   // every 200ms up to 10 times (2 seconds total).
 
   useEffect(() => {
+    // Define stableClick at the effect level so both setupBackButton and
+    // cleanup share the same reference. This is critical because Telegram's
+    // offClick compares by reference — a new anonymous fn would silently no-op.
+    const stableClick = () => backHandlerRef.current();
+
     const setupBackButton = () => {
       const webApp = getWebApp();
       const backButton = webApp?.BackButton;
@@ -228,8 +233,6 @@ export function useTelegramBackButton() {
         return false;
       }
 
-      const stableClick = () => backHandlerRef.current();
-
       backButton.offClick(stableClick); // Remove any stale handler
       backButton.onClick(stableClick);
 
@@ -241,13 +244,18 @@ export function useTelegramBackButton() {
     if (setupBackButton()) {
       isSetupRef.current = true;
     } else {
-      // Retry with exponential backoff
+      // Retry every 200ms up to 10 times (2 seconds total)
       let attempts = 0;
       const maxAttempts = 10;
       const trySetup = () => {
         attempts++;
         if (setupBackButton()) {
           isSetupRef.current = true;
+          // The first syncButtonVisibility() at the bottom of this effect
+          // returned early (no backButton). Now that we have one, sync
+          // visibility immediately — otherwise the back button stays hidden
+          // until the next route change.
+          syncButtonVisibility();
           return;
         }
         if (attempts < maxAttempts) {
@@ -271,10 +279,10 @@ export function useTelegramBackButton() {
         clearTimeout(retryTimerRef.current);
         retryTimerRef.current = null;
       }
-      // Clean up click handler
+      // Clean up click handler using the SAME reference as onClick
       const backButton = getWebApp()?.BackButton;
       if (backButton) {
-        backButton.offClick(() => backHandlerRef.current());
+        backButton.offClick(stableClick);
       }
       unsubscribe();
     };

--- a/hooks/telegram/useTelegramBackButton.ts
+++ b/hooks/telegram/useTelegramBackButton.ts
@@ -3,7 +3,6 @@
 
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useAppContext } from "@/contexts/AppContext";
 import { debugLogger as logger } from "@/lib/debugLogger";
 import { navigationStore } from "@/stores/navigationStore";
 
@@ -16,13 +15,31 @@ function currentFullPath(): string {
 }
 
 /**
+ * Returns the Telegram WebApp object directly from window.Telegram.
+ * This is the RELIABLE source — it exists from the very first JS execution
+ * inside a Telegram WebView, BEFORE any React rendering or async auth.
+ *
+ * Do NOT use tg from React context for BackButton operations.
+ * The context tg depends on async auth validation and may be null/stale
+ * when the hook first mounts.
+ */
+function getWebApp() {
+  if (typeof window === "undefined") return undefined;
+  return window.Telegram?.WebApp;
+}
+
+/**
  * Determines a sensible "go back" target based purely on the URL structure.
  * This is the SAFETY NET that makes the BackButton appear even when the
  * navigationStore is empty (page refresh, deep link, etc.).
  *
- * IMPORTANT: This function MUST be kept. Removing it (as Grok proposed) is a
- * regression — without it, BackButton would never show after a page refresh
- * even when there's a clear logical parent route.
+ * IMPORTANT: This function MUST be kept. Without it, BackButton would never
+ * show after a page refresh even when there's a clear logical parent route.
+ *
+ * Examples:
+ *   /franchize/vip-bike       → /vipbikerental
+ *   /franchize/vip-bike/cart  → /franchize/vip-bike
+ *   /rent/catalog             → /rent
  */
 function fallbackPathFor(path: string): string | null {
   const [pathname] = path.split(/[?#]/);
@@ -83,23 +100,29 @@ function resolveBackTarget(currentPath: string): string | null {
  * Manages the Telegram Mini App's native BackButton visibility and click handling.
  *
  * Key design decisions:
+ * - Does NOT use `tg` from React context (AppProvider) for BackButton operations.
+ *   The context tg depends on async auth validation and may be null/stale when
+ *   the hook first mounts. Instead, we use `window.Telegram.WebApp` directly,
+ *   which is injected by the Telegram client BEFORE any JavaScript runs.
  * - Does NOT push routes to navigationStore (TelegramNavigationTracker does that)
  * - Uses fallbackPathFor() as a safety net for page refreshes / deep links
- * - Does NOT use isInTelegramContext (which depends on async auth validation)
- *   for the show/hide decision; instead checks for real Telegram runtime
  * - Does NOT create duplicate browser history entries (no pushState guards)
  * - Relies on Telegram's built-in system back interception:
  *   when BackButton.isVisible is true, pressing Android system back fires
  *   BackButton.onClick instead of closing the app
  */
 export function useTelegramBackButton() {
-  const { tg } = useAppContext();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isHandlingBackRef = useRef(false);
   const previousRouteRef = useRef<string | null>(null);
   const readyCalledRef = useRef(false);
+  // Track whether we've successfully set up the BackButton listener,
+  // so we can retry if the runtime isn't available yet.
+  const isSetupRef = useRef(false);
+  // Retry timer for when Telegram runtime isn't available yet
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const currentRoute = useMemo(() => {
     const query = searchParams?.toString();
@@ -107,55 +130,46 @@ export function useTelegramBackButton() {
   }, [pathname, searchParams]);
 
   // ─── Visibility Sync ────────────────────────────────────────────
+  //
+  // IMPORTANT: This callback has NO dependency on `tg` from context.
+  // We always read from `window.Telegram.WebApp` directly at call time.
+  // This avoids stale closures and timing issues with context initialization.
 
   const syncButtonVisibility = useCallback(() => {
-    // Try context tg first, then fall back to window.Telegram directly.
-    // This handles the case where AppProvider hasn't initialized yet
-    // but the Telegram runtime is already available on window.
-    const backButton = tg?.BackButton ?? (typeof window !== "undefined" ? window.Telegram?.WebApp?.BackButton : undefined);
+    const webApp = getWebApp();
+    const backButton = webApp?.BackButton;
+
+    logger.info("[Telegram BackButton] syncButtonVisibility", {
+      hasWebApp: Boolean(webApp),
+      hasBackButton: Boolean(backButton),
+      browserPath: typeof window !== "undefined" ? currentFullPath() : "SSR",
+      canGoBack: navigationStore.canGoBack(),
+      stackLength: navigationStore.getState().stack.length,
+      nativeVisible: backButton?.isVisible,
+    });
+
     if (!backButton) return;
-
-    // Check for real Telegram runtime. We do NOT depend on isInTelegramContext
-    // because that relies on async auth validation which may be delayed or fail.
-    // The native BackButton is available as soon as telegram-web-app.js loads.
-    const hasTelegramRuntime = Boolean(
-      tg?.initData ||
-      tg?.initDataUnsafe?.user ||
-      (typeof window !== "undefined" && window.Telegram?.WebApp)
-    );
-
-    if (!hasTelegramRuntime) {
-      backButton.hide();
-      return;
-    }
 
     const browserPath = currentFullPath();
     const canShow = hasAppBackTarget(browserPath);
 
-    logger.info("[Telegram BackButton] visibility sync", {
-      browserPath,
-      canShow,
-      stackLength: navigationStore.getState().stack.length,
-      nativeVisible: backButton.isVisible,
-    });
-
     if (canShow) {
-      // Ensure tg.ready() has been called at least once.
-      // Some Telegram features don't work until ready() is called.
-      if (!readyCalledRef.current && tg?.ready) {
-        tg.ready();
+      // Call WebApp.ready() at least once. This is required for some
+      // Telegram features to work, including BackButton visibility.
+      if (!readyCalledRef.current && webApp?.ready) {
+        webApp.ready();
         readyCalledRef.current = true;
       }
       backButton.show();
+      logger.info("[Telegram BackButton] → SHOWN", { browserPath });
     } else {
       backButton.hide();
+      logger.info("[Telegram BackButton] → HIDDEN", { browserPath });
     }
-  }, [tg]); // NOTE: intentionally NO isInTelegramContext here
+  }, []); // EMPTY — no dependency on tg context
 
   // ─── Back Handler ───────────────────────────────────────────────
 
-  // We store the handler in a ref so the click/popstate listeners
-  // always call the latest version without needing to re-register.
   const backHandlerRef = useRef<() => void>(() => {});
 
   backHandlerRef.current = () => {
@@ -170,11 +184,11 @@ export function useTelegramBackButton() {
       router.push(targetPath);
     } else {
       logger.info("[Telegram BackButton] No app-level back target, closing Telegram WebApp.");
-      tg?.close?.();
+      // Use the global directly — don't depend on context tg
+      getWebApp()?.close?.();
     }
 
     // Reset the guard after a short delay to allow navigation to complete.
-    // This prevents double-handling if both BackButton.onClick and popstate fire.
     setTimeout(() => {
       isHandlingBackRef.current = false;
     }, 300);
@@ -196,15 +210,54 @@ export function useTelegramBackButton() {
   }, [currentRoute, syncButtonVisibility]);
 
   // ─── Mount Telegram BackButton click handler + store subscription ─
+  //
+  // This effect also includes retry logic: if `window.Telegram.WebApp`
+  // isn't available yet (e.g., the script hasn't loaded), we retry
+  // every 200ms up to 10 times (2 seconds total).
 
   useEffect(() => {
-    const backButton = tg?.BackButton ?? (typeof window !== "undefined" ? window.Telegram?.WebApp?.BackButton : undefined);
-    if (!backButton || typeof window === "undefined") return;
+    const setupBackButton = () => {
+      const webApp = getWebApp();
+      const backButton = webApp?.BackButton;
 
-    const stableClick = () => backHandlerRef.current();
+      if (!backButton) {
+        // Runtime not available yet — retry
+        if (!isSetupRef.current) {
+          logger.info("[Telegram BackButton] Runtime not available yet, will retry...");
+        }
+        return false;
+      }
 
-    backButton.offClick(stableClick); // Remove any stale handler first
-    backButton.onClick(stableClick);
+      const stableClick = () => backHandlerRef.current();
+
+      backButton.offClick(stableClick); // Remove any stale handler
+      backButton.onClick(stableClick);
+
+      logger.info("[Telegram BackButton] Click handler mounted successfully.");
+      return true;
+    };
+
+    // Try immediately
+    if (setupBackButton()) {
+      isSetupRef.current = true;
+    } else {
+      // Retry with exponential backoff
+      let attempts = 0;
+      const maxAttempts = 10;
+      const trySetup = () => {
+        attempts++;
+        if (setupBackButton()) {
+          isSetupRef.current = true;
+          return;
+        }
+        if (attempts < maxAttempts) {
+          retryTimerRef.current = setTimeout(trySetup, 200);
+        } else {
+          logger.warn("[Telegram BackButton] Failed to mount after 10 retries. Giving up.");
+        }
+      };
+      retryTimerRef.current = setTimeout(trySetup, 200);
+    }
 
     // Subscribe to navigation store changes so visibility updates
     // whenever TelegramNavigationTracker pushes a new route.
@@ -214,15 +267,20 @@ export function useTelegramBackButton() {
     syncButtonVisibility();
 
     return () => {
-      backButton.offClick(stableClick);
+      if (retryTimerRef.current) {
+        clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
+      }
+      // Clean up click handler
+      const backButton = getWebApp()?.BackButton;
+      if (backButton) {
+        backButton.offClick(() => backHandlerRef.current());
+      }
       unsubscribe();
     };
-  }, [tg, syncButtonVisibility]);
+  }, [syncButtonVisibility]);
 
   // ─── Handle browser popstate (system back/forward navigation) ────
-  //
-  // When the user presses the Android system back button or uses browser
-  // back/forward, popstate fires AFTER the browser has navigated.
   //
   // In Telegram Mini Apps, the system back button is handled by Telegram's
   // client: when BackButton.isVisible is true, pressing system back triggers
@@ -233,28 +291,11 @@ export function useTelegramBackButton() {
   // browser-initiated navigation. It does NOT try to intercept or guard
   // history entries — that approach leads to duplicate history entries and
   // the "two presses needed" bug.
-  //
-  // WHY NO ensureHistoryGuard / pushState guard?
-  // ─────────────────────────────────────────────
-  // The guard approach pushed an extra history entry per route so the browser
-  // had something to pop before closing. But popstate gives you the state
-  // of the NEW entry (where you landed), not the OLD entry (what you left).
-  // So checking __isExtra on popstate requires TWO system back presses:
-  //
-  //   Press 1: pop __isExtra → land on __backGuard (same URL, no action)
-  //   Press 2: pop __backGuard → land on previous __isExtra (triggers handler)
-  //
-  // That's worse UX than the original bug. Instead, we rely on Telegram's
-  // built-in interception: when BackButton.isVisible is true, the Telegram
-  // client fires BackButton.onClick on system back instead of closing.
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     const handlePopState = () => {
-      // After browser back/forward, reset our handling guard and sync visibility.
-      // The navigationStore will be updated by TelegramNavigationTracker's
-      // popstate handler (which updates previousUrlRef to prevent re-pushing).
       isHandlingBackRef.current = false;
       previousRouteRef.current = currentFullPath();
       syncButtonVisibility();


### PR DESCRIPTION
Good catch — you're right, we only fixed issue #2 but **not issue #1**. The hook still depends on `tg` from React context, which may be `null` or incomplete on first mount. Let me trace the actual failure:
## 🔬 Root cause of the remaining failure

The `syncButtonVisibility` callback has `[tg]` as a dependency:

```ts
const syncButtonVisibility = useCallback(() => {
    const backButton = tg?.BackButton ?? window.Telegram?.WebApp?.BackButton;
    // ...
}, [tg]); // ← PROBLEM: tg is null on first render
```

**On first render inside Telegram:**
1. `AppProvider` hasn't finished auth validation → `tg` from context is `null`/empty
2. `tg?.BackButton` → `undefined`
3. Falls back to `window.Telegram?.WebApp?.BackButton` → **should work... but only if the script has loaded**
4. The `telegram-web-app.js` script loads with `strategy="beforeInteractive"` — but in Next.js App Router, `beforeInteractive` is unreliable and the script may load LATE, after the first render
5. If `window.Telegram?.WebApp` doesn't exist yet → `backButton = undefined` → **early return, button never shown**
6. When `tg` from context finally updates (after auth), the callback IS recreated — BUT the Telegram client injects `window.Telegram.WebApp` synchronously before any JS runs, so **by the time auth completes, the global should be available**

Wait — actually the Telegram client DOES inject `window.Telegram` before ANY JavaScript runs. So `window.Telegram.WebApp.BackButton` should exist from the very first line of JS. Unless...

**The real issue:** `tg` from `useAppContext()` might be a STABLE OBJECT REFERENCE that starts empty and gets mutated in place. If `tg` is the same reference every render, then `[tg]` never changes, `syncButtonVisibility` is never recreated, and the stale closure keeps seeing the empty `tg`.

Even worse — `backHandlerRef.current` uses `tg?.close?.()`. If `tg` is null in the closure, closing the app doesn't work either.

**The fix:** Stop depending on `tg` from context entirely. Use `window.Telegram.WebApp` directly for ALL BackButton operations.
Now let me also update `ClientLayout.tsx` — since the hook no longer uses `tg` from context, we should remove the comment that says it does, and verify it works:
## Here's what changed and why

### The 3 changes in this fix:

| # | What | Why |
|---|---|---|
| 1 | **Removed `tg` from `useAppContext()` entirely** | The hook no longer depends on `tg` from React context. Instead, it reads `window.Telegram.WebApp` directly via `getWebApp()` helper. This is the core fix — `tg` from context is null/stale on first mount because it waits for async auth validation. |
| 2 | **`syncButtonVisibility` has `[]` empty deps** | No dependency on `tg` means no stale closure. Every call reads `window.Telegram.WebApp` fresh from the global. |
| 3 | **Added retry logic** | If `window.Telegram.WebApp.BackButton` isn't available yet (script still loading), the hook retries every 200ms up to 10 times (2 seconds). This handles edge cases where `telegram-web-app.js` loads late. |

### Why the previous fix didn't work:

```
First render inside Telegram:
  1. AppProvider starts auth validation → tg = null
  2. AppInitializers mounts → useTelegramBackButton() called
  3. syncButtonVisibility() runs:
     - tg?.BackButton → undefined (tg is null)
     - window.Telegram?.WebApp?.BackButton → should exist...
     - BUT: syncButtonVisibility is created with [tg] dep
     - Since tg is null, the callback captures the null tg
     - Even though we check window.Telegram fallback...
  
  Actually the fallback SHOULD work. But then:
  
  4. AppProvider finishes auth → tg updates to real object
  5. syncButtonVisibility is RECREATED (because [tg] dep changed)
  6. But the [currentRoute, syncButtonVisibility] effect re-runs
  7. syncButtonVisibility() is called with new tg → should show button
  
  BUT: if tg is a stable object reference that gets MUTATED in place
  (not replaced), then [tg] never triggers a re-render, and the
  callback is NEVER recreated with the real tg.
```

The fix eliminates this entire class of bugs by never reading from `tg` context at all.

### Files saved in `/home/z/my-project/download/`:
- **`useTelegramBackButton.ts`** — complete rewrite, no `tg` dependency
- **`ClientLayout.tsx`** — updated comments to match new behavior
- **`TelegramNavigationTracker.tsx`** — unchanged from previous version ✅

The `TelegramNavigationTracker.tsx` from your last approved diff is still correct — no changes needed there.

### Quick debug tip for production:

Watch for these log lines in the Telegram WebApp console:
```
[Telegram BackButton] syncButtonVisibility { hasWebApp: true, hasBackButton: true, canGoBack: true, nativeVisible: false }
[Telegram BackButton] → SHOWN { browserPath: "/franchize/vip-bike/cart" }
```

If you see `hasWebApp: false`, the Telegram script isn't loading — check the `beforeInteractive` script tag.