### PR TITLE
⚡: catalog — add small-category carousel, price guards and header cart indicator

### DIFF
--- a/BISS_QUEST.HTML
+++ b/BISS_QUEST.HTML
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <title>BISS QUEST Runtime Notes</title>
+</head>
+<body>
+  <h1>BISS QUEST — Runtime Guardrails</h1>
+  <h2>Notification bugfix memo (2026-05-21)</h2>
+  <ul>
+    <li>
+      Симптом: в уведомлении строка "Следующая задача" иногда отправлялась как короткий хвост id
+      (например <code>be32ce57...</code>) вместо полной URL.
+    </li>
+    <li>
+      Причина: использовался декоративный teaser-текст из старого шаблона уведомления, а не каноничный
+      <code>codex_task_url</code> из данных следующей SupaPlan-задачи.
+    </li>
+    <li>
+      Правило: для блока "Следующая задача" всегда сначала резолвить <code>next_quest_uuid</code>,
+      затем читать задачу из <code>supaplan_tasks</code> и брать реальный URL из
+      <code>metadata.codex_task_url</code> (fallback: парсить <code>codex_task_url:</code> из body).
+    </li>
+    <li>
+      Правило: branching suggestions отправлять сразу отдельным follow-up сообщением после victory message,
+      не откладывать на финальный отчёт агента.
+    </li>
+  </ul>
+  <h2>PR checklist for SupaPlan quests (mandatory)</h2>
+  <ul>
+    <li>PR title must start with <code>⚡:</code> for quest/auto-merge flows.</li>
+    <li>PR body must contain standalone line: <code>supaplan_task: &lt;task_id&gt;</code>.</li>
+    <li>Before sending notification, re-check PR title/body include both items above.</li>
+  </ul>
+</body>
+</html>

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -41,11 +41,13 @@ const sortWbItemLast = <T extends { category: string }>(groups: T[]) => {
   return [...regular, ...wbItems];
 };
 
+const hasRentPrice = (item: CatalogItemVM) => item.pricePerDay > 0;
+const hasSalePrice = (item: CatalogItemVM) => item.saleAvailable && Boolean(item.salePrice && item.salePrice > 0);
 
 function CatalogCardSkeleton({ index }: { index: number }) {
   return (
     <article className="overflow-hidden rounded-3xl border border-[var(--catalog-border)] bg-[var(--catalog-card-bg)]" aria-hidden="true">
-      <div className="relative aspect-[4/3] overflow-hidden bg-black/20 lg:aspect-square">
+      <div className="relative aspect-[9/16] overflow-hidden bg-black/20">
         <div
           className="absolute inset-y-0 w-1/2 animate-shimmer bg-gradient-to-r from-transparent via-white/15 to-transparent"
           style={{ animationDelay: `${index * 120}ms` }}
@@ -73,6 +75,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
   const [focusedItemId, setFocusedItemId] = useState<string | null>(null);
   const [quickFilter, setQuickFilter] = useState<QuickFilterKey>("all");
   const [campaignIndex, setCampaignIndex] = useState(0);
+  const [carouselActiveByCategory, setCarouselActiveByCategory] = useState<Record<string, number>>({});
   const searchParams = useSearchParams();
   const { user, dbUser } = useAppContext();
   const lastQueryViewedVehicleRef = useRef<string>("");
@@ -81,6 +84,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
   >();
   const resolvedSlug = crew.slug || slug;
   const showFloatingCart = ctaPolicy ? shouldShowFloatingCart(ctaPolicy, { cartRelevant: true }) : true;
+  const carouselRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   const promoModules = useMemo(() => {
     const now = Date.now();
@@ -307,6 +311,53 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
     }
   }, [auctionTickOptions, items, searchParams]);
 
+  useEffect(() => {
+    const observers: IntersectionObserver[] = [];
+    const rafIds: number[] = [];
+    const cleanupByCategory: Array<() => void> = [];
+
+    itemsByCategory.forEach((group) => {
+      if (group.items.length > 8) return;
+      const root = carouselRefs.current[group.category];
+      if (!root) return;
+      const cards = Array.from(root.querySelectorAll<HTMLElement>("[data-carousel-card='true']"));
+      if (cards.length === 0) return;
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          const visible = entries
+            .filter((entry) => entry.isIntersecting)
+            .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+          if (!visible) return;
+          const nextIndex = Number((visible.target as HTMLElement).dataset.carouselIndex ?? "0");
+          setCarouselActiveByCategory((prev) => (prev[group.category] === nextIndex ? prev : { ...prev, [group.category]: nextIndex }));
+        },
+        { root, threshold: [0.55, 0.75] },
+      );
+
+      cards.forEach((card) => observer.observe(card));
+      observers.push(observer);
+
+      const onScroll = () => {
+        const rafId = window.requestAnimationFrame(() => {
+          const slotWidth = cards[0]?.offsetWidth || 1;
+          const nextIndex = Math.round(root.scrollLeft / slotWidth);
+          setCarouselActiveByCategory((prev) => (prev[group.category] === nextIndex ? prev : { ...prev, [group.category]: nextIndex }));
+        });
+        rafIds.push(rafId);
+      };
+
+      root.addEventListener("scroll", onScroll, { passive: true });
+      cleanupByCategory.push(() => root.removeEventListener("scroll", onScroll));
+    });
+
+    return () => {
+      observers.forEach((observer) => observer.disconnect());
+      rafIds.forEach((id) => window.cancelAnimationFrame(id));
+      cleanupByCategory.forEach((cleanup) => cleanup());
+    };
+  }, [itemsByCategory]);
+
   return (
     <>
       <section
@@ -490,14 +541,33 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                     {group.items.length} шт.
                   </span>
                 </div>
-                <div className="grid grid-cols-2 gap-3 xl:grid-cols-3 2xl:grid-cols-4">
-                  {group.items.map((item) => {
-                    const rentalStrip = buildCatalogRentalStrip(item, crew);
-                    return (
+                {group.items.length <= 8 ? (
+                  <>
+                    <div
+                      ref={(node) => {
+                        carouselRefs.current[group.category] = node;
+                      }}
+                      className="flex snap-x snap-mandatory gap-3 overflow-x-auto pb-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+                      tabIndex={0}
+                      role="region"
+                      aria-label={`Карусель категории ${group.category}`}
+                      onKeyDown={(event) => {
+                        if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
+                        const root = carouselRefs.current[group.category];
+                        if (!root) return;
+                        const step = root.clientWidth * 0.9;
+                        root.scrollBy({ left: event.key === "ArrowRight" ? step : -step, behavior: "smooth" });
+                      }}
+                    >
+                      {group.items.map((item, index) => {
+                        const rentalStrip = buildCatalogRentalStrip(item, crew);
+                        return (
                     <article
                       key={item.id}
                       data-catalog-item="true"
-                      className="group overflow-hidden rounded-2xl border"
+                      data-carousel-card="true"
+                      data-carousel-index={index}
+                      className="group w-[78vw] max-w-[340px] shrink-0 snap-start overflow-hidden rounded-2xl border transition-shadow hover:shadow-[0_0_0_1px_var(--catalog-accent),0_0_28px_color-mix(in_srgb,var(--catalog-accent)_35%,transparent)] sm:w-[320px]"
                       style={catalogCardVariantStyles(crew.theme, item.id.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0))}
                     >
                       <button
@@ -510,7 +580,85 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                         onBlur={() => setFocusedItemId((prev) => (prev === item.id ? null : prev))}
                         style={focusedItemId === item.id ? interactionRingStyle(crew.theme) : undefined}
                       >
-                        <div className="relative aspect-[4/3] w-full lg:aspect-square">
+                        <div className="relative aspect-[9/16] w-full">
+                          {item.imageUrl ? (
+                            <Image src={item.imageUrl} alt={item.title} fill sizes="(max-width: 1279px) 78vw, 320px" className="object-cover" />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center px-3 text-center text-xs" style={surface.mutedText}>Фото байка загружается — карточка уже доступна для брони</div>
+                          )}
+                        </div>
+                        <div className="p-3">
+                          <div className="mb-2 flex flex-wrap gap-1.5">
+                            {item.isHot && (
+                              <span className="inline-flex rounded-full bg-[color:color-mix(in_srgb,var(--catalog-accent)_86%,transparent)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--catalog-accent-contrast)]">
+                                Высокий спрос
+                              </span>
+                            )}
+                            <span className="inline-flex rounded-full px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em]" style={{ backgroundColor: rentalStrip.isAvailable ? "#1f7a3a3d" : "#dc262640", color: "#e6f4ea", border: rentalStrip.isAvailable ? "1px solid rgba(46, 160, 67, 0.45)" : "1px solid rgba(220, 38, 38, 0.45)" }}>{rentalStrip.availabilityLabel}</span>
+                            {item.saleAvailable && <span className="inline-flex rounded-full border border-amber-300/60 bg-amber-400/25 px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em] text-amber-100">Доступен к покупке</span>}
+                          </div>
+                          {item.reviewSummary.count > 0 && <span className="inline-flex rounded-full border border-yellow-300/60 bg-yellow-400/20 px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em] text-yellow-100">★ {item.reviewSummary.average.toFixed(1)} · {item.reviewSummary.count}</span>}
+                          <h3 className="mt-1 text-sm font-semibold leading-5">{item.title}</h3>
+                          <p className="text-xs" style={surface.mutedText}>{item.description || item.subtitle}</p>
+                          <div className="mt-2 rounded-2xl border border-white/10 bg-black/15 p-2 text-[10px] leading-4" aria-label={`Аренда ${item.title}: ${rentalStrip.todayLabel}`}>
+                            <div className="flex items-center justify-between gap-2 font-semibold text-[var(--catalog-text)]"><span>Слот: {rentalStrip.todayLabel}</span><span className={rentalStrip.isAvailable ? "text-emerald-200" : "text-amber-100"}>{rentalStrip.nearestStartWindow}</span></div>
+                            <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5" style={surface.mutedText}><span>Точка: {rentalStrip.pickupHint}</span><span>{rentalStrip.priceTeaser}</span></div>
+                          </div>
+                          {item.reviewSummary.latest?.text && <p className="mt-2 rounded-xl border border-white/10 px-2 py-1.5 text-[11px] leading-4" style={surface.mutedText}>“{item.reviewSummary.latest.text}”</p>}
+                          {hasRentPrice(item) ? <p className="mt-2 text-base font-bold text-[var(--catalog-accent)]">{item.rentPriceLabel}</p> : null}
+                          {hasSalePrice(item) ? <p className="mt-1 text-xs font-semibold text-amber-200">Цена покупки: {item.salePrice?.toLocaleString("ru-RU")} ₽</p> : null}
+                          {!hasRentPrice(item) && !hasSalePrice(item) ? <p className="mt-2 text-xs font-medium text-white/80">Цена по запросу</p> : null}
+                          <div className="mt-2 flex gap-2"><span className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--catalog-accent)] px-2 py-2.5 text-xs font-bold text-[var(--catalog-accent-contrast)] transition-transform active:scale-95"><ShoppingCart className="h-4 w-4" />{item.saleAvailable ? "Закрепить байк" : "Забронировать выезд"}</span></div>
+                        </div>
+                      </button>
+                    </article>
+                        );
+                      })}
+                    </div>
+                    <div className="mt-2 flex items-center justify-center gap-2" aria-label={`Пагинация карусели ${group.category}`}>
+                      {group.items.map((item, index) => {
+                        const isActive = (carouselActiveByCategory[group.category] ?? 0) === index;
+                        return (
+                          <button
+                            key={`${item.id}-dot`}
+                            type="button"
+                            aria-label={`Показать карточку ${index + 1}`}
+                            aria-current={isActive ? "true" : undefined}
+                            className="h-2.5 w-2.5 rounded-full transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--catalog-accent)]"
+                            style={{ backgroundColor: isActive ? crew.theme.palette.accentMain : `${crew.theme.palette.borderSoft}AA`, transform: isActive ? "scale(1.1)" : "scale(1)" }}
+                            onClick={() => {
+                              const root = carouselRefs.current[group.category];
+                              if (!root) return;
+                              const slotWidth = root.querySelector<HTMLElement>("[data-carousel-card='true']")?.offsetWidth || root.clientWidth;
+                              root.scrollTo({ left: slotWidth * index, behavior: "smooth" });
+                            }}
+                          />
+                        );
+                      })}
+                    </div>
+                  </>
+                ) : (
+                <div className="grid grid-cols-2 gap-3 xl:grid-cols-3 2xl:grid-cols-4">
+                  {group.items.map((item) => {
+                    const rentalStrip = buildCatalogRentalStrip(item, crew);
+                    return (
+                    <article
+                      key={item.id}
+                      data-catalog-item="true"
+                      className="group overflow-hidden rounded-2xl border transition-shadow hover:shadow-[0_0_0_1px_var(--catalog-accent),0_0_28px_color-mix(in_srgb,var(--catalog-accent)_35%,transparent)]"
+                      style={catalogCardVariantStyles(crew.theme, item.id.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0))}
+                    >
+                      <button
+                        type="button"
+                        aria-label={`Открыть карточку ${item.title}: ${item.rentPriceLabel}`}
+                        data-catalog-item-button="true"
+                        className="block w-full text-left"
+                        onClick={() => openItem(item)}
+                        onFocus={() => setFocusedItemId(item.id)}
+                        onBlur={() => setFocusedItemId((prev) => (prev === item.id ? null : prev))}
+                        style={focusedItemId === item.id ? interactionRingStyle(crew.theme) : undefined}
+                      >
+                        <div className="relative aspect-[9/16] w-full">
                           {item.imageUrl ? (
                             <Image src={item.imageUrl} alt={item.title} fill sizes="(max-width: 1279px) 50vw, (max-width: 1535px) 33vw, 25vw" className="object-cover" />
                           ) : (
@@ -567,14 +715,15 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                               “{item.reviewSummary.latest.text}”
                             </p>
                           )}
-                          <p className="mt-2 text-base font-bold text-[var(--catalog-accent)]">
-                            {item.rentPriceLabel}
-                          </p>
-                          {item.saleAvailable && item.salePrice ? (
+                          {hasRentPrice(item) ? (
+                            <p className="mt-2 text-base font-bold text-[var(--catalog-accent)]">{item.rentPriceLabel}</p>
+                          ) : null}
+                          {hasSalePrice(item) ? (
                             <p className="mt-1 text-xs font-semibold text-amber-200">
-                              Цена покупки: {item.salePrice.toLocaleString("ru-RU")} ₽
+                              Цена покупки: {item.salePrice?.toLocaleString("ru-RU")} ₽
                             </p>
                           ) : null}
+                          {!hasRentPrice(item) && !hasSalePrice(item) ? <p className="mt-2 text-xs font-medium text-white/80">Цена по запросу</p> : null}
                           <div className="mt-2 flex gap-2">
                             <span className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--catalog-accent)] px-2 py-2.5 text-xs font-bold text-[var(--catalog-accent-contrast)] transition-transform active:scale-95">
                               <ShoppingCart className="h-4 w-4" />
@@ -587,6 +736,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                     );
                   })}
                 </div>
+                )}
               </section>
             ))}
           </div>

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -76,6 +76,8 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
   const [quickFilter, setQuickFilter] = useState<QuickFilterKey>("all");
   const [campaignIndex, setCampaignIndex] = useState(0);
   const [carouselActiveByCategory, setCarouselActiveByCategory] = useState<Record<string, number>>({});
+  const [carouselParallaxByItem, setCarouselParallaxByItem] = useState<Record<string, { x: number; y: number }>>({});
+  const [carouselLoadedByItem, setCarouselLoadedByItem] = useState<Record<string, true>>({});
   const searchParams = useSearchParams();
   const { user, dbUser } = useAppContext();
   const lastQueryViewedVehicleRef = useRef<string>("");
@@ -561,6 +563,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                     >
                       {group.items.map((item, index) => {
                         const rentalStrip = buildCatalogRentalStrip(item, crew);
+                        const parallax = carouselParallaxByItem[item.id] ?? { x: 0, y: 0 };
                         return (
                     <article
                       key={item.id}
@@ -579,10 +582,32 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                         onFocus={() => setFocusedItemId(item.id)}
                         onBlur={() => setFocusedItemId((prev) => (prev === item.id ? null : prev))}
                         style={focusedItemId === item.id ? interactionRingStyle(crew.theme) : undefined}
+                        onPointerMove={(event) => {
+                          const rect = event.currentTarget.getBoundingClientRect();
+                          const dx = ((event.clientX - rect.left) / rect.width - 0.5) * 2;
+                          const dy = ((event.clientY - rect.top) / rect.height - 0.5) * 2;
+                          setCarouselParallaxByItem((prev) => ({ ...prev, [item.id]: { x: dx, y: dy } }));
+                        }}
+                        onPointerLeave={() => {
+                          setCarouselParallaxByItem((prev) => ({ ...prev, [item.id]: { x: 0, y: 0 } }));
+                        }}
                       >
                         <div className="relative aspect-[9/16] w-full">
+                          {item.imageUrl && !carouselLoadedByItem[item.id] && (
+                            <div className="absolute inset-0 overflow-hidden bg-black/30">
+                              <div className="absolute inset-y-0 w-1/2 animate-shimmer bg-gradient-to-r from-transparent via-white/15 to-transparent" />
+                            </div>
+                          )}
                           {item.imageUrl ? (
-                            <Image src={item.imageUrl} alt={item.title} fill sizes="(max-width: 1279px) 78vw, 320px" className="object-cover" />
+                            <Image
+                              src={item.imageUrl}
+                              alt={item.title}
+                              fill
+                              sizes="(max-width: 1279px) 78vw, 320px"
+                              className="object-cover transition-transform duration-300 ease-out"
+                              style={{ transform: `scale(1.06) translate3d(${parallax.x * 8}px, ${parallax.y * 8}px, 0)` }}
+                              onLoad={() => setCarouselLoadedByItem((prev) => ({ ...prev, [item.id]: true }))}
+                            />
                           ) : (
                             <div className="flex h-full w-full items-center justify-center px-3 text-center text-xs" style={surface.mutedText}>Фото байка загружается — карточка уже доступна для брони</div>
                           )}

--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -315,7 +315,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
 
   useEffect(() => {
     const observers: IntersectionObserver[] = [];
-    const rafIds: number[] = [];
+    const rafByCategory: Record<string, number | undefined> = {};
     const cleanupByCategory: Array<() => void> = [];
 
     itemsByCategory.forEach((group) => {
@@ -341,12 +341,15 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
       observers.push(observer);
 
       const onScroll = () => {
-        const rafId = window.requestAnimationFrame(() => {
+        if (rafByCategory[group.category]) {
+          window.cancelAnimationFrame(rafByCategory[group.category] as number);
+        }
+        rafByCategory[group.category] = window.requestAnimationFrame(() => {
           const slotWidth = cards[0]?.offsetWidth || 1;
           const nextIndex = Math.round(root.scrollLeft / slotWidth);
           setCarouselActiveByCategory((prev) => (prev[group.category] === nextIndex ? prev : { ...prev, [group.category]: nextIndex }));
+          rafByCategory[group.category] = undefined;
         });
-        rafIds.push(rafId);
       };
 
       root.addEventListener("scroll", onScroll, { passive: true });
@@ -355,7 +358,9 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
 
     return () => {
       observers.forEach((observer) => observer.disconnect());
-      rafIds.forEach((id) => window.cancelAnimationFrame(id));
+      Object.values(rafByCategory).forEach((id) => {
+        if (id) window.cancelAnimationFrame(id);
+      });
       cleanupByCategory.forEach((cleanup) => cleanup());
     };
   }, [itemsByCategory]);

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -3,12 +3,13 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Menu } from "lucide-react";
+import { Menu, ShoppingCart } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import type { FranchizeCrewVM } from "../actions";
 import { HeaderMenu } from "../modals/HeaderMenu";
 import { FranchizeProfileButton } from "./FranchizeProfileButton";
+import { useFranchizeCart } from "../hooks/useFranchizeCart";
 import { toCategoryId } from "../lib/navigation";
 import { FRANCHIZE_HEADER_CORNER_GUARD_STYLE, FRANCHIZE_HEADER_SAFE_AREA_STYLE } from "../lib/route-cta-policy";
 import type { FranchizeSectionLink } from "../lib/section-links";
@@ -38,7 +39,9 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
   const headerLogoHref = crew.header.logoHref || mainCatalogPath;
   const railRef = useRef<HTMLDivElement | null>(null);
   const prevPathnameRef = useRef<string | null>(null);
+  const [indicatorStyle, setIndicatorStyle] = useState<{ width: number; left: number; opacity: number }>({ width: 0, left: 0, opacity: 0 });
   const activePillText = readablePaletteTextOnColor(crew.theme.palette.accentMain, crew.theme.palette);
+  const { itemCount } = useFranchizeCart(crew.slug);
 
   // ── Logo loading state machine ──
   //   loading → (onLoad) → dissolving → (animationEnd) → revealed
@@ -190,10 +193,26 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
     }
   }, [activePath, pathname, visibleRailLinks]);
   // ------------------------------------------------------------------
+  useEffect(() => {
+    const container = railRef.current;
+    if (!container) return;
+    const activeRailLink = visibleRailLinks.find(
+      (link) => link.active || (!link.href.startsWith("#") && (pathname === link.href || activePath === link.href)),
+    );
+    if (!activeRailLink) {
+      setIndicatorStyle((prev) => ({ ...prev, opacity: 0 }));
+      return;
+    }
+    const activeEl = Array.from(container.querySelectorAll<HTMLElement>("[data-category-pill]")).find(
+      (element) => element.dataset.categoryPill === activeRailLink.categoryLabel,
+    );
+    if (!activeEl) return;
+    setIndicatorStyle({ width: activeEl.offsetWidth, left: activeEl.offsetLeft, opacity: 1 });
+  }, [activePath, pathname, visibleRailLinks]);
 
   return (
     <header
-      className="sticky top-0 z-50 border-b pb-2 backdrop-blur-2xl"
+      className="sticky top-0 z-50 border-b pb-2 pt-[max(env(safe-area-inset-top),0.15rem)] backdrop-blur-2xl"
       style={{
         ...FRANCHIZE_HEADER_SAFE_AREA_STYLE,
         borderColor: crew.theme.palette.borderSoft,
@@ -212,7 +231,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
           style={{
             ...FRANCHIZE_HEADER_CORNER_GUARD_STYLE,
             display: "grid",
-            gridTemplateColumns: "44px 1fr auto",
+            gridTemplateColumns: "44px 1fr auto auto",
             alignItems: "center",
             gap: "0.75rem",
             maxHeight: isCompact ? 0 : 112,
@@ -308,6 +327,19 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
             borderColor={crew.theme.palette.borderSoft}
             currentSlug={crew.slug}
           />
+          <Link
+            href={`/franchize/${crew.slug}/cart`}
+            aria-label={`Корзина, позиций: ${itemCount}`}
+            className="relative inline-flex h-11 w-11 items-center justify-center rounded-xl border transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--crew-header-accent)]"
+            style={{ borderColor: crew.theme.palette.borderSoft, backgroundColor: withAlpha(crew.theme.palette.bgBase, 0.8), color: crew.theme.palette.textPrimary }}
+          >
+            <ShoppingCart className="h-4 w-4" />
+            {itemCount > 0 && (
+              <span className="absolute -right-1 -top-1 inline-flex min-w-5 items-center justify-center rounded-full bg-[var(--crew-header-accent)] px-1.5 text-[10px] font-bold text-[var(--crew-header-accent-text)]">
+                {itemCount > 99 ? "99+" : itemCount}
+              </span>
+            )}
+          </Link>
         </div>
       </div>
 
@@ -318,6 +350,11 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
             ref={railRef}
             className="relative mx-auto flex w-full max-w-7xl gap-2 overflow-x-auto no-scrollbar pb-1 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden snap-x snap-mandatory"
           >
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute bottom-1 h-0.5 rounded-full bg-[var(--crew-header-accent)] transition-all duration-300 ease-out"
+              style={{ width: `${indicatorStyle.width}px`, transform: `translateX(${indicatorStyle.left}px)`, opacity: indicatorStyle.opacity }}
+            />
             {visibleRailLinks.map((link) => {
               const isActive = link.active || (!link.href.startsWith("#") && (pathname === link.href || activePath === link.href));
               return (


### PR DESCRIPTION
### Motivation
- Improve mobile/compact UX for categories with few items by providing a horizontal carousel and visible pagination controls.  
- Make pricing presentation robust by distinguishing rent vs purchase availability and showing "Цена по запросу" when neither is present.  
- Surface cart state in the header with a badge to give users quick access and feedback about items in cart.  
- Add operational runtime notes and PR checklist for SupaPlan workflows via a new `BISS_QUEST.HTML` guard document.

### Description
- Added `BISS_QUEST.HTML` with runtime guardrails, a notification bugfix memo, and a mandatory PR checklist for SupaPlan quests.  
- In `CatalogClient.tsx` introduced helper predicates `hasRentPrice` and `hasSalePrice`, switched card aspect ratios to `9/16`, and added conditional rendering for rent/purchase/price-on-request labels.  
- Implemented a small-group carousel (for groups with <= 8 items) using `carouselRefs`, `carouselActiveByCategory` state, an `IntersectionObserver` + scroll handler, keyboard navigation, and pagination dots that scroll to cards smoothly.  
- Applied visual polish: hover shadow transitions on cards, consistent image sizing, and safety checks for optional `salePrice` access.  
- In `CrewHeader.tsx` added a cart link with `ShoppingCart` icon and item count badge via `useFranchizeCart`, introduced an animated indicator bar under the category rail (`indicatorStyle`), and adjusted header layout and safe-area padding.

### Testing
- Ran TypeScript typecheck via `yarn tsc` and it completed without errors.  
- Executed project build with `yarn build` (Next.js) and the build succeeded.  
- Ran unit tests with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c0252a9883259447a7cf84ec8693)
supaplan_task: be32ce57-a1f5-4401-a307-311ec56ba68f