### PR TITLE
Catalog card redesign, header cart/rail indicator, docs and SupaPlan UUID CLI hint

### DIFF
--- a/BISS_QUEST.HTML
+++ b/BISS_QUEST.HTML
@@ -26,5 +26,11 @@
       не откладывать на финальный отчёт агента.
     </li>
   </ul>
+  <h2>PR checklist for SupaPlan quests (mandatory)</h2>
+  <ul>
+    <li>PR title must start with <code>⚡:</code> for quest/auto-merge flows.</li>
+    <li>PR body must contain standalone line: <code>supaplan_task: &lt;task_id&gt;</code>.</li>
+    <li>Before sending notification, re-check PR title/body include both items above.</li>
+  </ul>
 </body>
 </html>

--- a/BISS_QUEST.HTML
+++ b/BISS_QUEST.HTML
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <title>BISS QUEST Runtime Notes</title>
+</head>
+<body>
+  <h1>BISS QUEST — Runtime Guardrails</h1>
+  <h2>Notification bugfix memo (2026-05-21)</h2>
+  <ul>
+    <li>
+      Симптом: в уведомлении строка "Следующая задача" иногда отправлялась как короткий хвост id
+      (например <code>be32ce57...</code>) вместо полной URL.
+    </li>
+    <li>
+      Причина: использовался декоративный teaser-текст из старого шаблона уведомления, а не каноничный
+      <code>codex_task_url</code> из данных следующей SupaPlan-задачи.
+    </li>
+    <li>
+      Правило: для блока "Следующая задача" всегда сначала резолвить <code>next_quest_uuid</code>,
+      затем читать задачу из <code>supaplan_tasks</code> и брать реальный URL из
+      <code>metadata.codex_task_url</code> (fallback: парсить <code>codex_task_url:</code> из body).
+    </li>
+    <li>
+      Правило: branching suggestions отправлять сразу отдельным follow-up сообщением после victory message,
+      не откладывать на финальный отчёт агента.
+    </li>
+  </ul>
+</body>
+</html>

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -42,6 +42,7 @@ const sortWbItemLast = <T extends { category: string }>(groups: T[]) => {
 };
 
 type VisiblePriceLine = { key: "rent" | "sale"; label: string; value: string; tone: "accent" | "sale" };
+type VisibleSpecChip = { icon: string; text: string };
 
 function getVisiblePriceLines(item: CatalogItemVM): VisiblePriceLine[] {
   const lines: VisiblePriceLine[] = [];
@@ -65,6 +66,43 @@ function getVisiblePriceLines(item: CatalogItemVM): VisiblePriceLine[] {
   }
 
   return lines;
+}
+
+function getVisibleSpecChips(item: CatalogItemVM): VisibleSpecChip[] {
+  const preferredRules = [
+    { match: /(мощ|power|kw|вт)/i, icon: "⚡" },
+    { match: /(запас|дальн|range|km|км)/i, icon: "🛣" },
+    { match: /(батар|аккум|battery|ah|wh)/i, icon: "🔋" },
+  ] as const;
+
+  const chips: VisibleSpecChip[] = [];
+  const usedIndexes = new Set<number>();
+
+  for (const rule of preferredRules) {
+    const specIndex = item.specs.findIndex((entry, index) => {
+      if (usedIndexes.has(index)) return false;
+      return rule.match.test(`${entry.label} ${entry.value}`);
+    });
+
+    if (specIndex >= 0) {
+      const entry = item.specs[specIndex];
+      usedIndexes.add(specIndex);
+      chips.push({ icon: rule.icon, text: `${entry.label}: ${entry.value}` });
+    }
+  }
+
+  if (chips.length >= 2) return chips.slice(0, 3);
+
+  for (let index = 0; index < item.specs.length; index += 1) {
+    if (usedIndexes.has(index)) continue;
+    const entry = item.specs[index];
+    const value = `${entry.label}: ${entry.value}`.trim();
+    if (!value) continue;
+    chips.push({ icon: "•", text: value });
+    if (chips.length >= 3) break;
+  }
+
+  return chips.slice(0, 3);
 }
 
 
@@ -520,6 +558,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                   {group.items.map((item) => {
                     const rentalStrip = buildCatalogRentalStrip(item, crew);
                     const visiblePrices = getVisiblePriceLines(item);
+                    const visibleSpecs = getVisibleSpecChips(item);
                     return (
                     <article
                       key={item.id}
@@ -565,9 +604,9 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                             <h3 className="text-sm font-semibold leading-5 text-white">{item.title}</h3>
                             <p className="line-clamp-2 text-[11px] text-white/85">{item.description || item.subtitle}</p>
                             <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-white/75">
-                              {item.specs.power && <span>⚡ {item.specs.power}</span>}
-                              {item.specs.range && <span>🛣 {item.specs.range}</span>}
-                              {item.specs.battery && <span>🔋 {item.specs.battery}</span>}
+                              {visibleSpecs.map((spec, index) => (
+                                <span key={`${item.id}-spec-${index}`}>{spec.icon} {spec.text}</span>
+                              ))}
                             </div>
                             <div className="mt-2 space-y-0.5">
                               {visiblePrices.map((line) => (

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -41,11 +41,37 @@ const sortWbItemLast = <T extends { category: string }>(groups: T[]) => {
   return [...regular, ...wbItems];
 };
 
+type VisiblePriceLine = { key: "rent" | "sale"; label: string; value: string; tone: "accent" | "sale" };
+
+function getVisiblePriceLines(item: CatalogItemVM): VisiblePriceLine[] {
+  const lines: VisiblePriceLine[] = [];
+
+  if (item.pricePerDay > 0) {
+    lines.push({
+      key: "rent",
+      label: "Аренда",
+      value: item.rentPriceLabel,
+      tone: "accent",
+    });
+  }
+
+  if (item.saleAvailable && item.salePrice && item.salePrice > 0) {
+    lines.push({
+      key: "sale",
+      label: "Покупка",
+      value: `${item.salePrice.toLocaleString("ru-RU")} ₽`,
+      tone: "sale",
+    });
+  }
+
+  return lines;
+}
+
 
 function CatalogCardSkeleton({ index }: { index: number }) {
   return (
     <article className="overflow-hidden rounded-3xl border border-[var(--catalog-border)] bg-[var(--catalog-card-bg)]" aria-hidden="true">
-      <div className="relative aspect-[4/3] overflow-hidden bg-black/20 lg:aspect-square">
+      <div className="relative aspect-[9/16] overflow-hidden rounded-[inherit] bg-black/20">
         <div
           className="absolute inset-y-0 w-1/2 animate-shimmer bg-gradient-to-r from-transparent via-white/15 to-transparent"
           style={{ animationDelay: `${index * 120}ms` }}
@@ -493,11 +519,12 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                 <div className="grid grid-cols-2 gap-3 xl:grid-cols-3 2xl:grid-cols-4">
                   {group.items.map((item) => {
                     const rentalStrip = buildCatalogRentalStrip(item, crew);
+                    const visiblePrices = getVisiblePriceLines(item);
                     return (
                     <article
                       key={item.id}
                       data-catalog-item="true"
-                      className="group overflow-hidden rounded-2xl border"
+                      className="group overflow-hidden rounded-3xl border"
                       style={catalogCardVariantStyles(crew.theme, item.id.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0))}
                     >
                       <button
@@ -510,76 +537,59 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                         onBlur={() => setFocusedItemId((prev) => (prev === item.id ? null : prev))}
                         style={focusedItemId === item.id ? interactionRingStyle(crew.theme) : undefined}
                       >
-                        <div className="relative aspect-[4/3] w-full lg:aspect-square">
+                        <div className="relative aspect-[9/16] w-full">
                           {item.imageUrl ? (
                             <Image src={item.imageUrl} alt={item.title} fill sizes="(max-width: 1279px) 50vw, (max-width: 1535px) 33vw, 25vw" className="object-cover" />
                           ) : (
                             <div className="flex h-full w-full items-center justify-center px-3 text-center text-xs" style={surface.mutedText}>Фото байка загружается — карточка уже доступна для брони</div>
                           )}
-                        </div>
-                        <div className="p-3">
-                          <div className="mb-2 flex flex-wrap gap-1.5">
-                            {item.isHot && (
-                              <span className="inline-flex rounded-full bg-[color:color-mix(in_srgb,var(--catalog-accent)_86%,transparent)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--catalog-accent-contrast)]">
-                                Высокий спрос
-                              </span>
-                            )}
-                            <span
-                              className="inline-flex rounded-full px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em]"
-                              style={{
-                                backgroundColor: rentalStrip.isAvailable ? "#1f7a3a3d" : "#dc262640",
-                                color: "#e6f4ea",
-                                border: rentalStrip.isAvailable ? "1px solid rgba(46, 160, 67, 0.45)" : "1px solid rgba(220, 38, 38, 0.45)",
-                              }}
-                            >
-                              {rentalStrip.availabilityLabel}
-                            </span>
-                            {item.saleAvailable && (
-                              <span className="inline-flex rounded-full border border-amber-300/60 bg-amber-400/25 px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em] text-amber-100">
-                                Доступен к покупке
-                              </span>
-                            )}
-                          </div>
-                          {item.reviewSummary.count > 0 && (
-                            <span className="inline-flex rounded-full border border-yellow-300/60 bg-yellow-400/20 px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em] text-yellow-100">
-                              ★ {item.reviewSummary.average.toFixed(1)} · {item.reviewSummary.count}
-                            </span>
-                          )}
-                          <h3 className="mt-1 text-sm font-semibold leading-5">{item.title}</h3>
-                          <p className="text-xs" style={surface.mutedText}>{item.description || item.subtitle}</p>
-                          <div
-                            className="mt-2 rounded-2xl border border-white/10 bg-black/15 p-2 text-[10px] leading-4"
-                            aria-label={`Аренда ${item.title}: ${rentalStrip.todayLabel}`}
-                          >
-                            <div className="flex items-center justify-between gap-2 font-semibold text-[var(--catalog-text)]">
-                              <span>Слот: {rentalStrip.todayLabel}</span>
-                              <span className={rentalStrip.isAvailable ? "text-emerald-200" : "text-amber-100"}>
-                                {rentalStrip.nearestStartWindow}
+                          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[62%] bg-gradient-to-t from-[color:color-mix(in_srgb,var(--catalog-card-bg)_92%,#000)] via-[color:color-mix(in_srgb,var(--catalog-card-bg)_72%,transparent)] to-transparent" />
+                          <div className="absolute inset-x-0 bottom-0 p-2.5 pb-3 sm:p-3">
+                            <div className="mb-1.5 flex flex-wrap gap-1.5">
+                              {item.isHot && (
+                                <span className="inline-flex rounded-full bg-[color:color-mix(in_srgb,var(--catalog-accent)_86%,transparent)] px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--catalog-accent-contrast)]">
+                                  Высокий спрос
+                                </span>
+                              )}
+                              <span
+                                className="inline-flex rounded-full px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em]"
+                                style={{
+                                  backgroundColor: rentalStrip.isAvailable ? "#1f7a3a3d" : "#dc262640",
+                                  color: "#e6f4ea",
+                                  border: rentalStrip.isAvailable ? "1px solid rgba(46, 160, 67, 0.45)" : "1px solid rgba(220, 38, 38, 0.45)",
+                                }}
+                              >
+                                {rentalStrip.availabilityLabel}
                               </span>
                             </div>
-                            <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5" style={surface.mutedText}>
-                              <span>Точка: {rentalStrip.pickupHint}</span>
-                              <span>{rentalStrip.priceTeaser}</span>
+                            <h3 className="text-sm font-semibold leading-5 text-white">{item.title}</h3>
+                            <p className="line-clamp-2 text-[11px] text-white/85">{item.description || item.subtitle}</p>
+                            <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-white/75">
+                              {item.specs.power && <span>⚡ {item.specs.power}</span>}
+                              {item.specs.range && <span>🛣 {item.specs.range}</span>}
+                              {item.specs.battery && <span>🔋 {item.specs.battery}</span>}
                             </div>
-                          </div>
-                          {item.reviewSummary.latest?.text && (
-                            <p className="mt-2 rounded-xl border border-white/10 px-2 py-1.5 text-[11px] leading-4" style={surface.mutedText}>
-                              “{item.reviewSummary.latest.text}”
-                            </p>
-                          )}
-                          <p className="mt-2 text-base font-bold text-[var(--catalog-accent)]">
-                            {item.rentPriceLabel}
-                          </p>
-                          {item.saleAvailable && item.salePrice ? (
-                            <p className="mt-1 text-xs font-semibold text-amber-200">
-                              Цена покупки: {item.salePrice.toLocaleString("ru-RU")} ₽
-                            </p>
-                          ) : null}
-                          <div className="mt-2 flex gap-2">
-                            <span className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--catalog-accent)] px-2 py-2.5 text-xs font-bold text-[var(--catalog-accent-contrast)] transition-transform active:scale-95">
-                              <ShoppingCart className="h-4 w-4" />
-                              {item.saleAvailable ? "Закрепить байк" : "Забронировать выезд"}
-                            </span>
+                            <div className="mt-2 space-y-0.5">
+                              {visiblePrices.map((line) => (
+                                <p
+                                  key={line.key}
+                                  className={line.tone === "accent" ? "text-sm font-bold text-[var(--catalog-accent)]" : "text-[11px] font-semibold text-amber-200"}
+                                >
+                                  {line.label}: {line.value}
+                                </p>
+                              ))}
+                              {visiblePrices.length === 0 ? (
+                                <p className="text-[11px] font-medium text-white/80">
+                                  Цена по запросу
+                                </p>
+                              ) : null}
+                            </div>
+                            <div className="mt-2">
+                              <span className="inline-flex min-h-10 w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--catalog-accent)] px-2 py-2 text-xs font-bold text-[var(--catalog-accent-contrast)] transition-transform active:scale-95">
+                                <ShoppingCart className="h-4 w-4" />
+                                {item.saleAvailable ? "Закрепить" : "Бронь"}
+                              </span>
+                            </div>
                           </div>
                         </div>
                       </button>

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -211,11 +211,9 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
     );
     if (!activeEl) return;
 
-    const trackRect = container.getBoundingClientRect();
-    const activeRect = activeEl.getBoundingClientRect();
     setIndicatorStyle({
-      width: activeRect.width,
-      left: activeRect.left - trackRect.left,
+      width: activeEl.offsetWidth,
+      left: activeEl.offsetLeft,
       opacity: 1,
     });
   }, [activePath, pathname, visibleRailLinks]);

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -3,12 +3,13 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Menu } from "lucide-react";
+import { Menu, ShoppingCart } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import type { FranchizeCrewVM } from "../actions";
 import { HeaderMenu } from "../modals/HeaderMenu";
 import { FranchizeProfileButton } from "./FranchizeProfileButton";
+import { useFranchizeCart } from "../hooks/useFranchizeCart";
 import { toCategoryId } from "../lib/navigation";
 import { FRANCHIZE_HEADER_CORNER_GUARD_STYLE, FRANCHIZE_HEADER_SAFE_AREA_STYLE } from "../lib/route-cta-policy";
 import type { FranchizeSectionLink } from "../lib/section-links";
@@ -38,7 +39,9 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
   const headerLogoHref = crew.header.logoHref || mainCatalogPath;
   const railRef = useRef<HTMLDivElement | null>(null);
   const prevPathnameRef = useRef<string | null>(null);
+  const [indicatorStyle, setIndicatorStyle] = useState<{ width: number; left: number; opacity: number }>({ width: 0, left: 0, opacity: 0 });
   const activePillText = readablePaletteTextOnColor(crew.theme.palette.accentMain, crew.theme.palette);
+  const { itemCount } = useFranchizeCart(crew.slug);
 
   // ── Logo loading state machine ──
   //   loading → (onLoad) → dissolving → (animationEnd) → revealed
@@ -190,10 +193,36 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
     }
   }, [activePath, pathname, visibleRailLinks]);
   // ------------------------------------------------------------------
+  useEffect(() => {
+    const container = railRef.current;
+    if (!container) return;
+
+    const activeRailLink = visibleRailLinks.find(
+      (link) => link.active || (!link.href.startsWith("#") && (pathname === link.href || activePath === link.href)),
+    );
+
+    if (!activeRailLink) {
+      setIndicatorStyle((prev) => ({ ...prev, opacity: 0 }));
+      return;
+    }
+
+    const activeEl = Array.from(container.querySelectorAll<HTMLElement>("[data-category-pill]")).find(
+      (element) => element.dataset.categoryPill === activeRailLink.categoryLabel,
+    );
+    if (!activeEl) return;
+
+    const trackRect = container.getBoundingClientRect();
+    const activeRect = activeEl.getBoundingClientRect();
+    setIndicatorStyle({
+      width: activeRect.width,
+      left: activeRect.left - trackRect.left,
+      opacity: 1,
+    });
+  }, [activePath, pathname, visibleRailLinks]);
 
   return (
     <header
-      className="sticky top-0 z-50 border-b pb-2 backdrop-blur-2xl"
+      className="sticky top-0 z-50 border-b pb-2 pt-[max(env(safe-area-inset-top),0.15rem)] backdrop-blur-2xl"
       style={{
         ...FRANCHIZE_HEADER_SAFE_AREA_STYLE,
         borderColor: crew.theme.palette.borderSoft,
@@ -212,7 +241,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
           style={{
             ...FRANCHIZE_HEADER_CORNER_GUARD_STYLE,
             display: "grid",
-            gridTemplateColumns: "44px 1fr auto",
+            gridTemplateColumns: "44px 1fr auto auto",
             alignItems: "center",
             gap: "0.75rem",
             maxHeight: isCompact ? 0 : 112,
@@ -308,6 +337,19 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
             borderColor={crew.theme.palette.borderSoft}
             currentSlug={crew.slug}
           />
+          <Link
+            href={`/franchize/${crew.slug}/cart`}
+            aria-label={`Корзина, позиций: ${itemCount}`}
+            className="relative inline-flex h-11 w-11 items-center justify-center rounded-xl border transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--crew-header-accent)]"
+            style={{ borderColor: crew.theme.palette.borderSoft, backgroundColor: withAlpha(crew.theme.palette.bgBase, 0.8), color: crew.theme.palette.textPrimary }}
+          >
+            <ShoppingCart className="h-4 w-4" />
+            {itemCount > 0 && (
+              <span className="absolute -right-1 -top-1 inline-flex min-w-5 items-center justify-center rounded-full bg-[var(--crew-header-accent)] px-1.5 text-[10px] font-bold text-[var(--crew-header-accent-text)]">
+                {itemCount > 99 ? "99+" : itemCount}
+              </span>
+            )}
+          </Link>
         </div>
       </div>
 
@@ -318,6 +360,11 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
             ref={railRef}
             className="relative mx-auto flex w-full max-w-7xl gap-2 overflow-x-auto no-scrollbar pb-1 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden snap-x snap-mandatory"
           >
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute bottom-1 h-0.5 rounded-full bg-[var(--crew-header-accent)] transition-all duration-300 ease-out"
+              style={{ width: `${indicatorStyle.width}px`, transform: `translateX(${indicatorStyle.left}px)`, opacity: indicatorStyle.opacity }}
+            />
             {visibleRailLinks.map((link) => {
               const isActive = link.active || (!link.href.startsWith("#") && (pathname === link.href || activePath === link.href));
               return (

--- a/docs/AGENT_DIARY.md
+++ b/docs/AGENT_DIARY.md
@@ -51,3 +51,9 @@ Open archive only for deep forensics on:
 - Root cause: HMAC data-check-string incorrectly omitted `signature`; client also depended only on `window.Telegram.WebApp.initData`, missing raw `tgWebAppData` URL-hash fallback when WebApp bootstrap was unavailable or late.
 - Fix/workaround: include every initData field except `hash` for bot-token HMAC validation, parse `tgWebAppData`/`tgWebAppStartParam` from launch URL fallback, and keep handled start params guarded while stale URL params remain.
 - Verification command: `npm test -- tests/franchize/telegram-webapp-auth.spec.ts && npm run lint && git diff --check`.
+
+### 2026-05-21
+- Symptom: operator inputs can sometimes be a raw UUID only, which may silently look like an invalid CLI command in SupaPlan tooling.
+- Root cause: `scripts/supaplan-skill.mjs` previously treated unknown command values uniformly and did not hint that a bare UUID is likely a task id lookup intent.
+- Fix/workaround: added UUID-shaped command detection in CLI entrypoint and a direct hint to run `task-status --taskId <uuid>` to verify SupaPlan task context first.
+- Verification command: `node scripts/supaplan-skill.mjs f3c5306d-2d8f-4cc4-bb77-26f20f7f9b11`.

--- a/scripts/supaplan-skill.mjs
+++ b/scripts/supaplan-skill.mjs
@@ -32,6 +32,7 @@ function getAdminClient() {
 const ALLOWED_AGENT_STATUSES = new Set(['claimed', 'running', 'ready_for_pr']);
 const CLAIM_RPC_FALLBACK_CODES = new Set(['42883', 'PGRST202']);
 const SUPAPLAN_TASK_REF_REGEX = /supaplan_task\s*:\s*([0-9a-fA-F-]{36})/i;
+const UUID_V4_OR_COMPAT_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
 
 
 function normalizeError(error) {
@@ -891,6 +892,10 @@ const runners = {
 };
 
 if (!command || !runners[command]) {
+  if (command && UUID_V4_OR_COMPAT_REGEX.test(command)) {
+    console.error(`Looks like a bare UUID input: "${command}".`);
+    console.error('Tip: check whether this is a SupaPlan task id and run `node scripts/supaplan-skill.mjs task-status --taskId <uuid>`.');
+  }
   console.error('Usage: node scripts/supaplan-skill.mjs <pick-task|update-status|task-status|log-event|inspect-migrations|review-merge-workflow|smoke-flow|status|add-task|validate-plugin-contracts> [--key value] (pick-task supports --capability <name|auto> --agentId <id> --dry-run; add-task supports --title --capability [--todoPath])');
   process.exit(1);
 }


### PR DESCRIPTION
### Motivation
- Improve mobile-first catalog item presentation and make price/availability more explicit on cards. 
- Surface cart status in the header with an inline item count and reduce navigation friction by centering the active category pill. 
- Prevent operator confusion when passing a bare UUID to SupaPlan CLI tooling and document recent runtime guardrails. 

### Description
- Reworked catalog cards in `CatalogClient.tsx`: changed image aspect to `9/16`, replaced the old card layout with a gradient overlay, compact title/description/specs, and new visible price lines using a new `VisiblePriceLine` type and `getVisiblePriceLines` helper. 
- Updated skeleton and card container classes/rounded corners and consolidated CTAs into simplified inline action markup. 
- Added header cart link and badge in `CrewHeader.tsx` using `useFranchizeCart`, introduced an animated rail indicator controlled by `indicatorStyle`, and added safe-area top padding for the header. 
- Added runtime notes file `BISS_QUEST.HTML` and extended `docs/AGENT_DIARY.md` with the SupaPlan/UUID incident and verification hint. 
- Improved `scripts/supaplan-skill.mjs` by adding `UUID_V4_OR_COMPAT_REGEX` and emitting a helpful tip when the first CLI argument looks like a bare UUID. 

### Testing
- Ran lint with `npm run lint` and static/type checks with `npm run build`, which completed without errors. 
- Executed unit/smoke tests with `npm test` (including relevant franchize specs), and all tests passed. 
- Manually exercised the catalog UI and header flows in a local dev build to verify layout, cart badge, and the SupaPlan CLI bare-UUID hint behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c01f5ecc832585fb056291b41427)

supaplan_task: f3c5306d-2d8f-4cc4-bb77-26f20f7f9b11