### PR TITLE
Show bike bottom-nav on franchize/map-riders routes and remove admin/map-routes leakage

### DIFF
--- a/components/layout/BottomNavigationBike.tsx
+++ b/components/layout/BottomNavigationBike.tsx
@@ -33,6 +33,7 @@ interface NavItemConfig {
 const ALL_POSSIBLE_NAV_ITEMS: NavItemConfig[] = [
   { href: "/leaderboard", icon: "FaRankingStar", label: "Leaderboard", color: "text-accent-text" }, // gold
   { href: "/crews", icon: "FaUsers", label: "Crews", color: "text-brand-green" }, // оставлен зеленый для разнообразия
+  { href: "/franchize/vip-bike/map-routes", icon: "FaMapLocationDot", label: "Map Routes", color: "text-brand-cyan" },
   { href: "/paddock", icon: "FaWarehouse", label: "Paddock", color: "text-brand-cyan", adminOnly: true }, // оставлен голубой
   { href: "/admin", icon: "FaCirclePlus", label: "Admin", color: "text-secondary" }, // indigo
   { href: "/franchize/vip-bike", icon: "FaMotorcycle", label: "Rent", isCentralCandidate: true, centralColor: "from-primary to-accent" }, // red-orange to gold
@@ -40,10 +41,10 @@ const ALL_POSSIBLE_NAV_ITEMS: NavItemConfig[] = [
 
 const navTranslations: Record<string, Record<string, string>> = {
   en: {
-    "Leaderboard": "Leaders", "Crews": "Crews", "Rent": "Rent", "Paddock": "Paddock", "Admin": "Admin",
+    "Leaderboard": "Leaders", "Crews": "Crews", "Map Routes": "Routes", "Rent": "Rent", "Paddock": "Paddock", "Admin": "Admin",
   },
   ru: {
-    "Leaderboard": "Лидеры", "Crews": "Команды", "Rent": "Аренда", "Paddock": "Паддок", "Admin": "Админ",
+    "Leaderboard": "Лидеры", "Crews": "Команды", "Map Routes": "Маршруты", "Rent": "Аренда", "Paddock": "Паддок", "Admin": "Админ",
   }
 };
 

--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -260,12 +260,20 @@ function LayoutLogicController({ children }: { children: React.ReactNode }) {
     "/admin",
     "/paddock",
     "/rentals",
+    "/franchize/",
+    "/franchize",
     //"/vipbikerental",
     "/strikeball", 
   ];
-  const showBottomNav = pathsToShowBottomNavForStartsWith.some((p) =>
-    pathname?.startsWith(p)
-  );
+  const isFranchizeMapRidersRoute =
+    pathname?.startsWith("/franchize/") && pathname?.includes("/map-riders");
+  const isFranchizeProductRoute = pathname?.startsWith("/franchize/");
+  const isAdminMapRoutesPage = pathname === "/admin/map-routes";
+  const showBottomNav =
+    !isAdminMapRoutesPage &&
+    (pathsToShowBottomNavForStartsWith.some((p) => pathname?.startsWith(p)) ||
+      isFranchizeMapRidersRoute ||
+      isFranchizeProductRoute);
 
   useEffect(() => {
     setShowHeaderAndFooter(
@@ -282,8 +290,7 @@ function LayoutLogicController({ children }: { children: React.ReactNode }) {
         pathname === "/blogger" ||
         pathname?.startsWith("/optimapipe") ||
         pathname?.startsWith("/rules") ||
-        pathname === "/" ||
-        pathname === "/admin/map-routes"
+        pathname === "/"
       )
     );
   }, [pathname]);


### PR DESCRIPTION
### Motivation
- Ensure the Bike-themed bottom navigation is shown for franchize product and map-riders flows (customer UX) while preventing accidental admin pages from consuming that customer nav.
- Keep admin tooling (`/admin/map-routes`) separate from the consumer navigation model so admin screens do not leak into the bike bottom-nav experience.

### Description
- Updated the bottom-nav visibility logic in `components/layout/ClientLayout.tsx` to treat franchize routes intentionally by adding checks for `pathname.startsWith('/franchize/')` and a specific `map-riders` include test, while explicitly excluding the admin route `'/admin/map-routes'` from showing the bike nav.
- Removed the previous special-case coupling of `'/admin/map-routes'` from the header/footer suppression list in `components/layout/ClientLayout.tsx` so admin tooling no longer inherits customer UI constraints.
- Added an explicit `Map Routes` nav item (`/franchize/vip-bike/map-routes`) and RU/EN translations to `components/layout/BottomNavigationBike.tsx` so map routes can be an intentional destination under the bike navigation taxonomy instead of relying on an admin route leak.

### Testing
- Ran `npm run -s lint` and the repository reported no ESLint warnings or errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c065ce7c83259daf92a213db49a6)