### PR TITLE
fix(franchize): correct Telegram promo deep links and add cart promo validation

### DIFF
--- a/app/franchize/[slug]/order/[id]/page.tsx
+++ b/app/franchize/[slug]/order/[id]/page.tsx
@@ -9,6 +9,7 @@ import { buildFranchizeSectionMetadata } from "../../metadata";
 
 interface FranchizeOrderPageProps {
   params: Promise<{ slug: string; id: string }>;
+  searchParams?: Promise<{ promo?: string }>;
 }
 
 
@@ -21,8 +22,9 @@ export async function generateMetadata({ params }: FranchizeOrderPageProps): Pro
   });
 }
 
-export default async function FranchizeOrderPage({ params }: FranchizeOrderPageProps) {
+export default async function FranchizeOrderPage({ params, searchParams }: FranchizeOrderPageProps) {
   const { slug, id } = await params;
+  const { promo } = (await searchParams) ?? {};
   const { crew, items } = await getFranchizeBySlug(slug);
   const surface = crewPaletteForSurface(crew.theme);
   const ctaPolicy = getFranchizeRouteCtaPolicy("order");
@@ -30,7 +32,7 @@ export default async function FranchizeOrderPage({ params }: FranchizeOrderPageP
   return (
     <main className={`min-h-screen ${ctaPolicy.pageBottomSafeAreaClassName}`} style={surface.page}>
       <CrewHeader crew={crew} activePath={`/franchize/${crew.slug || slug}/order/${id}`} groupLinks={items.map((item) => item.category)} />
-      <OrderPageClient crew={crew} slug={crew.slug || slug} orderId={id} items={items} />
+      <OrderPageClient crew={crew} slug={crew.slug || slug} orderId={id} items={items} initialPromoCode={promo} />
       <CrewFooter crew={crew} />
     </main>
   );

--- a/app/franchize/components/CartPageClient.tsx
+++ b/app/franchize/components/CartPageClient.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import type { CatalogItemVM, FranchizeCrewVM } from "../actions";
-import { upsertFranchizeIntent } from "../actions";
+import { upsertFranchizeIntent, validateFranchizePromoCode } from "../actions";
 import { useFranchizeCartLines } from "../hooks/useFranchizeCartLines";
 import { useFranchizeCart } from "../hooks/useFranchizeCart"; // Import cart state access
 import { crewPaletteForSurface } from "../lib/theme";
@@ -28,6 +28,34 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
   const router = useRouter();
   const { dbUser, user } = useAppContext();
   const [isSaving, setIsSaving] = useState(false);
+  const [promoCode, setPromoCode] = useState("");
+  const [promoMessage, setPromoMessage] = useState<{ tone: "success" | "error"; text: string } | null>(null);
+  const [isPromoChecking, setIsPromoChecking] = useState(false);
+
+  const normalizePromoCode = (value: string) => value.trim().toUpperCase();
+
+  const handleApplyPromo = async () => {
+    const normalized = normalizePromoCode(promoCode);
+    if (!normalized) {
+      setPromoMessage({ tone: "error", text: "Введите промокод перед проверкой." });
+      return;
+    }
+
+    setIsPromoChecking(true);
+    try {
+      const result = await validateFranchizePromoCode({ slug, code: normalized, baseAmount: subtotal });
+      if (!result.success) {
+        setPromoMessage({ tone: "error", text: result.error });
+        return;
+      }
+      setPromoCode(result.code);
+      setPromoMessage({ tone: "success", text: `${result.title}: скидка ${result.discountAmount.toLocaleString("ru-RU")} ₽` });
+    } catch {
+      setPromoMessage({ tone: "error", text: "Не удалось проверить промокод. Попробуйте ещё раз." });
+    } finally {
+      setIsPromoChecking(false);
+    }
+  };
 
   const handleProceed = async () => {
     setIsSaving(true);
@@ -62,7 +90,10 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
         await intentPromise;
     }
     // Navigate even if save failed (local storage might still be used by next page if hydrated client-side)
-    router.push(`/franchize/${slug}/order/demo-order?flow=${flow}`);
+    const normalizedPromo = normalizePromoCode(promoCode);
+    const params = new URLSearchParams({ flow });
+    if (normalizedPromo) params.set("promo", normalizedPromo);
+    router.push(`/franchize/${slug}/order/demo-order?${params.toString()}`);
   };
 
   return (
@@ -146,6 +177,31 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
             <p className="text-2xl font-semibold text-[var(--cart-accent)]">
               {subtotal.toLocaleString("ru-RU")} ₽
             </p>
+            <div className="mt-4 rounded-xl border p-3" style={{ borderColor: "var(--cart-border)" }}>
+              <p className="text-xs" style={surface.mutedText}>Промокод (проверим перед переходом к checkout)</p>
+              <div className="mt-2 flex gap-2">
+                <input
+                  value={promoCode}
+                  onChange={(e) => {
+                    setPromoCode(e.target.value);
+                    setPromoMessage(null);
+                  }}
+                  placeholder={crew.catalog.promoBanners.length > 0 ? crew.catalog.promoPlaceholder || "Введите промокод" : "Промокодов нет"}
+                  className="h-10 w-full rounded-lg border px-3 text-sm"
+                  style={{ borderColor: "var(--cart-border)", background: "transparent" }}
+                />
+                <button
+                  type="button"
+                  onClick={handleApplyPromo}
+                  disabled={!promoCode.trim() || isPromoChecking}
+                  className="rounded-lg border px-3 text-xs font-medium disabled:opacity-60"
+                  style={{ borderColor: "var(--cart-border)" }}
+                >
+                  {isPromoChecking ? "Проверка..." : "Применить"}
+                </button>
+              </div>
+              {promoMessage ? <p className={`mt-2 text-xs ${promoMessage.tone === "error" ? "text-rose-300" : "text-emerald-300"}`}>{promoMessage.text}</p> : null}
+            </div>
             <button
               type="button"
               disabled={isSaving}

--- a/app/franchize/components/OrderPageClient.tsx
+++ b/app/franchize/components/OrderPageClient.tsx
@@ -20,6 +20,7 @@ interface OrderPageClientProps {
   slug: string;
   orderId: string;
   items: CatalogItemVM[];
+  initialPromoCode?: string;
 }
 
 const payments = [
@@ -124,7 +125,7 @@ function normalizePromoCode(value: string): string {
   return value.trim().replace(/\s+/g, "").toUpperCase();
 }
 
-export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientProps) {
+export function OrderPageClient({ crew, slug, orderId, items, initialPromoCode }: OrderPageClientProps) {
   const { user, dbUser } = useAppContext();
   const { cartLines, subtotal } = useFranchizeCartLines(slug, items);
   const [isSubmitting, startSubmitTransition] = useTransition();
@@ -149,7 +150,7 @@ export function OrderPageClient({ crew, slug, orderId, items }: OrderPageClientP
       comment: "",
       rentalStartDate: "",
       signatureName: "",
-      promo: "",
+      promo: (initialPromoCode ?? "").trim().toUpperCase(),
       selectedExtras: [],
       payment: payments[0].id,
       deliveryMode: "pickup",

--- a/docs/sql/sly13-franchize-hydration.sql
+++ b/docs/sql/sly13-franchize-hydration.sql
@@ -234,6 +234,7 @@ set
               'activeFrom', '2026-01-01',
               'activeTo', '2026-12-31',
               'priority', 90,
+              'href', 'https://t.me/oneBikePlsBot?start=FOCUS13',
               'ctaLabel', 'Забрать'
             )
           ),

--- a/docs/sql/sly13-franchize-test-hydration.sql
+++ b/docs/sql/sly13-franchize-test-hydration.sql
@@ -234,6 +234,7 @@ set
               'activeFrom', '2026-01-01',
               'activeTo', '2026-12-31',
               'priority', 90,
+              'href', 'https://t.me/oneBikePlsBot?start=FOCUS13',
               'ctaLabel', 'Забрать'
             )
           ),

--- a/docs/sql/vip-bike-franchize-hydration.sql
+++ b/docs/sql/vip-bike-franchize-hydration.sql
@@ -266,6 +266,7 @@ set
               'activeFrom', '2026-03-01',
               'activeTo', '2026-05-31',
               'priority', 95,
+              'href', 'https://t.me/oneBikePlsBot?start=NEURO2026',
               'ctaLabel', 'Забрать нейро-скидку'
             )
           ),

--- a/docs/sql/vip-cross-franchize-hydration.sql
+++ b/docs/sql/vip-cross-franchize-hydration.sql
@@ -236,7 +236,7 @@ set
           'showTwoColumnsMobile', true,
           'useModalDetails', true,
           'promoBanners', jsonb_build_array(
-            jsonb_build_object('id', 'summer-2026', 'title', 'Промокод ЭНДУРО2026 для оффроуд маршрута по лесным тропам и карьеру', 'subtitle', '-10% на первую аренду', 'code', 'ЭНДУРО2026', 'activeFrom', '2026-04-01', 'activeTo', '2026-10-31', 'priority', 90, 'ctaLabel', 'Забрать скидку')
+            jsonb_build_object('id', 'summer-2026', 'title', 'Промокод ЭНДУРО2026 для оффроуд маршрута по лесным тропам и карьеру', 'subtitle', '-10% на первую аренду', 'code', 'ЭНДУРО2026', 'activeFrom', '2026-04-01', 'activeTo', '2026-10-31', 'priority', 90, 'href', 'https://t.me/oneBikePlsBot?start=ЭНДУРО2026', 'ctaLabel', 'Забрать скидку')
           ),
           'adCards', jsonb_build_array(
             jsonb_build_object('id', 'cross-equipment', 'title', 'PRO эндуро экипировка', 'subtitle', 'Добавь комплект защиты к аренде', 'href', '', 'imageUrl', '', 'badge', 'Safety', 'activeFrom', '2026-04-01', 'activeTo', '2026-10-31', 'priority', 70, 'ctaLabel', 'Смотреть детали'),


### PR DESCRIPTION
### Motivation
- Seed/sql promo banners used a malformed Telegram handoff and should use `?start=<code>` so promo CTAs open the bot with the promo code payload. 
- Users need the ability to validate/apply promos at the cart stage before entering checkout so the checkout promo flow can be prefilled and validated.

### Description
- Replaced non-actionable/malformed promo link patterns in hydration seed/docs to explicit Telegram start deep links (`https://t.me/oneBikePlsBot?start=<code>`) in `docs/sql/vip-bike-franchize-hydration.sql`, `docs/sql/vip-cross-franchize-hydration.sql`, `docs/sql/sly13-franchize-hydration.sql`, and `docs/sql/sly13-franchize-test-hydration.sql`.
- Added a promo input slot and client-side UX to the cart page in `app/franchize/components/CartPageClient.tsx`, including apply button, success/error feedback, and a call to server promo validation via `validateFranchizePromoCode` from `app/franchize/actions`.
- Propagated the applied promo from cart to checkout using a `promo` query parameter when navigating to the order route (`/franchize/{slug}/order/demo-order`).
- Wired route/component plumbing so order page accepts the `promo` search param and pre-fills the checkout form: updated `app/franchize/[slug]/order/[id]/page.tsx` to pass `initialPromoCode` and updated `app/franchize/components/OrderPageClient.tsx` to use that value as the form default.
- Left server-side validation and final checkout integrity checks unchanged: `app/franchize/server-actions/promotions.ts` delegates to `app/franchize/actions-runtime.ts` where `validateFranchizePromoCode` and `resolveFranchizeCheckoutTotal` remain responsible for canonical validation and discount recomputation.

### Testing
- Ran project linter: `npm run -s lint` — succeeded with no ESLint errors.
- Attempted a targeted Next lint invocation for specific files which failed due to Next CLI project-root detection when invoked in isolation, but the full lint pass above validated code style.
- Changes were committed on branch and prepared as a PR titled `fix: correct Telegram promo deep links and add cart-stage promo validation`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c07585688325be335c900d91406e)