### PR TITLE
Fix franchize item modal close button safe-area inset + focus order

### DIFF
--- a/app/franchize/lib/route-cta-policy.ts
+++ b/app/franchize/lib/route-cta-policy.ts
@@ -52,7 +52,7 @@ export const FRANCHIZE_HEADER_CORNER_GUARD_STYLE = {
 } as const;
 
 export const FRANCHIZE_MODAL_CLOSE_SAFE_AREA_STYLE = {
-  top: "calc(max(env(safe-area-inset-top), 0px) + 0.75rem)",
+  top: "calc(max(env(safe-area-inset-top), 0px) + 4.2rem)",
   right: "calc(max(env(safe-area-inset-right), 0px) + 0.75rem)",
 } as const;
 

--- a/app/franchize/lib/route-cta-policy.ts
+++ b/app/franchize/lib/route-cta-policy.ts
@@ -51,6 +51,11 @@ export const FRANCHIZE_HEADER_CORNER_GUARD_STYLE = {
   paddingInline: "clamp(0.25rem, max(env(safe-area-inset-left), env(safe-area-inset-right)), 1.25rem)",
 } as const;
 
+export const FRANCHIZE_MODAL_CLOSE_SAFE_AREA_STYLE = {
+  top: "calc(max(env(safe-area-inset-top), 0px) + 0.75rem)",
+  right: "calc(max(env(safe-area-inset-right), 0px) + 0.75rem)",
+} as const;
+
 export const FRANCHIZE_FLOATING_CART_SAFE_AREA_CLASS =
   "fixed bottom-[calc(6rem+env(safe-area-inset-bottom))] right-4 z-[60] flex items-center gap-3";
 

--- a/app/franchize/modals/Item.tsx
+++ b/app/franchize/modals/Item.tsx
@@ -17,6 +17,7 @@ import {
 import { ItemGallery } from "../components/ItemGallery";
 import { buildCatalogRentalStrip } from "../lib/catalog-rental-strip";
 import { crewPaletteForSurface } from "../lib/theme";
+import { FRANCHIZE_MODAL_CLOSE_SAFE_AREA_STYLE } from "../lib/route-cta-policy";
 
 interface ItemModalProps {
   item: CatalogItemVM | null;
@@ -286,6 +287,17 @@ export function ItemModal({
         style={surface.card}
       >
         <div className="relative flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain [scrollbar-gutter:stable] [-webkit-overflow-scrolling:touch] [touch-action:pan-y]">
+          {/* Quick Close Button */}
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--item-accent)]"
+            style={FRANCHIZE_MODAL_CLOSE_SAFE_AREA_STYLE}
+            aria-label="Закрыть"
+          >
+            <X className="h-4 w-4" />
+          </button>
+
           {/* Gallery Component */}
           <ItemGallery
             images={gallery}
@@ -299,16 +311,6 @@ export function ItemModal({
             mainAspectRatio="16/11"
             disableKeyboardNav={false}
           />
-
-          {/* Quick Close Button */}
-          <button
-            type="button"
-            onClick={onClose}
-            className="absolute right-3 top-3 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--item-accent)]"
-            aria-label="Закрыть"
-          >
-            <X className="h-4 w-4" />
-          </button>
 
           {/* Content */}
           <div className="space-y-4 p-4 sm:p-5">


### PR DESCRIPTION
### Motivation
- Ensure the item modal close control respects Telegram/iOS safe-area insets so it is not flush with device edges. 
- Make the close button the first focusable control in the modal tab order to improve keyboard/assistive navigation while preserving existing keyboard close behavior.

### Description
- Add `FRANCHIZE_MODAL_CLOSE_SAFE_AREA_STYLE` to `app/franchize/lib/route-cta-policy.ts` that uses `env(safe-area-inset-*)` for top/right inset offsets. 
- Update `app/franchize/modals/Item.tsx` to import and apply the shared safe-area style and move the close button markup before the gallery so it becomes the first focusable control. 
- Preserve the existing Escape-key handler and focus-trap logic (no keyboard handler changes).

### Testing
- Ran `node scripts/typecheck-franchize-slice.mjs` which passed for the franchize slice (typecheck reported unrelated transitive debt outside the allowlist).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c0309a688325b8f3df88a6def465)