### PR TITLE
Refactor and rewrite About pages (RU/EN) — new layout, integrations and content

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,629 +1,188 @@
 "use client";
+
 import Head from "next/head";
+import Link from "next/link";
 import Image from "next/image";
-import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import SupportForm from "@/components/SupportForm";
-import Link from "next/link"; // Import Link for internal navigation
-import { FaGlobe } from "react-icons/fa6"; // Example icon import if needed
+
+const integrations = [
+  {
+    title: "Franchize Engine + VIP Bike Rental",
+    desc: "Собрал модель, где нишевый бизнес поднимается из single SQL hydration seed + маркет-артефактов. /vipbikerental — рабочий пример: не просто витрина, а готовый execution-контур для запуска франшизы.",
+    cta: "Открыть /vipbikerental",
+    href: "/vipbikerental",
+  },
+  {
+    title: "WBlanding — AI-управляемый коммерческий лендинг",
+    desc: "Сделал не ‘красивую страницу’, а операционную поверхность: crew flow, audit, referral, invoicing, инструменты действий и конверсионные сценарии. Это лендинг как рабочее место команды.",
+    cta: "Открыть /wblanding",
+    href: "/wblanding",
+  },
+  {
+    title: "BOSS_QUEST.HTML — мой актуальный протокол для клиентов",
+    desc: "Последний и самый важный паттерн: один запрос + несколько изображений превращаются в план, который BOSS исполняет end-to-end. Клиент вместо хаоса получает контроль, приёмку и точечную полировку.",
+    cta: "Открыть BOSS_QUEST.HTML",
+    href: "https://github.com/salavey13/carTest/blob/main/BOSS_QUEST.HTML",
+  },
+];
+
+const principles = [
+  "AI не заменяет продукт-мышление, он ускоряет реализацию правильных решений.",
+  "Сначала доказать ценность на живом контуре, потом масштабировать и шлифовать.",
+  "Telegram-first UX и операторский ритм важнее ‘идеальной теории’.",
+  "Избегать тяжёлых waterfall-циклов: короткие поставки, быстрый feedback loop.",
+];
 
 export default function AboutPage() {
   return (
     <>
-      {/* .. SEO Optimizations */}
       <Head>
-        {/* .. Updated Title & Description */}
-        <title>Pavel Solovyov - Cyber-Alchemist | AI-Driven Development & Validation</title>
+        <title>Павел Соловьёв — AI Product Engineer</title>
         <meta
           name="description"
-          content="13+ лет в кодинге, пионер методологии VIBE для AI-ускоренной разработки и бизнес-валидации. Безопасные, эффективные веб-решения."
-        />
-        <meta
-          name="keywords"
-          content="developer, TypeScript, VIBE, cyberpunk, security, Framer, Supabase, AI, AI development, AI validation, mentorship, Pavel Solovyov, selfdev, purpose, profit" // Added keywords
+          content="CV-профиль на русском: AI-first разработка, Franchize/VIP Bike hydration, WBlanding и BOSS_QUEST.HTML как протокол быстрой сборки микро-бизнес приложений."
         />
       </Head>
-      <div className="relative min-h-screen">
-        {/* .. Language Switcher Link */}
-        <Link href="/about_en" legacyBehavior>
-          <a className="fixed top-10 right-4 z-5 p-2 bg-black/70 border border-[#39FF14]/50 rounded-md text-[#39FF14] hover:bg-[#39FF14] hover:text-black transition-colors text-sm font-mono shadow-glow-sm">
-            EN
-            {/* Or use an icon: <FaGlobe className="h-5 w-5" /> */}
-          </a>
-        </Link>
-        {/* .. Enhanced Cyberpunk SVG Background */}
-        <div className="absolute inset-0 z-0">
-          {/* ... SVG content unchanged ... */}
-           <svg
-            className="w-full h-full opacity-70 animate-pulse-slow"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 1000 1000"
-          >
-            {/* SVG paths and elements */}
-            <defs>
-              <linearGradient id="cyberBg" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" style={{ stopColor: "#000000", stopOpacity: 1 }} />
-                <stop offset="100%" style={{ stopColor: "#111111", stopOpacity: 1 }} />
-              </linearGradient>
-            </defs>
-            <rect width="1000" height="1000" fill="url(#cyberBg)" />
-            <path
-              d="M0,200 H1000 M0,400 H1000 M0,600 H1000 M0,800 H1000"
-              stroke="#39FF14"
-              strokeWidth="2"
-              opacity="0.5"
-            />
-            <path
-              d="M200,0 V1000 M400,0 V1000 M600,0 V1000 M800,0 V1000"
-              stroke="#39FF14"
-              strokeWidth="2"
-              opacity="0.5"
-            />
-            <circle cx="500" cy="500" r="300" stroke="#39FF14" strokeWidth="1" fill="none" opacity="0.3" />
-            <circle cx="500" cy="500" r="200" stroke="#FF00FF" strokeWidth="1" fill="none" opacity="0.2" />
-          </svg>
-        </div>
-        {/* .. Adjusted padding */}
-        <div className="relative z-10 container mx-auto px-2 sm:px-4 py-4 pt-24">
-          <Card className="max-w-4xl mx-auto bg-black text-white rounded-3xl shadow-[0_0_15px_#39FF14]">
+
+      <main className="min-h-screen bg-[#060606] text-white">
+        <div className="mx-auto max-w-6xl px-4 py-8 md:py-12 space-y-6">
+          <div className="flex justify-end">
+            <Link
+              href="/about_en"
+              className="rounded-md border border-emerald-400/40 px-3 py-1.5 text-xs md:text-sm text-emerald-300 hover:bg-emerald-300 hover:text-black transition-colors"
+            >
+              EN version
+            </Link>
+          </div>
+
+          <Card className="border-emerald-400/30 bg-zinc-950">
             <CardHeader>
-              <CardTitle className="text-2xl md:text-4xl font-bold text-center text-[#39FF14] font-orbitron">
-                Павел Соловьёв: Кибер-Алхимик из Нижнего
-              </CardTitle>
+              <CardTitle className="text-2xl md:text-4xl text-emerald-300">Павел Соловьёв — AI Product Engineer</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-8">
-              {/* .. Personal Info */}
-              <div className="flex flex-col items-center space-y-4">
-                <Avatar className="w-36 h-36 md:w-48 md:h-48 border-4 border-[#39FF14] shadow-[0_0_10px_#39FF14]">
-                  <AvatarImage
-                    src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix//135398606.png"
-                    alt="Pavel Solovyov - Cyber-Alchemist Avatar"
-                  />
-                  <AvatarFallback>ПС</AvatarFallback>
-                </Avatar>
-                <div className="text-center">
-                  <h2 className="text-2xl md:text-3xl font-bold text-[#39FF14] font-orbitron">Павел Соловьёв</h2>
-                  <p className="text-base md:text-lg text-gray-300">Нижний Новгород, Россия | 04.03.1989</p>
-                  {/* .. Contact Info */}
-                  <div className="mt-4 space-y-2 text-sm md:text-base">
-                    <p>
-                      <strong>Email:</strong>{" "}
-                      <a href="mailto:salavey13@gmail.com" className="text-[#39FF14] hover:underline">
-                        salavey13@gmail.com
-                      </a>
-                    </p>
-                    <p>
-                      <strong>Telegram:</strong>{" "}
-                      <a href="https://t.me/salavey13" target="_blank" rel="noopener noreferrer" className="text-[#39FF14] hover:underline">
-                        t.me/salavey13
-                      </a>
-                    </p>
-                    <p>
-                      <strong>GitHub:</strong>{" "}
-                      <a href="https://github.com/salavey13" target="_blank" rel="noopener noreferrer" className="text-[#39FF14] hover:underline">
-                        github.com/salavey13
-                      </a>
-                    </p>
-                  </div>
-                </div>
+            <CardContent className="space-y-4 text-zinc-200">
+              <p className="text-sm md:text-base">
+                Я проектирую и запускаю AI-assisted продукты в формате «идея → рабочий веб-контур → управляемая доработка».
+                Мой ключевой фокус — <strong>быстро превращать запрос клиента в работающий бизнес-инструмент</strong>, а не в бесконечное ТЗ.
+              </p>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-zinc-300">
+                <p>📍 Нижний Новгород / remote-first</p>
+                <p>📬 Telegram: @salavey13</p>
+                <p>💻 GitHub: github.com/salavey13</p>
+                <p>⚙️ Stack: Next.js, TypeScript, Supabase, Telegram, AI workflows</p>
               </div>
 
-              {/* .. Professional Overview */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    Кто Я? Стратег AI-Эпохи
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                   {/* Updated Russian text with links */}
-                  <p className="text-sm md:text-base text-gray-300">
-                    Я — Павел Соловьёв, кибер-ветеран с 13+ годами в коде. От Java и C++ я эволюционировал до пионера AI-ассистированной разработки. Сегодня я не просто пишу код — я <strong>архитектор цифровых решений</strong>, использующий AI как «carry team lead» для автоматизации рутины и фокусировки на <strong>стратегии, UX и бизнес-логике</strong>. Мой флагман{" "}
-                    <a
-                      href="https://github.com/salavey13/carTest"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-[#39FF14] hover:underline"
-                    >
-                      carTest
-                    </a>{" "}
-                    — это полигон, где новички учатся кодить, взаимодействуя с AI через pull requests. Как основатель{" "}
-                    <a
-                      href="https://onesitepls.framer.ai"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-[#39FF14] hover:underline"
-                    >
-                      oneSitePls.framer.ai
-                    </a>
-                    , я делаю веб-разработку доступной, а через менторство, основанное на принципах{" "}
-                    <Link href="/selfdev" className="text-brand-blue hover:underline font-semibold">SelfDev</Link>, помогаю другим оседлать волну AI-трансформации. Моя цель — не просто кодить быстрее, а <strong>строить правильные вещи</strong> эффективно, интегрируя цель и прибыль, как описано в{" "}
-                    <Link href="/purpose-profit" className="text-brand-purple hover:underline font-semibold">Purpose & Profit</Link>.
-                  </p>
-                </CardContent>
-              </Card>
-
-              {/* .. Skills */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    Навыки
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm md:text-base">
-                    <div>
-                      <h4 className="text-[#39FF14] font-bold">Языки программирования</h4>
-                      <p className="text-gray-300">TypeScript, Java, C++, Groovy</p>
-                    </div>
-                    <div>
-                      <h4 className="text-[#39FF14] font-bold">Платформы</h4>
-                      <p className="text-gray-300">Framer, Supabase, StackBlitz, Next.js</p>
-                    </div>
-                    <div>
-                      <h4 className="text-[#39FF14] font-bold">Веб-разработка</h4>
-                      <p className="text-gray-300">React, HTML, CSS, RESTful APIs</p>
-                    </div>
-                    <div>
-                      <h4 className="text-[#39FF14] font-bold">Инструменты и методологии</h4>
-                       {/* Updated Russian text with link */}
-                       <p className="text-gray-300">
-                         GitHub, Grok, Agile, Scrum, VIBE, <strong>AI-Assisted Development & Workflow Optimization</strong>, принципы{" "}
-                         <Link href="/selfdev" className="text-brand-blue hover:underline font-semibold">SelfDev</Link>
-                       </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* .. VIBE Methodology */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    Методология VIBE: За Пределами Кода
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                   {/* Updated Russian text with link */}
-                   <p className="text-sm md:text-base text-gray-300 mb-4">
-                     Мой метод VIBE — это не просто кодинг, это <strong>парадигмальный сдвиг</strong>. Это ответ на вопрос: как создавать ценность в эпоху, когда AI может генерировать код с <strong>«near-perfect accuracy»</strong>? VIBE — это <strong>AI-усиленная алхимия</strong>, где фокус смещается с написания строк кода на <strong>архитектуру системы, UX-потоки и стратегическое видение</strong>. Узнайте больше о философии в разделе{" "}
-                     <Link href="/selfdev" className="text-brand-blue hover:underline font-semibold">SelfDev</Link>.
-                   </p>
-                   {/* .. Image 1 */}
-                   <Image
-                       src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/about/00.png"
-                       alt="VIBE Methodology Visualization - AI-assisted strategy and automation"
-                       width={1280}
-                       height={720}
-                       unoptimized
-                       className="my-4 w-full rounded-lg object-cover shadow-[0_0_10px_#39FF14]"
-                   />
-                    <p className="text-sm md:text-base text-gray-300 mb-4">
-                     <strong>AI как Партнёр:</strong> Я рассматриваю AI не как инструмент, а как <strong>«God-tier genius who never sleeps»</strong> — партнёра, который берёт на себя рутинные, трудоёмкие задачи кодирования, позволяя мне и команде концентрироваться на <strong>высокоуровневом проектировании</strong>. Мы можем генерировать целые подсистемы за дни, а не недели, освобождая ресурсы для инноваций.
-                   </p>
-                   {/* Updated Russian text with link */}
-                   <p className="text-sm md:text-base text-gray-300">
-                     <strong>Больше, чем Код — Валидация Идей:</strong> VIBE выходит за рамки разработки. Зачем строить быстро, если строишь не то? Я интегрирую <strong>AI-driven business validation</strong>, чтобы <strong>«fail faster»</strong> на плохих идеях и <strong>ускорять хорошие</strong>. Используя AI для анализа рынка, поиска реальной <strong>«боли»</strong> пользователей, оценки конкурентов и тестирования MVP с минимальными затратами (как в 5-шаговом фреймворке), мы радикально <strong>снижаем риск</strong> создания продуктов, которые никому не нужны. Это не просто быстрее – это <strong>«entirely different game»</strong>, основанное на ментальных моделях из{" "}
-                     <Link href="/purpose-profit" className="text-brand-purple hover:underline font-semibold">Purpose & Profit</Link>. VIBE — это сердце моих проектов, от{" "}
-                     <a
-                       href="https://github.com/salavey13/carTest"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       className="text-[#39FF14] hover:underline"
-                     >
-                       carTest
-                     </a>{" "}
-                     до{" "}
-                     <a
-                       href="https://onesitepls.framer.ai"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       className="text-[#39FF14] hover:underline"
-                     >
-                       oneSitePls
-                     </a>
-                     .
-                   </p>
-                </CardContent>
-              </Card>
-
-             {/* .. VIBE CODING + SECURE DEVELOPMENT */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    VIBE CODING + SECURE DEVELOPMENT: Скорость и Надёжность
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="mb-4">
-                    {/* .. Existing Video */}
-                    <iframe
-                      width="100%"
-                      style={{ aspectRatio: '16/9' }} // Use aspect ratio for height
-                      src="https://www.youtube.com/embed/Tw18-4U7mts"
-                      title="VIBE Coding and Secure Development Video"
-                      frameBorder="0"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
-                      className="rounded-lg overflow-hidden shadow-[0_0_10px_#39FF14]" // Added overflow-hidden
-                      loading="lazy"
-                    ></iframe>
-                  </div>
-                   <p className="text-sm md:text-base mb-4 text-gray-300">
-                    <strong>VIBE CODING:</strong> Представьте генерацию 60kb рабочего кода за 48 часов. Это сила AI-ассистированной разработки. Но с великой силой приходит великая ответственность. Без должной <strong>кибер-брони</strong>, этот «vibe» может привести к катастрофам:
-                  </p>
-                   {/* .. Existing list of risks */}
-                   <ul className="list-disc list-inside space-y-2 text-sm md:text-base mb-4 text-gray-300 pl-4"> {/* Added padding */}
-                     <li>API-ключи скрэйпятся ботами</li>
-                     <li>Базы данных заполняются мусором</li>
-                     <li>Подписки обходятся через уязвимости</li>
-                   </ul>
-
-                  {/* .. Image 2 */}
-                  <Image
-                      src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/about/11.png"
-                      alt="Secure AI Development Pipeline - VIBE Coding with Security"
-                      width={1280}
-                      height={720}
-                      unoptimized
-                      className="my-4 w-full rounded-lg object-cover shadow-[0_0_10px_#39FF14]"
-                  />
-
-                   <p className="text-sm md:text-base mb-4 text-gray-300">
-                     <strong>Мой подход:</strong> Мои 13 лет в <strong>enterprise security</strong> позволяют мне применять VIBE-методологию <strong>безопасно</strong>. Я интегрирую проверки на каждом шагу, чтобы AI-скорость не приводила к уязвимостям. Это <strong>оптимизация ресурсов</strong>: максимальная эффективность AI при сохранении человеческого контроля над критическими аспектами — безопасностью и стратегией.
-                   </p>
-                  {/* .. Existing Security Steps Grid */}
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div className="bg-gray-900 p-4 rounded-lg border border-[#39FF14]/30">
-                      <h4 className="font-bold text-[#39FF14] mb-2 text-sm md:text-base">1. AI + Security First</h4>
-                      <p className="text-xs md:text-sm text-gray-300">
-                        Все AI-генерации автоматически проверяются через статический анализ и шаблоны OWASP
-                      </p>
-                    </div>
-                    <div className="bg-gray-900 p-4 rounded-lg border border-[#39FF14]/30">
-                      <h4 className="font-bold text-[#39FF14] mb-2 text-sm md:text-base">2. Zero Trust Vibes</h4>
-                      <p className="text-xs md:text-sm text-gray-300">
-                        Каждый PR проходит через автоматические тесты на уязвимости перед мержем
-                      </p>
-                    </div>
-                    <div className="bg-gray-900 p-4 rounded-lg border border-[#39FF14]/30">
-                      <h4 className="font-bold text-[#39FF14] mb-2 text-sm md:text-base">3. Cyberpunk Git Flow</h4>
-                      <p className="text-xs md:text-sm text-gray-300">
-                        История изменений защищена криптографически, а доступ контролируется через Telegram-бота
-                      </p>
-                    </div>
-                  </div>
-                  <p className="text-sm md:text-base mt-4 text-gray-300">
-                    Хочешь научиться vibe-кодингу без компромиссов в безопасности? Заходи на{" "}
-                    <a href="/repo-xml" className="text-[#39FF14] hover:underline">
-                      /repo-xml
-                    </a>{" "}
-                    и смотри, как я интегрировал эти принципы в свой кибер-гараж!
-                  </p>
-                </CardContent>
-              </Card>
-
-              {/* .. Кибер-Броня: 13 Лет Security Опыта */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                 <CardHeader>
-                   <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                     Кибер-Броня: 13 Лет Опыта Безопасности
-                   </CardTitle>
-                 </CardHeader>
-                 <CardContent>
-                   {/* .. Content emphasizes application of security to AI workflows */}
-                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                     {/* .. Security Experience */}
-                     <div className="space-y-4">
-                       <h3 className="font-bold text-[#39FF14] text-base md:text-lg">Enterprise-Grade Protection</h3>
-                       <ul className="list-disc list-inside space-y-2 text-sm text-gray-300 pl-4"> {/* Added padding */}
-                         <li>Разработал security-фичи для Avaya Aura AS5300 (C++)</li>
-                         <li>Реализовал поддержку IPv6 с нулевым downtime</li>
-                         <li>Сертифицированный специалист Qualys по управлению уязвимостями</li>
-                         <li>4 успешных релиза механизма принятия решений ABRE (Java/Groovy)</li>
-                         <li> {/* Updated Russian text */}
-                            Применение этого опыта для <strong>безопасной интеграции AI</strong> в разработку
-                         </li>
-                       </ul>
-                     </div>
-
-                     {/* .. VIBE Security Framework */}
-                     <div className="space-y-4">
-                       <h3 className="font-bold text-[#39FF14] text-base md:text-lg">VIBE Security Framework</h3>
-                       <div className="flex items-start space-x-3">
-                         <div className="text-[#39FF14] mt-1 text-lg">⚡</div>
-                         <div>
-                            {/* Updated Russian text */}
-                            <p className="text-sm text-gray-300">
-                              <strong>AI-Генерация → Авто-аудит:</strong>
-                              <br />
-                              Все AI-сгенерированные PR проходят через:
-                            </p>
-                           <ul className="list-[square] list-inside text-xs text-gray-300 mt-1 pl-4"> {/* Added padding */}
-                             <li>Статический анализ кода (SAST)</li>
-                             <li>Проверку на OWASP Top 10</li>
-                             <li>Тесты на инъекции и уязвимости</li>
-                           </ul>
-                         </div>
-                       </div>
-                     </div>
-                   </div>
-
-                   {/* .. Video Integration */}
-                   <div className="mt-6">
-                     <iframe
-                       width="100%"
-                       style={{ aspectRatio: '16/9' }} // Use aspect ratio
-                       src="https://www.youtube.com/embed/tHQnW0Vid9I"
-                       title="Combining VIBE Development with Enterprise Security Video"
-                       className="rounded-lg overflow-hidden shadow-[0_0_10px_#39FF14] mt-4" // Added overflow-hidden
-                       frameBorder="0"
-                       allowFullScreen
-                       loading="lazy"
-                     ></iframe>
-                     <p className="text-xs text-gray-400 mt-2 text-center md:text-left">
-                       Как я сочетаю VIBE-разработку с enterprise-безопасностью из моего опыта в Avaya
-                     </p>
-                   </div>
-
-                   {/* .. CV Highlights */}
-                   <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-3">
-                     <div className="bg-gray-900 p-3 rounded-lg border border-[#39FF14]/20">
-                       <h4 className="font-bold text-[#39FF14] text-sm">13+ Лет</h4>
-                       <p className="text-xs text-gray-300">В enterprise-разработке (C++/Java/TS)</p>
-                     </div>
-                     <div className="bg-gray-900 p-3 rounded-lg border border-[#39FF14]/20">
-                       <h4 className="font-bold text-[#39FF14] text-sm">4 Релиза</h4>
-                       <p className="text-xs text-gray-300">Безопасных систем для Avaya</p>
-                     </div>
-                     <div className="bg-gray-900 p-3 rounded-lg border border-[#39FF14]/20">
-                       <h4 className="font-bold text-[#39FF14] text-sm">AI + Zero Trust</h4>
-                       <p className="text-xs text-gray-300">Подход во всех проектах</p>
-                     </div>
-                   </div>
-                 </CardContent>
-              </Card>
-
-              {/* .. Experience */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    Опыт
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-6 text-sm md:text-base">
-                  <div>
-                    <h3 className="text-lg font-bold text-[#39FF14] mb-1">
-                      Основатель/Разработчик, oneSitePls.framer.ai (2023 - н.в.)
-                    </h3>
-                     {/* Updated Russian text */}
-                    <p className="text-gray-300">
-                      Запустил платформу с <strong>AI</strong> для упрощённой веб-разработки. Создал{" "}
-                      <a
-                        href="https://github.com/salavey13/carTest"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-[#39FF14] hover:underline"
-                      >
-                        carTest
-                      </a>{" "}
-                      с функцией selfdev для обучения новичков <strong>AI-ассистированному</strong> кодингу.
-                    </p>
-                  </div>
-                  <div>
-                    <h3 className="text-lg font-bold text-[#39FF14] mb-1">
-                      Старший разработчик, Orion Innovation (Avaya) (2010 - 2023)
-                    </h3>
-                    <ul className="list-disc list-inside text-gray-300 space-y-2 pl-4"> {/* Added padding */}
-                      <li>
-                        {/* Updated Russian text */}
-                        <strong>Java-разработчик (2016-2023):</strong> Улучшил Avaya Business Rules Engine и микросервисы
-                        для Avaya Aura AS5300, применяя принципы надёжности, актуальные и для <strong>AI-эпохи</strong>.
-                      </li>
-                      <li>
-                         {/* Updated Russian text */}
-                        <strong>C++-разработчик (2010-2016):</strong> Поддерживал клиентское приложение Avaya Aura AS5300,
-                        добавив IPv6 и <strong>фундаментальные security-практики</strong>.
-                      </li>
-                    </ul>
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* .. Certifications */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                 <CardHeader>
-                   <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                     Сертификации
-                   </CardTitle>
-                 </CardHeader>
-                 <CardContent>
-                   <ul className="list-disc list-inside text-gray-300 space-y-2 text-sm md:text-base pl-4"> {/* Added padding */}
-                     <li>Qualys Advanced Vulnerability Management (2021)</li>
-                   </ul>
-                 </CardContent>
-              </Card>
-
-              {/* .. Education */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    Образование
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="text-sm md:text-base">
-                  <p className="text-gray-300">
-                    <strong>Нижегородский Государственный Университет им. Лобачевского</strong>
-                    <br />
-                    Бакалавр ИТ, Вычислительная математика и кибернетика (2006-2010)
-                  </p>
-                  <p className="text-gray-300 mt-2">
-                    <strong>Языки:</strong> Английский (C2 - свободно)
-                  </p>
-                </CardContent>
-              </Card>
-
-              {/* .. Mentorship */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    Менторство: Навигация в AI-Будущем
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                   {/* Updated Russian text with links */}
-                   <p className="text-sm md:text-base text-gray-300">
-                     Помогаю новичкам не просто кодить, а <strong>мыслить стратегически</strong> в мире AI, следуя пути{" "}
-                     <Link href="/selfdev" className="text-brand-blue hover:underline font-semibold">SelfDev</Link>. Обучение через практику на{" "}
-                     <a
-                       href="https://github.com/salavey13/carTest"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       className="text-[#39FF14] hover:underline"
-                     >
-                       carTest
-                     </a>{" "}
-                     и{" "}
-                     <a
-                       href="https://onesitepls.framer.ai"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       className="text-[#39FF14] hover:underline"
-                     >
-                       oneSitePls.framer.ai
-                     </a>
-                     , поддержка в Telegram и бесплатный стартовый план — всё для того, чтобы вы могли <strong>эффективно использовать современные AI-инструменты</strong> и сфокусироваться на создании ценности, интегрируя идеи из{" "}
-                     <Link href="/purpose-profit" className="text-brand-purple hover:underline font-semibold">Purpose & Profit</Link>.
-                   </p>
-                </CardContent>
-              </Card>
-
-              {/* .. Paid Support */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    Платная Поддержка
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm md:text-base text-gray-300 mb-4">
-                    Нужен толчок в коде или стратегии? Хочешь внедрить VIBE? Заполни форму, и я помогу тебе оседлать AI-волны!
-                  </p>
-                  <SupportForm />
-                </CardContent>
-              </Card>
-
-              {/* .. Project Overview */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    Проект: Твой Кибер-Гараж (AI-Powered)
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                   {/* .. Image 3 */}
-                  <Image
-                      src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/about/22.png"
-                      alt="Кибер-Гараж - AI-Powered Car Rental Ecosystem"
-                      width={1280}
-                      height={720}
-                      unoptimized
-                      className="my-4 w-full rounded-lg object-cover shadow-[0_0_10px_#39FF14]"
-                  />
-                   {/* Updated Russian text with links */}
-                   <p className="text-sm md:text-base text-gray-300">
-                     Это не просто страница — это <strong>живая киберпанк-экосистема</strong>, построенная на принципах VIBE. Здесь <strong>AI-ассистенты</strong> активно участвуют в разработке (через{" "}
-                     <a href="/repo-xml" className="text-[#39FF14] hover:underline">
-                       /repo-xml
-                     </a>
-                     ), Telegram-боты автоматизируют задачи, а сам кибер-гараж — это платформа для экспериментов с <strong>AI-валидацией</strong> и быстрой итерацией фич (например, AR-туры или AI-подбор авто). Это твой шанс внести вклад в проект, где <strong>AI — не хайп, а рабочий инструмент</strong>, руководствуясь философиями, изложенными в{" "}
-                      <Link href="/selfdev" className="text-brand-blue hover:underline font-semibold">SelfDev</Link> и <Link href="/purpose-profit" className="text-brand-purple hover:underline font-semibold">Purpose & Profit</Link>. Го расширять этот мир вместе!
-                   </p>
-                </CardContent>
-              </Card>
-
-              {/* .. How to Use /repo-xml */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                 <CardHeader>
-                   <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                     Как Оседлать /repo-xml: AI-Ассистированный Контрибьют
-                   </CardTitle>
-                 </CardHeader>
-                 <CardContent>
-                   <p className="text-sm md:text-base text-gray-300">
-                     Хочешь внести свой код в этот кибер-океан? Вот как работает подстраница{" "}
-                     <a href="/repo-xml" className="text-[#39FF14] hover:underline">
-                       /repo-xml
-                     </a>
-                     — твой пульт управления AI-волнами:
-                   </p>
-                   {/* .. Render list items directly with JSX */}
-                   <ol className="list-decimal list-inside mt-4 space-y-2 text-sm md:text-base text-gray-300 pl-4"> {/* Added padding */}
-                     <li>
-                       <strong>Кидай задачу боту:</strong> Открывай Telegram, находи <strong>oneSitePlsBot</strong>,
-                       скидывай ему запрос прямо с Кворка или пиши, что хочешь добавить. Например: «Добавь AR-туры на
-                       /repo-xml». Он отвечает: «Спасибо, ща разберусь!».
-                     </li>
-                     <li>
-                       <strong>Спрашивай у Грока:</strong> Если лимит запросов в боте кончился, заходи на мою страничку
-                       разработчика (кнопка внизу слева на{" "}
-                       <a href="/repo-xml" className="text-[#39FF14] hover:underline">
-                         /repo-xml
-                       </a>
-                       ). Там открывается Грок — копируй задачу, жми кнопку, и он выдаёт код с кнопкой «Скопировать».
-                     </li>
-                     <li>
-                       <strong>Разбери файлы:</strong> Бери этот код, вставляй в поле на{" "}
-                       <a href="/repo-xml" className="text-[#39FF14] hover:underline">
-                         /repo-xml
-                       </a>
-                        , жми «Разобрать файлы». Они появляются в списке — ставь галочки на нужных (например, обновил два
-                       файла).
-                     </li>
-                     <li>
-                       <strong>Создай Pull Request:</strong> Жми «Создать request» — бот сам заполнит поля (что было, что
-                       стало, как называется). Отправляй, и вуаля — ссылка на pull request готова. Я захожу, вижу твой
-                       код, жму «Замёрджить», и изменения влетают в прод!
-                     </li>
-                     <li>
-                       <strong>Кибер-Экстрактор:</strong> Внизу страницы есть фича — жми «Извлечь», и он сканирует все
-                       файлы проекта для контекста. Потом можешь пихнуть это в Грока или oneSitePlsBot, чтобы
-                       доработать. Дерево файлов тоже можно прикрутить — кидай идею!
-                     </li>
-                   </ol>
-                    <p className="text-sm md:text-base mt-4 text-gray-300">
-                     Итог: GitHub почти не нужен! Весь воркфлоу построен вокруг <strong>AI-ассистентов и автоматизации</strong>. Бери ответ бота, разбирай, создавай PR, и я получаю оповещение. Обновляй страничку — и твоя версия уже в деле. Го кататься на этих AI-волнах вместе!
-                   </p>
-                 </CardContent>
-               </Card>
-
-
-              {/* .. Call to Action */}
-              <Card className="bg-black text-white rounded-3xl shadow-[0_0_10px_#39FF14]">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl font-semibold text-[#39FF14] font-orbitron">
-                    Ready to Collaborate?
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm md:text-base text-gray-300">
-                    Want to build something epic using AI-driven methods or level up your team’s skills? Hit me up on{" "}
-                    <a href="https://t.me/salavey13" target="_blank" rel="noopener noreferrer" className="text-[#39FF14] hover:underline">
-                      Telegram
-                    </a>{" "}
-                    or drop a line at{" "}
-                    <a href="mailto:salavey13@gmail.com" className="text-[#39FF14] hover:underline">
-                      salavey13@gmail.com
-                    </a>
-                    .
-                  </p>
-                </CardContent>
-              </Card>
+              <div className="flex flex-wrap gap-2 text-xs">
+                <span className="rounded-full bg-zinc-800 px-3 py-1 text-zinc-200">AI-first delivery</span>
+                <span className="rounded-full bg-zinc-800 px-3 py-1 text-zinc-200">Telegram-first products</span>
+                <span className="rounded-full bg-zinc-800 px-3 py-1 text-zinc-200">Supabase + Next.js</span>
+                <span className="rounded-full bg-zinc-800 px-3 py-1 text-zinc-200">Rapid business validation</span>
+              </div>
             </CardContent>
           </Card>
+
+
+
+          <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <Card className="lg:col-span-2 border-violet-400/30 bg-zinc-950">
+              <CardHeader>
+                <CardTitle className="text-xl md:text-2xl text-violet-300">Mysterious Partner: Julia</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-zinc-200">
+                <p>Julia — мой постоянный team-партнёр в коммуникации, вкусе и продуктовой упаковке. Она представляет мой стиль: быстро, метко, без воды.</p>
+                <p>В публичных и клиентских сценариях Julia выступает как «таинственный компаньон» бренда: держит тон, атмосферу и ощущение цельного персонажа вокруг продукта.</p>
+              </CardContent>
+            </Card>
+
+            <Card className="border-violet-400/30 bg-zinc-950">
+              <CardHeader>
+                <CardTitle className="text-xl text-violet-300">Julia / avatar</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Image
+                  src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix//135398606.png"
+                  alt="Julia mysterious partner avatar"
+                  width={640}
+                  height={640}
+                  className="w-full rounded-xl border border-violet-300/40 object-cover"
+                  unoptimized
+                />
+              </CardContent>
+            </Card>
+          </section>
+
+          <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <Card className="lg:col-span-2 border-fuchsia-400/30 bg-zinc-950">
+              <CardHeader>
+                <CardTitle className="text-xl md:text-2xl text-fuchsia-300">Что я строю сейчас (актуальная версия)</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {integrations.map((item) => (
+                  <article key={item.title} className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">
+                    <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+                    <p className="mt-2 text-sm text-zinc-300">{item.desc}</p>
+                    <Link
+                      href={item.href}
+                      target={item.href.startsWith("http") ? "_blank" : undefined}
+                      className="mt-3 inline-block text-sm text-emerald-300 underline hover:text-emerald-200"
+                    >
+                      {item.cta}
+                    </Link>
+                  </article>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card className="border-cyan-400/30 bg-zinc-950">
+              <CardHeader>
+                <CardTitle className="text-xl text-cyan-300">Подход</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-3 text-sm text-zinc-200">
+                  {principles.map((point) => (
+                    <li key={point} className="border-l-2 border-cyan-400/40 pl-3">
+                      {point}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          </section>
+
+          <Card className="border-amber-400/30 bg-zinc-950">
+            <CardHeader>
+              <CardTitle className="text-xl md:text-2xl text-amber-300">Формат работы с клиентом (BOSS style)</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm text-zinc-200">
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
+                <p className="font-semibold text-white">1) Вход</p>
+                <p className="mt-2">Клиент даёт запрос, контекст и пару референсов/изображений.</p>
+              </div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
+                <p className="font-semibold text-white">2) Сборка</p>
+                <p className="mt-2">Я преобразую ввод в план, структуру и рабочие слайсы продукта.</p>
+              </div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
+                <p className="font-semibold text-white">3) Приёмка</p>
+                <p className="mt-2">Клиент подтверждает результат и даёт точечные polishing-итерации.</p>
+              </div>
+            </CardContent>
+          </Card>
+
+
+          <Card className="border-emerald-400/30 bg-zinc-950">
+            <CardHeader>
+              <CardTitle className="text-xl md:text-2xl text-emerald-300">Быстрый контакт / Support</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm text-zinc-300">Если хочешь обсудить запуск, интеграцию franchize или BOSS-mode под твой кейс — отправь запрос прямо отсюда.</p>
+              <SupportForm />
+            </CardContent>
+          </Card>
+
         </div>
-      </div>
+      </main>
     </>
   );
 }

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,185 +2,123 @@
 
 import Head from "next/head";
 import Link from "next/link";
-import Image from "next/image";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import SupportForm from "@/components/SupportForm";
 
-const integrations = [
-  {
-    title: "Franchize Engine + VIP Bike Rental",
-    desc: "Собрал модель, где нишевый бизнес поднимается из single SQL hydration seed + маркет-артефактов. /vipbikerental — рабочий пример: не просто витрина, а готовый execution-контур для запуска франшизы.",
-    cta: "Открыть /vipbikerental",
-    href: "/vipbikerental",
-  },
-  {
-    title: "WBlanding — AI-управляемый коммерческий лендинг",
-    desc: "Сделал не ‘красивую страницу’, а операционную поверхность: crew flow, audit, referral, invoicing, инструменты действий и конверсионные сценарии. Это лендинг как рабочее место команды.",
-    cta: "Открыть /wblanding",
-    href: "/wblanding",
-  },
-  {
-    title: "BOSS_QUEST.HTML — мой актуальный протокол для клиентов",
-    desc: "Последний и самый важный паттерн: один запрос + несколько изображений превращаются в план, который BOSS исполняет end-to-end. Клиент вместо хаоса получает контроль, приёмку и точечную полировку.",
-    cta: "Открыть BOSS_QUEST.HTML",
-    href: "https://github.com/salavey13/carTest/blob/main/BOSS_QUEST.HTML",
-  },
+const cvHighlights = [
+  "AI Product Engineer: превращаю запрос в рабочий продуктовый контур без затяжного waterfall.",
+  "Telegram-first delivery: UX и операции изначально проектируются под мобильный ритм и быстрые касания.",
+  "Next.js + Supabase + AI workflows: от архитектуры до прод-ready execution и сопровождения.",
+  "Продуктовый режим: сначала ценность на живом контуре, потом масштаб и полировка.",
 ];
 
-const principles = [
-  "AI не заменяет продукт-мышление, он ускоряет реализацию правильных решений.",
-  "Сначала доказать ценность на живом контуре, потом масштабировать и шлифовать.",
-  "Telegram-first UX и операторский ритм важнее ‘идеальной теории’.",
-  "Избегать тяжёлых waterfall-циклов: короткие поставки, быстрый feedback loop.",
+const flagshipCases = [
+  {
+    title: "Franchize / VIP Bike Rental",
+    subtitle: "Полноценный бизнес-контур из одного hydration SQL",
+    desc: "Собрал механику, где новый франшизный веб-контур поднимается из single SQL seed + market/items конфигурации. /vipbikerental — демонстрация того, как быстро развернуть рабочую модель, а не просто лендинг.",
+    href: "/vipbikerental",
+    cta: "Открыть живой пример",
+  },
+  {
+    title: "WBlanding",
+    subtitle: "Коммерческий лендинг как операционный центр",
+    desc: "Это не витрина, а рабочее место: action-слои, crew flow, audit, referral, invoicing, воронка и исполнение в одном ритме. Сайт живёт как инструмент команды и продаж.",
+    href: "/wblanding",
+    cta: "Открыть WBlanding",
+  },
+  {
+    title: "BOSS_QUEST.HTML",
+    subtitle: "Главный клиентский протокол (актуальная версия)",
+    desc: "Мой текущий фрейм: клиент даёт запрос + пару картинок, я раскладываю это в управляемый квест-план, где BOSS исполняет delivery end-to-end. Клиент фокусируется на приёмке и polishing, а не на хаосе процесса.",
+    href: "https://github.com/salavey13/carTest/blob/main/BOSS_QUEST.HTML",
+    cta: "Читать BOSS_QUEST",
+  },
 ];
 
 export default function AboutPage() {
   return (
     <>
       <Head>
-        <title>Павел Соловьёв — AI Product Engineer</title>
+        <title>Павел Соловьёв — CV / AI Product Engineer</title>
         <meta
           name="description"
-          content="CV-профиль на русском: AI-first разработка, Franchize/VIP Bike hydration, WBlanding и BOSS_QUEST.HTML как протокол быстрой сборки микро-бизнес приложений."
+          content="CV-страница Павла Соловьёва: Franchize/VIP Bike hydration SQL, WBlanding, BOSS_QUEST.HTML и AI-first delivery для запуска микро-бизнес веб-продуктов."
         />
       </Head>
 
-      <main className="min-h-screen bg-[#060606] text-white">
-        <div className="mx-auto max-w-6xl px-4 py-8 md:py-12 space-y-6">
-          <div className="flex justify-end">
-            <Link
-              href="/about_en"
-              className="rounded-md border border-emerald-400/40 px-3 py-1.5 text-xs md:text-sm text-emerald-300 hover:bg-emerald-300 hover:text-black transition-colors"
-            >
-              EN version
-            </Link>
+      <main className="min-h-screen bg-[#050507] text-zinc-100">
+        <div className="mx-auto max-w-6xl px-4 pb-14 pt-16 md:pt-24 space-y-8">
+          <div className="flex justify-between items-center gap-3">
+            <p className="text-xs md:text-sm tracking-[0.16em] text-zinc-400 uppercase">about / cv-mode</p>
+            <Link href="/about_en" className="rounded-md border border-cyan-400/40 px-3 py-1.5 text-xs md:text-sm text-cyan-300 hover:bg-cyan-300 hover:text-black transition-colors">EN Portfolio</Link>
           </div>
 
-          <Card className="border-emerald-400/30 bg-zinc-950">
+          <Card className="border-emerald-400/30 bg-zinc-950/90">
             <CardHeader>
-              <CardTitle className="text-2xl md:text-4xl text-emerald-300">Павел Соловьёв — AI Product Engineer</CardTitle>
+              <CardTitle className="text-3xl md:text-5xl text-emerald-300 leading-tight">Павел Соловьёв — AI Product Engineer</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4 text-zinc-200">
-              <p className="text-sm md:text-base">
-                Я проектирую и запускаю AI-assisted продукты в формате «идея → рабочий веб-контур → управляемая доработка».
-                Мой ключевой фокус — <strong>быстро превращать запрос клиента в работающий бизнес-инструмент</strong>, а не в бесконечное ТЗ.
-              </p>
-
+            <CardContent className="space-y-5">
+              <p className="text-base md:text-lg text-zinc-200">Делаю продукты, которые продают и работают: от идеи и контекста клиента до живого веб-контура с понятной приёмкой.</p>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-zinc-300">
-                <p>📍 Нижний Новгород / remote-first</p>
-                <p>📬 Telegram: @salavey13</p>
-                <p>💻 GitHub: github.com/salavey13</p>
-                <p>⚙️ Stack: Next.js, TypeScript, Supabase, Telegram, AI workflows</p>
+                <p>📍 Нижний Новгород / remote-first</p><p>📬 Telegram: @salavey13</p>
+                <p>💻 GitHub: github.com/salavey13</p><p>⚙️ Stack: Next.js, TypeScript, Supabase, AI, Telegram</p>
               </div>
-
-              <div className="flex flex-wrap gap-2 text-xs">
-                <span className="rounded-full bg-zinc-800 px-3 py-1 text-zinc-200">AI-first delivery</span>
-                <span className="rounded-full bg-zinc-800 px-3 py-1 text-zinc-200">Telegram-first products</span>
-                <span className="rounded-full bg-zinc-800 px-3 py-1 text-zinc-200">Supabase + Next.js</span>
-                <span className="rounded-full bg-zinc-800 px-3 py-1 text-zinc-200">Rapid business validation</span>
-              </div>
+              <ul className="space-y-2 text-sm md:text-base text-zinc-200">
+                {cvHighlights.map((item) => <li key={item} className="border-l-2 border-emerald-400/40 pl-3">{item}</li>)}
+              </ul>
             </CardContent>
           </Card>
 
-
-
-          <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <Card className="lg:col-span-2 border-violet-400/30 bg-zinc-950">
-              <CardHeader>
-                <CardTitle className="text-xl md:text-2xl text-violet-300">Mysterious Partner: Julia</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-zinc-200">
-                <p>Julia — мой постоянный team-партнёр в коммуникации, вкусе и продуктовой упаковке. Она представляет мой стиль: быстро, метко, без воды.</p>
-                <p>В публичных и клиентских сценариях Julia выступает как «таинственный компаньон» бренда: держит тон, атмосферу и ощущение цельного персонажа вокруг продукта.</p>
+          <section className="grid gap-6 lg:grid-cols-3">
+            <Card className="lg:col-span-2 border-violet-400/30 bg-zinc-950/90">
+              <CardHeader><CardTitle className="text-2xl text-violet-300">Julia — mysterious partner</CardTitle></CardHeader>
+              <CardContent className="space-y-3 text-zinc-200 text-sm md:text-base">
+                <p>Julia — партнёр-персона бренда: отвечает за атмосферу, тон и цельный характер презентации. Это отдельный образ, не подмена моей личности.</p>
+                <p>В клиентских сценариях Julia усиливает упаковку и эмоциональный контур, пока я держу архитектуру, delivery и бизнес-результат.</p>
               </CardContent>
             </Card>
-
-            <Card className="border-violet-400/30 bg-zinc-950">
-              <CardHeader>
-                <CardTitle className="text-xl text-violet-300">Julia / avatar</CardTitle>
-              </CardHeader>
+            <Card className="border-violet-400/30 bg-zinc-950/90">
+              <CardHeader><CardTitle className="text-xl text-violet-300">Avatar signal</CardTitle></CardHeader>
               <CardContent>
-                <Image
-                  src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix//135398606.png"
-                  alt="Julia mysterious partner avatar"
-                  width={640}
-                  height={640}
-                  className="w-full rounded-xl border border-violet-300/40 object-cover"
-                  unoptimized
-                />
+                <div className="aspect-square rounded-xl border border-violet-300/40 bg-[radial-gradient(circle_at_30%_20%,#8b5cf655,#0a0a0f_55%),linear-gradient(140deg,#111827,#3f3f46)] p-4 flex items-end">
+                  <p className="text-xs text-violet-200/90 tracking-[0.2em] uppercase">JULIA / SIGNAL</p>
+                </div>
               </CardContent>
             </Card>
           </section>
 
-          <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <Card className="lg:col-span-2 border-fuchsia-400/30 bg-zinc-950">
-              <CardHeader>
-                <CardTitle className="text-xl md:text-2xl text-fuchsia-300">Что я строю сейчас (актуальная версия)</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {integrations.map((item) => (
-                  <article key={item.title} className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">
-                    <h3 className="text-lg font-semibold text-white">{item.title}</h3>
-                    <p className="mt-2 text-sm text-zinc-300">{item.desc}</p>
-                    <Link
-                      href={item.href}
-                      target={item.href.startsWith("http") ? "_blank" : undefined}
-                      className="mt-3 inline-block text-sm text-emerald-300 underline hover:text-emerald-200"
-                    >
-                      {item.cta}
-                    </Link>
-                  </article>
-                ))}
-              </CardContent>
-            </Card>
-
-            <Card className="border-cyan-400/30 bg-zinc-950">
-              <CardHeader>
-                <CardTitle className="text-xl text-cyan-300">Подход</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-3 text-sm text-zinc-200">
-                  {principles.map((point) => (
-                    <li key={point} className="border-l-2 border-cyan-400/40 pl-3">
-                      {point}
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          </section>
-
-          <Card className="border-amber-400/30 bg-zinc-950">
-            <CardHeader>
-              <CardTitle className="text-xl md:text-2xl text-amber-300">Формат работы с клиентом (BOSS style)</CardTitle>
-            </CardHeader>
-            <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm text-zinc-200">
-              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
-                <p className="font-semibold text-white">1) Вход</p>
-                <p className="mt-2">Клиент даёт запрос, контекст и пару референсов/изображений.</p>
-              </div>
-              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
-                <p className="font-semibold text-white">2) Сборка</p>
-                <p className="mt-2">Я преобразую ввод в план, структуру и рабочие слайсы продукта.</p>
-              </div>
-              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
-                <p className="font-semibold text-white">3) Приёмка</p>
-                <p className="mt-2">Клиент подтверждает результат и даёт точечные polishing-итерации.</p>
-              </div>
+          <Card className="border-fuchsia-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-fuchsia-300">Флагманские интеграции и демо</CardTitle></CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-3">
+              {flagshipCases.map((item) => (
+                <article key={item.title} className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-4">
+                  <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+                  <p className="mt-1 text-xs text-fuchsia-200">{item.subtitle}</p>
+                  <p className="mt-3 text-sm text-zinc-300">{item.desc}</p>
+                  <Link href={item.href} target={item.href.startsWith("http") ? "_blank" : undefined} className="mt-3 inline-block text-sm text-emerald-300 underline hover:text-emerald-200">{item.cta}</Link>
+                </article>
+              ))}
             </CardContent>
           </Card>
 
+          <Card className="border-amber-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-amber-300">BOSS-mode: как я веду клиента</CardTitle></CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-4 text-sm text-zinc-200">
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4"><p className="font-semibold text-white">01 · Intake</p><p className="mt-2">Запрос, цель, пара визуальных ориентиров.</p></div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4"><p className="font-semibold text-white">02 · Decompose</p><p className="mt-2">Разбор на работающие product-слайсы и операционный план.</p></div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4"><p className="font-semibold text-white">03 · Deliver</p><p className="mt-2">Быстрый выкат контуров, где клиент уже может щупать ценность.</p></div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4"><p className="font-semibold text-white">04 · Polish</p><p className="mt-2">Точечная полировка до уровня «готово к бою».</p></div>
+            </CardContent>
+          </Card>
 
-          <Card className="border-emerald-400/30 bg-zinc-950">
-            <CardHeader>
-              <CardTitle className="text-xl md:text-2xl text-emerald-300">Быстрый контакт / Support</CardTitle>
-            </CardHeader>
+          <Card className="border-emerald-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-emerald-300">Support / старт диалога</CardTitle></CardHeader>
             <CardContent className="space-y-3">
-              <p className="text-sm text-zinc-300">Если хочешь обсудить запуск, интеграцию franchize или BOSS-mode под твой кейс — отправь запрос прямо отсюда.</p>
+              <p className="text-sm text-zinc-300">Если нужен запуск под ключ или адаптация BOSS-модели под ваш кейс — напишите здесь, соберём execution-путь.</p>
               <SupportForm />
             </CardContent>
           </Card>
-
         </div>
       </main>
     </>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,38 +1,47 @@
 "use client";
 
 import Head from "next/head";
+import Image from "next/image";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import SupportForm from "@/components/SupportForm";
 
-const cvHighlights = [
-  "AI Product Engineer: превращаю запрос в рабочий продуктовый контур без затяжного waterfall.",
-  "Telegram-first delivery: UX и операции изначально проектируются под мобильный ритм и быстрые касания.",
-  "Next.js + Supabase + AI workflows: от архитектуры до прод-ready execution и сопровождения.",
-  "Продуктовый режим: сначала ценность на живом контуре, потом масштаб и полировка.",
+const coreBlocks = [
+  {
+    title: "Кто я",
+    text: "13+ лет в разработке (C++/Java/TS), сегодня — AI Product Engineer. Моя зона силы: быстро превращать бизнес-запрос в рабочий веб-контур с понятной приёмкой и дальнейшим ростом.",
+  },
+  {
+    title: "Что даю клиенту",
+    text: "Не просто ‘страницу’, а работающий продуктовый ритм: архитектура, интеграции, операционный UX, быстрые итерации и контроль качества по живым результатам.",
+  },
+  {
+    title: "Как работаю",
+    text: "BOSS-mode delivery: intake запроса → декомпозиция → быстрый выкат рабочих слайсов → полировка под реальный контекст команды и продаж.",
+  },
 ];
 
-const flagshipCases = [
+const flagship = [
   {
-    title: "Franchize / VIP Bike Rental",
-    subtitle: "Полноценный бизнес-контур из одного hydration SQL",
-    desc: "Собрал механику, где новый франшизный веб-контур поднимается из single SQL seed + market/items конфигурации. /vipbikerental — демонстрация того, как быстро развернуть рабочую модель, а не просто лендинг.",
+    name: "Franchize + VIP Bike",
+    proof: "Полноценный запуск через hydration SQL",
+    details:
+      "Модель, где новый бизнес-контур собирается из single SQL seed + market/items. /vipbikerental показывает, как быстро запустить не мокап, а живую систему.",
     href: "/vipbikerental",
-    cta: "Открыть живой пример",
   },
   {
-    title: "WBlanding",
-    subtitle: "Коммерческий лендинг как операционный центр",
-    desc: "Это не витрина, а рабочее место: action-слои, crew flow, audit, referral, invoicing, воронка и исполнение в одном ритме. Сайт живёт как инструмент команды и продаж.",
+    name: "WBlanding",
+    proof: "Лендинг как операционная панель",
+    details:
+      "Action-слои, crew, audit, referral, invoicing и коммерческая логика в одном пространстве. Это интерфейс для действий, а не ‘декоративная обложка’.",
     href: "/wblanding",
-    cta: "Открыть WBlanding",
   },
   {
-    title: "BOSS_QUEST.HTML",
-    subtitle: "Главный клиентский протокол (актуальная версия)",
-    desc: "Мой текущий фрейм: клиент даёт запрос + пару картинок, я раскладываю это в управляемый квест-план, где BOSS исполняет delivery end-to-end. Клиент фокусируется на приёмке и polishing, а не на хаосе процесса.",
+    name: "BOSS_QUEST.HTML",
+    proof: "Последний и главный протокол взаимодействия",
+    details:
+      "Один запрос + пару изображений превращаю в исполнимый квест-план: BOSS ведёт delivery end-to-end, клиент концентрируется на acceptance и polishing.",
     href: "https://github.com/salavey13/carTest/blob/main/BOSS_QUEST.HTML",
-    cta: "Читать BOSS_QUEST",
   },
 ];
 
@@ -40,82 +49,68 @@ export default function AboutPage() {
   return (
     <>
       <Head>
-        <title>Павел Соловьёв — CV / AI Product Engineer</title>
-        <meta
-          name="description"
-          content="CV-страница Павла Соловьёва: Franchize/VIP Bike hydration SQL, WBlanding, BOSS_QUEST.HTML и AI-first delivery для запуска микро-бизнес веб-продуктов."
-        />
+        <title>Павел Соловьёв — About / CV</title>
+        <meta name="description" content="CV-страница Павла Соловьёва: опыт, flagship-кейсы Franchize/VIP Bike, WBlanding, BOSS_QUEST и формат BOSS-mode delivery." />
       </Head>
 
-      <main className="min-h-screen bg-[#050507] text-zinc-100">
-        <div className="mx-auto max-w-6xl px-4 pb-14 pt-16 md:pt-24 space-y-8">
-          <div className="flex justify-between items-center gap-3">
-            <p className="text-xs md:text-sm tracking-[0.16em] text-zinc-400 uppercase">about / cv-mode</p>
-            <Link href="/about_en" className="rounded-md border border-cyan-400/40 px-3 py-1.5 text-xs md:text-sm text-cyan-300 hover:bg-cyan-300 hover:text-black transition-colors">EN Portfolio</Link>
+      <main className="min-h-screen bg-[#06070b] text-zinc-100">
+        <div className="mx-auto max-w-6xl px-4 pb-16 pt-20 md:pt-28 space-y-8">
+          <div className="flex items-center justify-between">
+            <p className="text-xs tracking-[0.2em] uppercase text-zinc-400">about / ru</p>
+            <Link href="/about_en" className="rounded-lg border border-emerald-400/40 px-3 py-1.5 text-xs text-emerald-300 hover:bg-emerald-300 hover:text-black transition-colors">about_en (RU portfolio)</Link>
           </div>
 
-          <Card className="border-emerald-400/30 bg-zinc-950/90">
-            <CardHeader>
-              <CardTitle className="text-3xl md:text-5xl text-emerald-300 leading-tight">Павел Соловьёв — AI Product Engineer</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-5">
-              <p className="text-base md:text-lg text-zinc-200">Делаю продукты, которые продают и работают: от идеи и контекста клиента до живого веб-контура с понятной приёмкой.</p>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-zinc-300">
-                <p>📍 Нижний Новгород / remote-first</p><p>📬 Telegram: @salavey13</p>
-                <p>💻 GitHub: github.com/salavey13</p><p>⚙️ Stack: Next.js, TypeScript, Supabase, AI, Telegram</p>
+          <Card className="border-emerald-400/35 bg-zinc-950/90">
+            <CardContent className="grid gap-6 p-6 md:grid-cols-[220px_1fr] md:p-8">
+              <div>
+                <Image src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix//135398606.png" alt="Павел Соловьёв" width={700} height={900} className="h-full w-full rounded-2xl border border-emerald-300/40 object-cover" unoptimized />
               </div>
-              <ul className="space-y-2 text-sm md:text-base text-zinc-200">
-                {cvHighlights.map((item) => <li key={item} className="border-l-2 border-emerald-400/40 pl-3">{item}</li>)}
-              </ul>
+              <div className="space-y-4">
+                <h1 className="text-3xl md:text-5xl font-semibold text-emerald-300">Павел Соловьёв</h1>
+                <p className="text-base md:text-lg text-zinc-200">AI Product Engineer · Telegram-first builder · архитектура + скорость + бизнес-результат</p>
+                <div className="grid grid-cols-1 gap-2 text-sm text-zinc-300 md:grid-cols-2">
+                  <p>📍 Нижний Новгород / remote</p><p>📬 Telegram: @salavey13</p>
+                  <p>💻 github.com/salavey13</p><p>⚙️ Next.js · Supabase · AI workflows</p>
+                </div>
+              </div>
             </CardContent>
           </Card>
 
-          <section className="grid gap-6 lg:grid-cols-3">
-            <Card className="lg:col-span-2 border-violet-400/30 bg-zinc-950/90">
-              <CardHeader><CardTitle className="text-2xl text-violet-300">Julia — mysterious partner</CardTitle></CardHeader>
-              <CardContent className="space-y-3 text-zinc-200 text-sm md:text-base">
-                <p>Julia — партнёр-персона бренда: отвечает за атмосферу, тон и цельный характер презентации. Это отдельный образ, не подмена моей личности.</p>
-                <p>В клиентских сценариях Julia усиливает упаковку и эмоциональный контур, пока я держу архитектуру, delivery и бизнес-результат.</p>
-              </CardContent>
-            </Card>
-            <Card className="border-violet-400/30 bg-zinc-950/90">
-              <CardHeader><CardTitle className="text-xl text-violet-300">Avatar signal</CardTitle></CardHeader>
-              <CardContent>
-                <div className="aspect-square rounded-xl border border-violet-300/40 bg-[radial-gradient(circle_at_30%_20%,#8b5cf655,#0a0a0f_55%),linear-gradient(140deg,#111827,#3f3f46)] p-4 flex items-end">
-                  <p className="text-xs text-violet-200/90 tracking-[0.2em] uppercase">JULIA / SIGNAL</p>
-                </div>
-              </CardContent>
-            </Card>
+          <section className="grid gap-4 md:grid-cols-3">
+            {coreBlocks.map((b) => (
+              <Card key={b.title} className="border-cyan-400/25 bg-zinc-950/90">
+                <CardHeader><CardTitle className="text-xl text-cyan-300">{b.title}</CardTitle></CardHeader>
+                <CardContent className="text-sm text-zinc-300">{b.text}</CardContent>
+              </Card>
+            ))}
           </section>
 
           <Card className="border-fuchsia-400/30 bg-zinc-950/90">
-            <CardHeader><CardTitle className="text-2xl text-fuchsia-300">Флагманские интеграции и демо</CardTitle></CardHeader>
+            <CardHeader><CardTitle className="text-2xl text-fuchsia-300">Ключевые интеграции и демо</CardTitle></CardHeader>
             <CardContent className="grid gap-4 md:grid-cols-3">
-              {flagshipCases.map((item) => (
-                <article key={item.title} className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-4">
-                  <h3 className="text-lg font-semibold text-white">{item.title}</h3>
-                  <p className="mt-1 text-xs text-fuchsia-200">{item.subtitle}</p>
-                  <p className="mt-3 text-sm text-zinc-300">{item.desc}</p>
-                  <Link href={item.href} target={item.href.startsWith("http") ? "_blank" : undefined} className="mt-3 inline-block text-sm text-emerald-300 underline hover:text-emerald-200">{item.cta}</Link>
+              {flagship.map((item) => (
+                <article key={item.name} className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-4">
+                  <h3 className="text-lg font-semibold text-white">{item.name}</h3>
+                  <p className="mt-1 text-xs text-fuchsia-200">{item.proof}</p>
+                  <p className="mt-3 text-sm text-zinc-300">{item.details}</p>
+                  <Link href={item.href} target={item.href.startsWith("http") ? "_blank" : undefined} className="mt-3 inline-block text-sm text-emerald-300 underline">Открыть</Link>
                 </article>
               ))}
             </CardContent>
           </Card>
 
-          <Card className="border-amber-400/30 bg-zinc-950/90">
-            <CardHeader><CardTitle className="text-2xl text-amber-300">BOSS-mode: как я веду клиента</CardTitle></CardHeader>
-            <CardContent className="grid gap-4 md:grid-cols-4 text-sm text-zinc-200">
-              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4"><p className="font-semibold text-white">01 · Intake</p><p className="mt-2">Запрос, цель, пара визуальных ориентиров.</p></div>
-              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4"><p className="font-semibold text-white">02 · Decompose</p><p className="mt-2">Разбор на работающие product-слайсы и операционный план.</p></div>
-              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4"><p className="font-semibold text-white">03 · Deliver</p><p className="mt-2">Быстрый выкат контуров, где клиент уже может щупать ценность.</p></div>
-              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4"><p className="font-semibold text-white">04 · Polish</p><p className="mt-2">Точечная полировка до уровня «готово к бою».</p></div>
+          <Card className="border-violet-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-violet-300">Julia — mysterious partner</CardTitle></CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-[1.3fr_0.7fr]">
+              <p className="text-sm md:text-base text-zinc-300">Julia — отдельный бренд-персонаж и партнёр по подаче: атмосфера, эмоциональный контур и цельный стиль коммуникации. Это дополнительный слой бренда рядом с моим основным инженерным и продуктовым контуром.</p>
+              <div className="rounded-xl border border-violet-300/40 bg-[radial-gradient(circle_at_30%_20%,#8b5cf666,#09090b_65%)] p-4 text-xs uppercase tracking-[0.22em] text-violet-200">Julia / signal</div>
             </CardContent>
           </Card>
 
-          <Card className="border-emerald-400/30 bg-zinc-950/90">
-            <CardHeader><CardTitle className="text-2xl text-emerald-300">Support / старт диалога</CardTitle></CardHeader>
+          <Card className="border-amber-400/35 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-amber-300">SupportForm / быстрый старт</CardTitle></CardHeader>
             <CardContent className="space-y-3">
-              <p className="text-sm text-zinc-300">Если нужен запуск под ключ или адаптация BOSS-модели под ваш кейс — напишите здесь, соберём execution-путь.</p>
+              <p className="text-sm text-zinc-300">Нужен запуск или перезапуск продукта, BOSS-mode, franchize hydration или жёсткая полировка действующего контура — напишите детали, я соберу конкретный execution-план.</p>
               <SupportForm />
             </CardContent>
           </Card>

--- a/app/about_en/page.tsx
+++ b/app/about_en/page.tsx
@@ -5,24 +5,30 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import SupportForm from "@/components/SupportForm";
 
-const portfolioProof = [
+const portfolioTracks = [
   {
-    title: "Franchize Engine / VIP Bike Rental",
-    result: "Hydrated a full niche business surface from a single SQL seed + market items.",
-    details: "The `/vipbikerental` flow shows how a reusable franchise template can be bootstrapped fast, then iterated as a real product system.",
-    href: "/vipbikerental",
+    title: "Трек A · Franchize-конструктор",
+    bullets: [
+      "Шаблонный запуск веб-бизнеса из hydration SQL + market-пакета.",
+      "Флагман: /vipbikerental как рабочий контур, а не ‘презенташка’.",
+      "Подходит для быстрого MVP/SMB запуска под конкретную нишу.",
+    ],
   },
   {
-    title: "WBlanding",
-    result: "Converted a landing into an operator cockpit.",
-    details: "Integrated crew actions, audit tooling, referral mechanics, and invoicing pathways into one execution-oriented commercial surface.",
-    href: "/wblanding",
+    title: "Трек B · WBlanding execution surface",
+    bullets: [
+      "Конверсионный фронт + операционный слой (crew, audit, referral, invoicing).",
+      "Сценарии собраны вокруг реальных действий команды и денег.",
+      "Удобно масштабировать по модулям без переписывания ядра.",
+    ],
   },
   {
-    title: "BOSS_QUEST.HTML",
-    result: "Latest client workflow protocol.",
-    details: "Turns a raw client request + a couple of images into a practical execution quest where the client mainly accepts and requests polish.",
-    href: "https://github.com/salavey13/carTest/blob/main/BOSS_QUEST.HTML",
+    title: "Трек C · BOSS_QUEST протокол",
+    bullets: [
+      "Клиент приносит запрос + референсы/изображения.",
+      "Я превращаю это в поэтапный executable-план с контролем качества.",
+      "Фокус клиента: принимать результат и задавать точечную полировку.",
+    ],
   },
 ];
 
@@ -30,68 +36,56 @@ export default function AboutEnPage() {
   return (
     <>
       <Head>
-        <title>Pavel Solovyov — Portfolio / AI Product Engineer</title>
-        <meta name="description" content="Portfolio page for Pavel Solovyov featuring Franchize/VIP Bike, WBlanding and BOSS_QUEST workflow." />
+        <title>about_en — отдельное портфолио (RU)</title>
+        <meta name="description" content="Отдельная русская portfolio-страница с другим контентом: проектные треки, формат сотрудничества и BOSS delivery." />
       </Head>
 
-      <main className="min-h-screen bg-[#050507] text-zinc-100">
-        <div className="mx-auto max-w-6xl px-4 pb-14 pt-16 md:pt-24 space-y-8">
-          <div className="flex justify-between items-center gap-3">
-            <p className="text-xs md:text-sm tracking-[0.16em] text-zinc-400 uppercase">about_en / portfolio-mode</p>
-            <Link href="/about" className="rounded-md border border-emerald-400/40 px-3 py-1.5 text-xs md:text-sm text-emerald-300 hover:bg-emerald-300 hover:text-black transition-colors">RU CV</Link>
+      <main className="min-h-screen bg-[#07070b] text-zinc-100">
+        <div className="mx-auto max-w-6xl px-4 pb-16 pt-20 md:pt-28 space-y-8">
+          <div className="flex items-center justify-between">
+            <p className="text-xs tracking-[0.2em] uppercase text-zinc-400">about_en / ru-portfolio</p>
+            <Link href="/about" className="rounded-lg border border-cyan-400/40 px-3 py-1.5 text-xs text-cyan-300 hover:bg-cyan-300 hover:text-black transition-colors">back to about CV</Link>
           </div>
 
           <Card className="border-cyan-400/30 bg-zinc-950/90">
-            <CardHeader><CardTitle className="text-3xl md:text-5xl text-cyan-300">Pavel Solovyov — AI Product Engineer</CardTitle></CardHeader>
-            <CardContent className="space-y-4 text-zinc-200">
-              <p className="text-base md:text-lg">I build AI-assisted product systems that sell, operate, and scale — not just demo pages.</p>
-              <p className="text-sm md:text-base">My engagement style is BOSS-mode delivery: fast intent capture, clear execution map, working releases, and measurable polishing loops.</p>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-zinc-300">
-                <p>Location: Nizhny Novgorod / remote-first</p><p>Telegram: @salavey13</p>
-                <p>GitHub: github.com/salavey13</p><p>Stack: Next.js, TypeScript, Supabase, Telegram, AI workflows</p>
-              </div>
+            <CardHeader><CardTitle className="text-3xl md:text-5xl text-cyan-300">Портфолио формата «запрос → рабочий продукт»</CardTitle></CardHeader>
+            <CardContent className="space-y-3 text-zinc-200">
+              <p className="text-base md:text-lg">Эта страница специально отдельная от `/about`: здесь не CV, а витрина delivery-подхода и продуктовых треков.</p>
+              <p className="text-sm md:text-base">Если `/about` продаёт меня как специалиста, то `/about_en` продаёт мой формат исполнения задач и типовые траектории, по которым быстро собираются рабочие веб-контуры.</p>
             </CardContent>
           </Card>
 
-          <Card className="border-fuchsia-400/30 bg-zinc-950/90">
-            <CardHeader><CardTitle className="text-2xl text-fuchsia-300">Portfolio proof (live system examples)</CardTitle></CardHeader>
-            <CardContent className="grid gap-4 md:grid-cols-3">
-              {portfolioProof.map((item) => (
-                <article key={item.title} className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-4">
-                  <h3 className="text-lg font-semibold text-white">{item.title}</h3>
-                  <p className="mt-2 text-sm text-cyan-200">{item.result}</p>
-                  <p className="mt-3 text-sm text-zinc-300">{item.details}</p>
-                  <Link href={item.href} target={item.href.startsWith("http") ? "_blank" : undefined} className="mt-3 inline-block text-sm text-cyan-300 underline hover:text-cyan-200">Open case</Link>
-                </article>
-              ))}
-            </CardContent>
-          </Card>
+          <section className="grid gap-4 md:grid-cols-3">
+            {portfolioTracks.map((track) => (
+              <Card key={track.title} className="border-fuchsia-400/25 bg-zinc-950/90">
+                <CardHeader><CardTitle className="text-xl text-fuchsia-300">{track.title}</CardTitle></CardHeader>
+                <CardContent>
+                  <ul className="space-y-2 text-sm text-zinc-300">
+                    {track.bullets.map((b) => <li key={b} className="border-l-2 border-fuchsia-400/35 pl-3">{b}</li>)}
+                  </ul>
+                </CardContent>
+              </Card>
+            ))}
+          </section>
 
-          <Card className="border-amber-400/30 bg-zinc-950/90">
-            <CardHeader><CardTitle className="text-2xl text-amber-300">How clients work with me</CardTitle></CardHeader>
-            <CardContent className="grid gap-4 md:grid-cols-2 text-sm text-zinc-200">
+          <Card className="border-emerald-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-emerald-300">Формат сотрудничества</CardTitle></CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-2 text-sm text-zinc-300">
               <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
-                <p className="font-semibold text-white">For founders / operators</p>
-                <p className="mt-2">You bring intent, constraints, and references. I return an execution-ready product path with visible checkpoints.</p>
+                <p className="font-semibold text-white">Для владельца бизнеса</p>
+                <p className="mt-2">Минимум бюрократии: цель, ограничения, материалы. На выходе — рабочий план и реализация, где видны этапы и прогресс.</p>
               </div>
               <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
-                <p className="font-semibold text-white">For teams</p>
-                <p className="mt-2">I plug into existing flows and accelerate delivery with AI + architecture discipline, not chaotic one-off hacks.</p>
+                <p className="font-semibold text-white">Для команды/продакта</p>
+                <p className="mt-2">Интеграция в текущий стек и процессы: усиливаю delivery через AI + архитектурную дисциплину без поломки существующей логики.</p>
               </div>
             </CardContent>
           </Card>
 
           <Card className="border-violet-400/30 bg-zinc-950/90">
-            <CardHeader><CardTitle className="text-2xl text-violet-300">Julia partner layer</CardTitle></CardHeader>
-            <CardContent className="text-sm text-zinc-200">
-              Julia is the recurring presentation companion in my brand narrative: mystery, tone, and cinematic consistency. It supports communication while my core role remains product architecture and delivery ownership.
-            </CardContent>
-          </Card>
-
-          <Card className="border-emerald-400/30 bg-zinc-950/90">
-            <CardHeader><CardTitle className="text-2xl text-emerald-300">Quick contact / Support</CardTitle></CardHeader>
+            <CardHeader><CardTitle className="text-2xl text-violet-300">Связаться / SupportForm</CardTitle></CardHeader>
             <CardContent className="space-y-3">
-              <p className="text-sm text-zinc-300">If you want to launch a micro-business app from a rough brief — send context here and I will propose a concrete build path.</p>
+              <p className="text-sm text-zinc-300">Опишите задачу, желаемый срок и что уже есть (контент/SQL/референсы) — отвечу с практичным планом внедрения.</p>
               <SupportForm />
             </CardContent>
           </Card>

--- a/app/about_en/page.tsx
+++ b/app/about_en/page.tsx
@@ -2,179 +2,99 @@
 
 import Head from "next/head";
 import Link from "next/link";
-import Image from "next/image";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import SupportForm from "@/components/SupportForm";
 
-const projects = [
+const portfolioProof = [
   {
-    title: "Franchize Engine + VIP Bike Rental",
-    desc: "A repeatable model where a full web business surface is hydrated from a single SQL crew seed plus market items. /vipbikerental is the live flagship proof.",
-    cta: "Open /vipbikerental",
+    title: "Franchize Engine / VIP Bike Rental",
+    result: "Hydrated a full niche business surface from a single SQL seed + market items.",
+    details: "The `/vipbikerental` flow shows how a reusable franchise template can be bootstrapped fast, then iterated as a real product system.",
     href: "/vipbikerental",
   },
   {
     title: "WBlanding",
-    desc: "Built as an operator-ready commercial surface: conversion entry, crew flow, referral and invoicing mechanics, plus practical action modules for execution.",
-    cta: "Open /wblanding",
+    result: "Converted a landing into an operator cockpit.",
+    details: "Integrated crew actions, audit tooling, referral mechanics, and invoicing pathways into one execution-oriented commercial surface.",
     href: "/wblanding",
   },
   {
     title: "BOSS_QUEST.HTML",
-    desc: "My latest client protocol: one request + a few images become an execution plan run by BOSS end-to-end. Clients stay focused on acceptance and polish, not process chaos.",
-    cta: "Read BOSS_QUEST.HTML",
+    result: "Latest client workflow protocol.",
+    details: "Turns a raw client request + a couple of images into a practical execution quest where the client mainly accepts and requests polish.",
     href: "https://github.com/salavey13/carTest/blob/main/BOSS_QUEST.HTML",
   },
-];
-
-const engagement = [
-  "Start from real business intent (not heavyweight specs).",
-  "Translate intent into a concrete execution map and working slices.",
-  "Ship quickly, validate on live usage, then polish with measurable iterations.",
 ];
 
 export default function AboutEnPage() {
   return (
     <>
       <Head>
-        <title>Pavel Solovyov — AI Product Engineer</title>
-        <meta
-          name="description"
-          content="Updated English about page with flagship demos: Franchize/VIP Bike hydration, WBlanding, and BOSS_QUEST.HTML client workflow."
-        />
+        <title>Pavel Solovyov — Portfolio / AI Product Engineer</title>
+        <meta name="description" content="Portfolio page for Pavel Solovyov featuring Franchize/VIP Bike, WBlanding and BOSS_QUEST workflow." />
       </Head>
 
-      <main className="min-h-screen bg-[#060606] text-white">
-        <div className="mx-auto max-w-6xl px-4 py-8 md:py-12 space-y-6">
-          <div className="flex justify-end">
-            <Link
-              href="/about"
-              className="rounded-md border border-cyan-400/40 px-3 py-1.5 text-xs md:text-sm text-cyan-300 hover:bg-cyan-300 hover:text-black transition-colors"
-            >
-              RU version
-            </Link>
+      <main className="min-h-screen bg-[#050507] text-zinc-100">
+        <div className="mx-auto max-w-6xl px-4 pb-14 pt-16 md:pt-24 space-y-8">
+          <div className="flex justify-between items-center gap-3">
+            <p className="text-xs md:text-sm tracking-[0.16em] text-zinc-400 uppercase">about_en / portfolio-mode</p>
+            <Link href="/about" className="rounded-md border border-emerald-400/40 px-3 py-1.5 text-xs md:text-sm text-emerald-300 hover:bg-emerald-300 hover:text-black transition-colors">RU CV</Link>
           </div>
 
-          <Card className="border-cyan-400/30 bg-zinc-950">
-            <CardHeader>
-              <CardTitle className="text-2xl md:text-4xl text-cyan-300">Pavel Solovyov — AI Product Engineer</CardTitle>
-            </CardHeader>
+          <Card className="border-cyan-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-3xl md:text-5xl text-cyan-300">Pavel Solovyov — AI Product Engineer</CardTitle></CardHeader>
             <CardContent className="space-y-4 text-zinc-200">
-              <p className="text-sm md:text-base">
-                I design and deliver AI-assisted product systems where the main outcome is a working business tool, not a documentation-heavy delay loop.
-              </p>
-              <p className="text-sm md:text-base">
-                My delivery rhythm is: intent capture → execution blueprint → fast shipping of working slices → validation-driven polish.
-              </p>
-
+              <p className="text-base md:text-lg">I build AI-assisted product systems that sell, operate, and scale — not just demo pages.</p>
+              <p className="text-sm md:text-base">My engagement style is BOSS-mode delivery: fast intent capture, clear execution map, working releases, and measurable polishing loops.</p>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-zinc-300">
-                <p>Location: Nizhny Novgorod / remote-first</p>
-                <p>Telegram: @salavey13</p>
-                <p>GitHub: github.com/salavey13</p>
-                <p>Stack: Next.js, TypeScript, Supabase, Telegram, AI workflows</p>
+                <p>Location: Nizhny Novgorod / remote-first</p><p>Telegram: @salavey13</p>
+                <p>GitHub: github.com/salavey13</p><p>Stack: Next.js, TypeScript, Supabase, Telegram, AI workflows</p>
               </div>
             </CardContent>
           </Card>
 
+          <Card className="border-fuchsia-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-fuchsia-300">Portfolio proof (live system examples)</CardTitle></CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-3">
+              {portfolioProof.map((item) => (
+                <article key={item.title} className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-4">
+                  <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+                  <p className="mt-2 text-sm text-cyan-200">{item.result}</p>
+                  <p className="mt-3 text-sm text-zinc-300">{item.details}</p>
+                  <Link href={item.href} target={item.href.startsWith("http") ? "_blank" : undefined} className="mt-3 inline-block text-sm text-cyan-300 underline hover:text-cyan-200">Open case</Link>
+                </article>
+              ))}
+            </CardContent>
+          </Card>
 
-
-          <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <Card className="lg:col-span-2 border-violet-400/30 bg-zinc-950">
-              <CardHeader>
-                <CardTitle className="text-xl md:text-2xl text-violet-300">Mysterious partner: Julia</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-zinc-200">
-                <p>Julia is my recurring team persona and creative partner layer across product storytelling and client communication.</p>
-                <p>She represents the same style values as my delivery model: sharp, practical, and cinematic without losing execution discipline.</p>
-              </CardContent>
-            </Card>
-
-            <Card className="border-violet-400/30 bg-zinc-950">
-              <CardHeader>
-                <CardTitle className="text-xl text-violet-300">Julia / avatar</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <Image
-                  src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix//135398606.png"
-                  alt="Julia mysterious partner avatar"
-                  width={640}
-                  height={640}
-                  className="w-full rounded-xl border border-violet-300/40 object-cover"
-                  unoptimized
-                />
-              </CardContent>
-            </Card>
-          </section>
-
-          <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <Card className="lg:col-span-2 border-emerald-400/30 bg-zinc-950">
-              <CardHeader>
-                <CardTitle className="text-xl md:text-2xl text-emerald-300">Flagship integrations & demos</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {projects.map((item) => (
-                  <article key={item.title} className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">
-                    <h3 className="text-lg font-semibold text-white">{item.title}</h3>
-                    <p className="mt-2 text-sm text-zinc-300">{item.desc}</p>
-                    <Link
-                      href={item.href}
-                      target={item.href.startsWith("http") ? "_blank" : undefined}
-                      className="mt-3 inline-block text-sm text-cyan-300 underline hover:text-cyan-200"
-                    >
-                      {item.cta}
-                    </Link>
-                  </article>
-                ))}
-              </CardContent>
-            </Card>
-
-            <Card className="border-fuchsia-400/30 bg-zinc-950">
-              <CardHeader>
-                <CardTitle className="text-xl text-fuchsia-300">Engagement model</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-3 text-sm text-zinc-200">
-                  {engagement.map((step) => (
-                    <li key={step} className="border-l-2 border-fuchsia-400/40 pl-3">
-                      {step}
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          </section>
-
-          <Card className="border-amber-400/30 bg-zinc-950">
-            <CardHeader>
-              <CardTitle className="text-xl md:text-2xl text-amber-300">What clients get</CardTitle>
-            </CardHeader>
-            <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm text-zinc-200">
+          <Card className="border-amber-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-amber-300">How clients work with me</CardTitle></CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-2 text-sm text-zinc-200">
               <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
-                <p className="font-semibold text-white">Speed with structure</p>
-                <p className="mt-2">Fast first value without sacrificing architecture and operational clarity.</p>
+                <p className="font-semibold text-white">For founders / operators</p>
+                <p className="mt-2">You bring intent, constraints, and references. I return an execution-ready product path with visible checkpoints.</p>
               </div>
               <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
-                <p className="font-semibold text-white">Operational continuity</p>
-                <p className="mt-2">Interfaces and data flows that can continue into production, not throwaway demos.</p>
-              </div>
-              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
-                <p className="font-semibold text-white">Clear acceptance loop</p>
-                <p className="mt-2">Client-visible checkpoints and polishing passes instead of vague “we’re still in progress”.</p>
+                <p className="font-semibold text-white">For teams</p>
+                <p className="mt-2">I plug into existing flows and accelerate delivery with AI + architecture discipline, not chaotic one-off hacks.</p>
               </div>
             </CardContent>
           </Card>
 
+          <Card className="border-violet-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-violet-300">Julia partner layer</CardTitle></CardHeader>
+            <CardContent className="text-sm text-zinc-200">
+              Julia is the recurring presentation companion in my brand narrative: mystery, tone, and cinematic consistency. It supports communication while my core role remains product architecture and delivery ownership.
+            </CardContent>
+          </Card>
 
-          <Card className="border-emerald-400/30 bg-zinc-950">
-            <CardHeader>
-              <CardTitle className="text-xl md:text-2xl text-emerald-300">Quick contact / Support</CardTitle>
-            </CardHeader>
+          <Card className="border-emerald-400/30 bg-zinc-950/90">
+            <CardHeader><CardTitle className="text-2xl text-emerald-300">Quick contact / Support</CardTitle></CardHeader>
             <CardContent className="space-y-3">
-              <p className="text-sm text-zinc-300">Want to discuss a launch, franchize hydration path, or BOSS-mode delivery for your case? Send a request here.</p>
+              <p className="text-sm text-zinc-300">If you want to launch a micro-business app from a rough brief — send context here and I will propose a concrete build path.</p>
               <SupportForm />
             </CardContent>
           </Card>
-
         </div>
       </main>
     </>

--- a/app/about_en/page.tsx
+++ b/app/about_en/page.tsx
@@ -1,294 +1,182 @@
 "use client";
 
 import Head from "next/head";
-import Image from "next/image";
 import Link from "next/link";
-import React from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import Image from "next/image";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import SupportForm from "@/components/SupportForm";
-import VibeContentRenderer from "@/components/VibeContentRenderer";
-import { cn } from "@/lib/utils";
 
-export default function RentAYogForMePage() {
+const projects = [
+  {
+    title: "Franchize Engine + VIP Bike Rental",
+    desc: "A repeatable model where a full web business surface is hydrated from a single SQL crew seed plus market items. /vipbikerental is the live flagship proof.",
+    cta: "Open /vipbikerental",
+    href: "/vipbikerental",
+  },
+  {
+    title: "WBlanding",
+    desc: "Built as an operator-ready commercial surface: conversion entry, crew flow, referral and invoicing mechanics, plus practical action modules for execution.",
+    cta: "Open /wblanding",
+    href: "/wblanding",
+  },
+  {
+    title: "BOSS_QUEST.HTML",
+    desc: "My latest client protocol: one request + a few images become an execution plan run by BOSS end-to-end. Clients stay focused on acceptance and polish, not process chaos.",
+    cta: "Read BOSS_QUEST.HTML",
+    href: "https://github.com/salavey13/carTest/blob/main/BOSS_QUEST.HTML",
+  },
+];
+
+const engagement = [
+  "Start from real business intent (not heavyweight specs).",
+  "Translate intent into a concrete execution map and working slices.",
+  "Ship quickly, validate on live usage, then polish with measurable iterations.",
+];
+
+export default function AboutEnPage() {
   return (
     <>
       <Head>
-        <title>Аренда Йога & WMS — oneSitePls / VIBE</title>
-        <meta name="description" content="Йог для ума, складской софт, сауна и байки. Плати звёздами в Telegram - быстро, по делу, без блядства." />
+        <title>Pavel Solovyov — AI Product Engineer</title>
+        <meta
+          name="description"
+          content="Updated English about page with flagship demos: Franchize/VIP Bike hydration, WBlanding, and BOSS_QUEST.HTML client workflow."
+        />
       </Head>
 
-      {/* Always dark mode — black edition */}
-      <div className="relative min-h-screen bg-black text-white">
-        <style>{`
-          @keyframes glitch-clip {
-            0% { clip-path: inset(0 0 0 0); transform: translate(0);} 
-            8% { clip-path: inset(12% 0 58% 0); transform: translate(-2px, -1px) skew(-0.5deg);} 
-            18% { clip-path: inset(28% 0 42% 0); transform: translate(2px, 1px) skew(0.5deg);} 
-            28% { clip-path: inset(6% 0 70% 0); transform: translate(-1px, 0) skew(-0.2deg);} 
-            50% { clip-path: inset(0 0 0 0); transform: translate(0);} 
-            100% { clip-path: inset(0 0 0 0); transform: translate(0);} 
-          }
-          .glitch-wrap { position: relative; display: inline-block; }
-          /* CENSOR overlay uses SCREEN blend so it *lightens* the underlying text, fixing "too dark on black" */
-          .glitch-censor {
-            position: absolute; inset: 0; pointer-events: none;
-            background: linear-gradient(90deg, rgba(255,255,255,0.06) 0%, rgba(255,0,150,0.06) 35%, rgba(255,255,255,0.04) 100%);
-            mix-blend-mode: screen; animation: glitch-clip 2.2s infinite; opacity: 0.95;
-          }
-          .glitch-text { position: relative; display: inline-block; color: #ffffff; text-shadow: 0 2px 8px rgba(0,0,0,0.6), 0 0 18px rgba(0,255,157,0.08); }
-          .glitch-text.punch { color: #fff; text-shadow: 0 2px 6px rgba(0,0,0,0.6), 0 0 12px rgba(255,20,147,0.12), 0 0 18px rgba(0,255,157,0.06); font-weight:800; }
-          .badge-neon { display:inline-block; padding:6px 10px; border-radius:999px; background: linear-gradient(90deg,#00ff9d33,#ff49c833); color:#030303; font-weight:700; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Roboto Mono", monospace; }
-          .hero-pan { transform-origin:center; will-change:transform; animation: heroPan 30s linear infinite; }
-          @keyframes heroPan { 0% { transform: scale(1.02) translateY(0px);} 50% { transform: scale(1.05) translateY(-10px);} 100% { transform: scale(1.02) translateY(0px);} }
-
-          /* Mobile optimizations */
-          @media (max-width: 640px) {
-            .glitch-text { font-size: 1.05rem; }
-          }
-
-        `}</style>
-
-        {/* HERO — taller and mobile-optimized */}
-        <section className="relative h-[86vh] min-h-[820px] flex items-center justify-center text-center p-6 overflow-hidden">
-          <div className="absolute inset-0 z-0">
-            <Image
-              src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/hero-4f94e671-c5c8-4405-ab08-8f9a47e1ad69.jpg"
-              alt="hero"
-              layout="fill"
-              objectFit="cover"
-              className="brightness-40 hero-pan"
-              priority
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/90 to-transparent" />
+      <main className="min-h-screen bg-[#060606] text-white">
+        <div className="mx-auto max-w-6xl px-4 py-8 md:py-12 space-y-6">
+          <div className="flex justify-end">
+            <Link
+              href="/about"
+              className="rounded-md border border-cyan-400/40 px-3 py-1.5 text-xs md:text-sm text-cyan-300 hover:bg-cyan-300 hover:text-black transition-colors"
+            >
+              RU version
+            </Link>
           </div>
 
-          <div className="relative z-10 max-w-4xl mx-auto px-4 text-white">
-            <h1 className="font-orbitron text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-tight tracking-tight">
-              <span className="block">АРЕНДУЙ ВАЙБ</span>
-              <span className="block text-primary">Йог. Склад. Байк. Разум.</span>
-            </h1>
+          <Card className="border-cyan-400/30 bg-zinc-950">
+            <CardHeader>
+              <CardTitle className="text-2xl md:text-4xl text-cyan-300">Pavel Solovyov — AI Product Engineer</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-zinc-200">
+              <p className="text-sm md:text-base">
+                I design and deliver AI-assisted product systems where the main outcome is a working business tool, not a documentation-heavy delay loop.
+              </p>
+              <p className="text-sm md:text-base">
+                My delivery rhythm is: intent capture → execution blueprint → fast shipping of working slices → validation-driven polish.
+              </p>
 
-            <p className="mt-5 text-sm sm:text-base md:text-lg text-gray-300 font-light max-w-3xl mx-auto">
-              Возьми не услугу — возьми опыт. Плати звёздами (Telegram Stars) — быстро, без посредников.
-              <strong className="text-accent-text"> Я не лечу душу — я режу хаос в голове и в бизнесе.</strong>
-            </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-zinc-300">
+                <p>Location: Nizhny Novgorod / remote-first</p>
+                <p>Telegram: @salavey13</p>
+                <p>GitHub: github.com/salavey13</p>
+                <p>Stack: Next.js, TypeScript, Supabase, Telegram, AI workflows</p>
+              </div>
+            </CardContent>
+          </Card>
 
-            <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-center items-center">
-              <Link href="/wblanding" legacyBehavior>
-                <a aria-label="Оптимизация Склада" className="w-full sm:w-auto">
-                  <Button size="lg" className="font-orbitron w-full sm:w-auto bg-indigo-600 hover:bg-indigo-700 text-white border-none shadow-[0_0_15px_rgba(79,70,229,0.5)]">
-                    <VibeContentRenderer content="::FaBox:: FIX WAREHOUSE" />
-                  </Button>
-                </a>
-              </Link>
 
-              <Link href="/franchize/vip-bike" legacyBehavior>
-                <a aria-label="Арендовать байк" className="w-full sm:w-auto">
-                  <Button size="lg" variant="accent" className="font-orbitron w-full sm:w-auto">
-                    <VibeContentRenderer content="::FaMotorcycle:: RENT BIKE" />
-                  </Button>
-                </a>
-              </Link>
-            </div>
 
-            <div className="mt-5 text-xs text-gray-400 font-mono">
-              <span className="badge-neon">НЕОН-ЛАЙФХАК</span>
-              <span className="ml-2">— дропни этот линк в телеграм чат и попроси оплатить 3★ — прямо сейчас.</span>
-            </div>
-          </div>
-        </section>
-
-        {/* MAIN GRID */}
-        <main className="container mx-auto px-4 py-10 space-y-10">
-          {/* Grid updated to 2 columns on MD to neatly fit 4 items */}
-          <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            
-            {/* 1. WAREHOUSE (New) */}
-            <Card className="bg-[#090909] border-zinc-800 hover:border-indigo-500/50 transition-all duration-300 shadow-lg">
+          <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <Card className="lg:col-span-2 border-violet-400/30 bg-zinc-950">
               <CardHeader>
-                <CardTitle className="font-orbitron text-2xl flex items-center gap-3 text-white">
-                  <VibeContentRenderer content="::FaBox::" /> WarehouseBot (WMS)
-                </CardTitle>
+                <CardTitle className="text-xl md:text-2xl text-violet-300">Mysterious partner: Julia</CardTitle>
               </CardHeader>
-              <CardContent>
-                <p className="text-sm text-gray-300 mb-4">Убийца энтерпрайз-софта. Управление складом для селлеров (WB, Ozon). Минимум кнопок, максимум денег.</p>
-                <ul className="list-disc list-inside text-sm space-y-2 mb-4 text-gray-400">
-                  <li>Real-time API синк (нет штрафам)</li>
-                  <li>Геймификация персонала (RPG на складе)</li>
-                  <li>Бесплатный аудит потерь</li>
-                </ul>
-                <div className="flex flex-col sm:flex-row gap-3">
-                  <Link href="/wblanding"><a className="w-full sm:w-auto"><Button className="w-full bg-indigo-600 hover:bg-indigo-700">Аудит Склада</Button></a></Link>
-                  <Link href="/wblanding#pricing"><a className="w-full sm:w-auto"><Button variant="secondary" className="w-full">Тарифы</Button></a></Link>
-                </div>
+              <CardContent className="space-y-3 text-sm text-zinc-200">
+                <p>Julia is my recurring team persona and creative partner layer across product storytelling and client communication.</p>
+                <p>She represents the same style values as my delivery model: sharp, practical, and cinematic without losing execution discipline.</p>
               </CardContent>
             </Card>
 
-            {/* 2. BIKES */}
-            <Card className="bg-[#070707] border-border">
+            <Card className="border-violet-400/30 bg-zinc-950">
               <CardHeader>
-                <CardTitle className="font-orbitron text-2xl flex items-center gap-3 text-white">
-                  <VibeContentRenderer content="::FaMotorcycle::" /> VIP-Аренда Байков
-                </CardTitle>
+                <CardTitle className="text-xl text-violet-300">Julia / avatar</CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-sm text-gray-300 mb-4">Байк — это ритуал. Чистый железный друг, страховка, защита и трек в кармане.</p>
-                <ul className="list-disc list-inside text-sm space-y-2 mb-4 text-gray-300">
-                  <li>Сервис, страховка и экипировка</li>
-                  <li>Промо-код: ЛЕТО2025 — скидка 10%</li>
-                  <li>Быстрая бронь — без бумажной волокиты</li>
-                </ul>
-                <div className="flex flex-col sm:flex-row gap-3">
-                  <Link href="/franchize/vip-bike"><a className="w-full sm:w-auto"><Button className="w-full">Забронировать</Button></a></Link>
-                  <Link href="/vipbikerental"><a className="w-full sm:w-auto"><Button variant="secondary" className="w-full">Детали</Button></a></Link>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* 3. SAUNA */}
-            <Card className="bg-[#070707] border-border">
-              <CardHeader>
-                <CardTitle className="font-orbitron text-2xl flex items-center gap-3 text-white">
-                  <VibeContentRenderer content="::FaFire::" /> Сауна &amp; Ресет
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-gray-300 mb-4">Тёплая комната, минимум разговоров, максимум эффект. Идеально после дороги или перед важной задачей.</p>
-                <ul className="list-disc list-inside text-sm space-y-2 mb-4 text-gray-300">
-                  <li>Частные сессии по времени</li>
-                  <li>Ароматы, полотенца, chill-zone</li>
-                  <li>Можно бронировать группой</li>
-                </ul>
-                <div className="flex flex-col sm:flex-row gap-3">
-                  <Link href="/sauna-rent"><a className="w-full sm:w-auto"><Button className="w-full">В Сауну</Button></a></Link>
-                  <Link href="/about#sauna"><a className="w-full sm:w-auto"><Button variant="secondary" className="w-full">Подробнее</Button></a></Link>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* 4. MIND YOGA */}
-            <Card className="bg-[#070707] border-border">
-              <CardHeader>
-                <CardTitle className="font-orbitron text-2xl flex items-center gap-3 text-white">
-                  <VibeContentRenderer content="::FaDragon::" /> Йог ума (я — твой йог)
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-gray-300 mb-4">Я — йог для ума: сажаю порядок в голове, режу страхи, учу фокусироваться. Не буддизм — результат.</p>
-                <ul className="list-disc list-inside text-sm space-y-2 mb-4 text-gray-300">
-                  <li>Индивидуальные сессии — практики</li>
-                  <li>Короткие циклы для собственников</li>
-                  <li>Оплата — только Telegram Stars (XTR)</li>
-                </ul>
-                <div className="flex flex-col sm:flex-row gap-3">
-                  <Link href="/about#mind"><a className="w-full sm:w-auto"><Button className="w-full">Арендовать Йога — 3★</Button></a></Link>
-                  <Link href="/selfdev"><a className="w-full sm:w-auto"><Button variant="secondary" className="w-full">Методика SelfDev</Button></a></Link>
-                </div>
+                <Image
+                  src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix//135398606.png"
+                  alt="Julia mysterious partner avatar"
+                  width={640}
+                  height={640}
+                  className="w-full rounded-xl border border-violet-300/40 object-cover"
+                  unoptimized
+                />
               </CardContent>
             </Card>
           </section>
 
-          {/* About / SelfDev punchy block */}
-          <section className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
-            <div className="lg:col-span-2 space-y-6">
-              <Card className="bg-[#050505] border-border">
-                <CardHeader>
-                  <CardTitle className="text-2xl font-orbitron flex items-center gap-3 text-white">
-                    <VibeContentRenderer content="::FaGlobe::" /> oneSitePls — философия VIBE
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm md:text-base text-gray-300 mb-4">Я — Павел. Делаю так, чтобы AI работал на реальные деньги и реальные жизни. VIBE — это про быстрые проверки, минимальный риск и реальную доставку.</p>
+          <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <Card className="lg:col-span-2 border-emerald-400/30 bg-zinc-950">
+              <CardHeader>
+                <CardTitle className="text-xl md:text-2xl text-emerald-300">Flagship integrations & demos</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {projects.map((item) => (
+                  <article key={item.title} className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">
+                    <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+                    <p className="mt-2 text-sm text-zinc-300">{item.desc}</p>
+                    <Link
+                      href={item.href}
+                      target={item.href.startsWith("http") ? "_blank" : undefined}
+                      className="mt-3 inline-block text-sm text-cyan-300 underline hover:text-cyan-200"
+                    >
+                      {item.cta}
+                    </Link>
+                  </article>
+                ))}
+              </CardContent>
+            </Card>
 
-                  <div className="relative">
-                    <div className="glitch-wrap">
-                      <h4 className="text-xl font-bold mb-2 glitch-text punch">Коротко: тестируй идеи, продавай результат.</h4>
-                      <div className="glitch-censor" aria-hidden />
-                    </div>
-                    <p className="mt-3 text-sm text-gray-400">Ненавижу «настройку среды». Люблю реультат. Монетизация через Telegram Stars — это честно, быстро и удобно для локальных сервисов.</p>
-                  </div>
-
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-6">
-                    <div className="p-4 bg-[#0b0b0b] rounded-lg border border-border">
-                      <h5 className="font-semibold text-accent-text mb-2">Validation</h5>
-                      <p className="text-xs text-gray-300">Fake-door, AI research, быстрый запуск — убей плохую идею до траты денег.</p>
-                    </div>
-                    <div className="p-4 bg-[#0b0b0b] rounded-lg border border-border">
-                      <h5 className="font-semibold text-accent-text mb-2">Security</h5>
-                      <p className="text-xs text-gray-300">SAST, PR scans, zero-trust — скорость без дури.</p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className="bg-[#050505] border-border">
-                <CardHeader>
-                  <CardTitle className="text-2xl font-orbitron flex items-center gap-3 text-white">
-                    <VibeContentRenderer content="::FaLightbulb::" /> SelfDev: стань своим продуктом
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-gray-300 mb-4">Не работай на чужой ритм. Создавай сервисы вокруг своей жизни: сауна, байк, менторство, **склад**. Я учу делать это быстро и без стыда.</p>
-
-                  <ol className="list-decimal list-inside text-sm text-gray-300 space-y-3 pl-4">
-                    <li>Начни с высокочековой услуги и протестируй спрос.</li>
-                    <li>Задействуй AI: контент, аутрич, автоматизация.</li>
-                    <li>Делегируй друзьям — растите вместе (я могу обучить).</li>
-                  </ol>
-
-                  <p className="mt-4 text-xs text-gray-400">Хочешь, чтобы я помог лично? Бронирование — по звёздам. Быстро, честно, без разводов.</p>
-                </CardContent>
-              </Card>
-            </div>
-
-            {/* Right column - Support Form + CTA (sticky on md+, relative on mobile) */}
-            <aside className="">
-              <Card className="bg-[#080808] border-border md:sticky md:top-24 relative">
-                <CardHeader>
-                  <CardTitle className="text-xl font-orbitron flex items-center gap-3 text-white">
-                    <VibeContentRenderer content="::FaDragon::" /> Быстрая помощь — оплати звёздами
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-gray-300 mb-4">Нужна консультация, VIP-сессия или быстрый тест идеи? Выбирай уровень — счёт придёт в Telegram. Я увижу и отвечу.</p>
-
-                  <div className="mb-4">
-                    <SupportForm />
-                  </div>
-
-                  <div className="text-xs text-gray-400">
-                    <p className="mb-2"><strong>Почему Stars?</strong> Микроплатёж, низкий порог, быстро.</p>
-                    <p>Если надо — пиши напрямую: <a href="mailto:salavey13@gmail.com" className="text-accent-text hover:underline">salavey13@gmail.com</a> или <a href="https://t.me/salavey13" className="text-accent-text hover:underline">Telegram</a>.</p>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className="bg-[#070707] border-border mt-6">
-                <CardContent>
-                  <h4 className="font-semibold text-accent-text mb-2">Быстрые ссылки</h4>
-                  <ul className="text-sm list-inside space-y-2 text-gray-300">
-                    <li><Link href="/wblanding"><a className="hover:underline text-indigo-400">WarehouseBot (WMS)</a></Link></li>
-                    <li><Link href="/vipbikerental"><a className="hover:underline">VIP Байк</a></Link></li>
-                    <li><Link href="/sauna-rent"><a className="hover:underline">Сауна</a></Link></li>
-                    <li><Link href="/about#mind"><a className="hover:underline">Аренда йога — я</a></Link></li>
-                    <li><Link href="/repo-xml"><a className="hover:underline">/repo-xml Studio</a></Link></li>
-                  </ul>
-                </CardContent>
-              </Card>
-            </aside>
+            <Card className="border-fuchsia-400/30 bg-zinc-950">
+              <CardHeader>
+                <CardTitle className="text-xl text-fuchsia-300">Engagement model</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-3 text-sm text-zinc-200">
+                  {engagement.map((step) => (
+                    <li key={step} className="border-l-2 border-fuchsia-400/40 pl-3">
+                      {step}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
           </section>
 
-          {/* FOOTER CTA */}
-          <section className="py-8 text-center">
-            <p className="text-sm text-gray-400 mb-4">Хочешь чтобы я помог с продажами/аутричем для твоего локального сервиса? Сначала — одна сессия за 3★, дальше — как договоримся.</p>
-            <div className="flex flex-col sm:flex-row justify-center gap-3">
-              <Link href="/repo-xml"><a className="w-full sm:w-auto"><Button variant="outline" className="w-full sm:w-auto">Remix / Contribute</Button></a></Link>
-              <Link href="/selfdev"><a className="w-full sm:w-auto"><Button variant="secondary" className="w-full sm:w-auto">Начать SelfDev</Button></a></Link>
-            </div>
-          </section>
-        </main>
-      </div>
+          <Card className="border-amber-400/30 bg-zinc-950">
+            <CardHeader>
+              <CardTitle className="text-xl md:text-2xl text-amber-300">What clients get</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm text-zinc-200">
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
+                <p className="font-semibold text-white">Speed with structure</p>
+                <p className="mt-2">Fast first value without sacrificing architecture and operational clarity.</p>
+              </div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
+                <p className="font-semibold text-white">Operational continuity</p>
+                <p className="mt-2">Interfaces and data flows that can continue into production, not throwaway demos.</p>
+              </div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-4">
+                <p className="font-semibold text-white">Clear acceptance loop</p>
+                <p className="mt-2">Client-visible checkpoints and polishing passes instead of vague “we’re still in progress”.</p>
+              </div>
+            </CardContent>
+          </Card>
+
+
+          <Card className="border-emerald-400/30 bg-zinc-950">
+            <CardHeader>
+              <CardTitle className="text-xl md:text-2xl text-emerald-300">Quick contact / Support</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm text-zinc-300">Want to discuss a launch, franchize hydration path, or BOSS-mode delivery for your case? Send a request here.</p>
+              <SupportForm />
+            </CardContent>
+          </Card>
+
+        </div>
+      </main>
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace a long, tightly-coupled cyberpunk-styled about page with a cleaner, more maintainable and bilingual layout focused on product messaging and live demos.
- Surface current flagship demos and delivery principles (Franchize/VIP Bike, WBlanding, BOSS protocol) as structured cards for easier navigation and client onboarding.
- Reduce visual/markup complexity (huge inline SVGs and many nested blocks) to simplify maintenance and performance.
- Consolidate repeated patterns and remove unused pieces to make the page easier to extend and localize.

### Description
- Rewrote `app/about/page.tsx` and `app/about_en/page.tsx` into simplified `main`-based layouts using existing `Card` components and `SupportForm` for contact. 
- Introduced data-driven sections via `integrations`, `principles`, `projects`, and `engagement` arrays and rendered them as mapped card/article elements with appropriate `Link` targets. 
- Replaced the previous heavy background SVG hero and many legacy blocks with compact content blocks (profile, Julia partner, flagship integrations, client workflow) and updated SEO metadata (`<title>` and `<meta name="description">`).
- Removed several unused imports and older UI patterns (e.g., avatar component usages, `VibeContentRenderer`, large inline styles) and unified styling to `bg-zinc-*` card layouts and concise utility classes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105d21f7e48324900613fef9719cab)