### PR TITLE
(feat): Enhanced /start handler with resolver versioning and raw signa

### DIFF
--- a/app/franchize/[slug]/components/VipBikeRentalClient-integration.tsx
+++ b/app/franchize/[slug]/components/VipBikeRentalClient-integration.tsx
@@ -1,0 +1,362 @@
+/**
+ * VipBikeRentalClient-integration.tsx
+ * ====================================
+ * Integration pattern for making VipBikeRentalClient data-driven.
+ *
+ * This file shows the MINIMAL changes needed to transform the current
+ * 1984-line component from "scattered if/else personalization" into
+ * "declarative section composition driven by resolve-experience".
+ *
+ * KEY CHANGES vs current VipBikeRentalClient.tsx:
+ *   1. Replace raw survey access with resolveVipBikeProfile()
+ *   2. Replace deriveHeroModeFromSurvey() with resolve-experience.ts
+ *   3. Replace vibeProfile memo with experience config
+ *   4. Replace hardcoded section order with experience.sectionOrder
+ *   5. Render sections via a sectionMap → sections.map(renderSection)
+ *   6. Add useBehaviorTracker() for progressive enrichment
+ *   7. Add anti-thrashing with experience lock writeback
+ *
+ * WHAT DOESN'T CHANGE:
+ *   - All existing section components (ConversionPilot, ElectroEnduroShowcase, etc.)
+ *   - The visual design of each section
+ *   - The hero video + tab system (still works the same way)
+ *   - The data fetching logic (catalog, map overview)
+ *
+ * This is a REFACTOR, not a rewrite. The goal is to make the component
+ * a thin orchestration shell that delegates personalization to the pipeline.
+ */
+
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { AnimatePresence, motion, useScroll, useTransform } from "framer-motion";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { BikeShowcase } from "@/components/BikeShowcase";
+import { VibeContentRenderer } from "@/components/VibeContentRenderer";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { useAppContext } from "@/contexts/AppContext";
+import type { CatalogItemVM, FranchizeTheme } from "@/app/franchize/actions";
+import {
+  DEFAULT_COLOR_OPTIONS,
+  DEFAULT_CONFIG_OPTIONS,
+  resolveBuyColorOptions,
+  resolveBuyConfigOptions,
+} from "@/app/franchize/lib/sale-config";
+
+// ── Pipeline imports ──
+import { resolveVipBikeProfile } from "@/app/franchize/lib/onboarding/resolve-profile";
+import { resolveVipBikeExperience, isExperienceLocked } from "@/app/franchize/lib/onboarding/resolve-experience";
+import { START_LINKS } from "@/app/franchize/lib/onboarding/payload-parser";
+import { useBehaviorTracker } from "@/app/franchize/lib/onboarding/track-behavior";
+import type {
+  SectionId,
+  HeroDisplayMode,
+  VipBikeExperienceConfig,
+  VipBikeUserProfile,
+} from "@/app/franchize/lib/onboarding/experience-types";
+
+// ── Existing types (unchanged) ──
+type ServiceItem = { icon: string; text: string };
+type MapRidersOverview = {
+  stats?: {
+    activeRiders?: number;
+    meetupCount?: number;
+    totalWeeklyDistanceKm?: number;
+  };
+  liveLocations?: Array<{
+    lat?: number;
+    lng?: number;
+    speed_kmh?: number;
+    updated_at?: string;
+    user_id?: string;
+  }>;
+  meetups?: Array<{
+    lat?: number;
+    lng?: number;
+    title?: string;
+    comment?: string;
+    scheduled_at?: string;
+  }>;
+  latestCompleted?: Array<{
+    rider_name?: string;
+    total_distance_km?: number;
+    duration_seconds?: number;
+    avg_speed_kmh?: number;
+    max_speed_kmh?: number;
+  }>;
+};
+
+type HeroPanel = {
+  mode: HeroDisplayMode;
+  label: string;
+  icon: string;
+  eyebrow: string;
+  title: string;
+  description: string;
+  imageUrl?: string;
+  href: string;
+  cta: string;
+  meta: Array<{ label: string; value: string }>;
+};
+
+// ── Existing helpers (unchanged) ──
+const formatCompactNumber = (value: number | undefined, fallback: number) =>
+  Number(value ?? fallback).toLocaleString("ru-RU", { maximumFractionDigits: 1 });
+
+// ... (fallbackHeroPanels, ConversionPilot, StepsProgress, etc. stay EXACTLY as-is)
+// ... I'm only showing the CHANGED sections below.
+
+// ═══════════════════════════════════════════════════════
+// THE KEY CHANGE: VipBikeRentalClient now uses the pipeline
+// ═══════════════════════════════════════════════════════
+
+export function VipBikeRentalClient({ items, theme }: { items: CatalogItemVM[]; theme: FranchizeTheme }) {
+  const { dbUser } = useAppContext();
+  const { scrollYProgress } = useScroll();
+  const y = useTransform(scrollYProgress, [0, 1], [0, -90]);
+
+  // ══════════════════════════════════════════════════════
+  // NEW: Resolve profile and experience from pipeline
+  // ══════════════════════════════════════════════════════
+  const profile = useMemo(() => resolveVipBikeProfile(dbUser), [dbUser]);
+  const resolvedExperience = useMemo(
+    () => resolveVipBikeExperience(profile, dbUser?.metadata?.experience_lock),
+    [profile, dbUser?.metadata?.experience_lock],
+  );
+
+  // NEW: Behavior tracker for progressive enrichment + lock writeback
+  const tracker = useBehaviorTracker();
+
+  // ══════════════════════════════════════════════════════
+  // NEW: Anti-thrashing with experience lock writeback
+  // ══════════════════════════════════════════════════════
+  // The experience is stored in state. On each profile change,
+  // we check if the previous experience is still locked.
+  // If locked → keep old experience. If not → apply new one.
+  const [currentExperience, setCurrentExperience] = useState<VipBikeExperienceConfig>(resolvedExperience);
+  const hasPersistedLock = useRef(false);
+
+  useEffect(() => {
+    // Anti-thrashing: if the current experience is still locked, don't change
+    if (isExperienceLocked(currentExperience)) {
+      return;
+    }
+
+    // Apply the new experience
+    setCurrentExperience(resolvedExperience);
+
+    // Persist the experience lock update (C2 fix)
+    // Only persist after the first experience is established
+    if (hasPersistedLock.current) {
+      tracker.persistExperienceLock(profile, resolvedExperience);
+    }
+    hasPersistedLock.current = true;
+  }, [resolvedExperience, currentExperience, profile, tracker]);
+
+  // Use the (possibly locked) current experience for rendering
+  const experience = currentExperience;
+
+  // Hero mode is now driven by the experience config
+  const [heroMode, setHeroMode] = useState<HeroDisplayMode>(experience.heroMode);
+
+  // Sync heroMode when experience changes (e.g., after survey data loads)
+  const hasManualHeroChoice = useRef(false);
+  useEffect(() => {
+    if (!hasManualHeroChoice.current) {
+      setHeroMode(experience.heroMode);
+    }
+  }, [experience.heroMode]);
+
+  const handleHeroModeChange = useCallback((mode: HeroDisplayMode) => {
+    hasManualHeroChoice.current = true;
+    setHeroMode(mode);
+  }, []);
+
+  // ══════════════════════════════════════════════════════
+  // NEW: vibeProfile is now derived from the experience config
+  // (replaces the 60-line memo that was reading raw survey signals)
+  // ══════════════════════════════════════════════════════
+  const vibeProfile = useMemo(() => {
+    const badge = deriveBadge(profile, experience);
+    const title = deriveTitle(profile, experience);
+    const note = deriveNote(profile, experience);
+
+    return {
+      badge,
+      title,
+      note,
+      ctaHref: experience.primaryCTA.href,
+      ctaLabel: experience.primaryCTA.label,
+      hasSurvey: profile.onboardingCompleted as boolean,
+      promoCode: profile.source?.promoCode || "",
+      isExternal: experience.primaryCTA.isExternal,
+    };
+  }, [profile, experience]);
+
+  // Data fetching (unchanged)
+  const [mapOverview, setMapOverview] = useState<MapRidersOverview | null>(null);
+  const [catalogItems, setCatalogItems] = useState<CatalogItemVM[]>(items);
+  const [isCatalogLoading, setIsCatalogLoading] = useState(items.length === 0);
+
+  // ... (fetch effects unchanged)
+
+  // heroPanels memo (unchanged, just the type adapts)
+  const heroPanels = useMemo<Record<HeroDisplayMode, HeroPanel>>(() => {
+    // ... same as before, but now includes "electro-enduro" mode
+    return {
+      ...fallbackHeroPanels,
+      // ... catalog-driven overrides
+      "electro-enduro": {
+        mode: "electro-enduro",
+        label: "Электро",
+        icon: "::FaBolt::",
+        eyebrow: "Тихая мощь нового поколения",
+        title: "Electro-Enduro S1",
+        description: "Электрический эндуро для города и бездорожья. Тишина, моментальный крутящий момент, нулевые выбросы.",
+        imageUrl: "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/IMG_bg-cf31dc2b-291b-440b-953b-6e1b4a838e4e.jpg",
+        href: "/franchize/vip-bike?category=electro",
+        cta: "Изучить электро",
+        meta: [
+          { label: "тип", value: "Electro-Enduro" },
+          { label: "запас хода", value: "до 120 км" },
+          { label: "зарядка", value: "2.5 часа" },
+        ],
+      },
+    } as Record<HeroDisplayMode, HeroPanel>;
+  }, [catalogItems, mapOverview]);
+
+  // ══════════════════════════════════════════════════════
+  // NEW: Section rendering via sectionMap with behavior tracking
+  // ══════════════════════════════════════════════════════
+  const sectionMap = useMemo(() => ({
+    hero: <HeroSection /* ...existing hero JSX... */ />,
+    bikeShowcase: <motion.section style={{ y }}><BikeShowcase /></motion.section>,
+    conversionPilot: <ConversionPilot items={catalogItems} overview={mapOverview} isCatalogLoading={isCatalogLoading} />,
+    electroShowcase: (
+      <div onViewportEnter={() => tracker.trackViewCategory("electro")}>
+        <ElectroEnduroShowcase items={catalogItems} isCatalogLoading={isCatalogLoading} />
+      </div>
+    ),
+    mapPreview: (
+      <div onViewportEnter={() => tracker.trackMapOpen()}>
+        <MapRidersLivePreview overview={mapOverview} />
+      </div>
+    ),
+    gearSection: <GearSection />,
+    stepsProgress: <StepsProgress items={catalogItems} />,
+    rentalQuickActions: <RentalQuickActionHub items={catalogItems} overview={mapOverview} isCatalogLoading={isCatalogLoading} />,
+    companyServiceHub: <VipBikeCompanyServiceHub />,
+    serviceCards: <ServiceCardsSection />,
+    howItWorks: <HowItWorksSection />,
+    investSection: (
+      <InvestSection onDwellTime={(seconds) => tracker.trackSectionDwell("investSection", seconds)} />
+    ),
+    faq: <FaqSection />,
+  }), [catalogItems, mapOverview, isCatalogLoading, heroMode, vibeProfile, tracker]);
+
+  // ══════════════════════════════════════════════════════
+  // NEW: Declarative section rendering with featured highlighting
+  // ══════════════════════════════════════════════════════
+  const renderedSections = useMemo(() => {
+    return experience.sectionOrder
+      .filter((id) => sectionMap[id] !== undefined)
+      .map((id) => {
+        const isFeatured = experience.featuredSections.includes(id);
+        return (
+          <div
+            key={id}
+            className={cn(
+              isFeatured && "ring-2 ring-brand-yellow/20 rounded-2xl",
+            )}
+          >
+            {sectionMap[id]}
+          </div>
+        );
+      });
+  }, [experience.sectionOrder, experience.featuredSections, sectionMap]);
+
+  // ══════════════════════════════════════════════════════
+  // RENDER: Same outer shell, sections rendered by pipeline
+  // ══════════════════════════════════════════════════════
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-background text-foreground">
+      {/* Background gradients (unchanged) */}
+      <div className="pointer-events-none fixed inset-0 z-[-2] bg-[radial-gradient(circle_at_top,rgba(255,106,0,0.14),transparent_35%),radial-gradient(circle_at_80%_20%,rgba(119,0,255,0.10),transparent_42%)]" />
+      <div className="pointer-events-none fixed inset-0 z-[-3] bg-[linear-gradient(to_bottom,rgba(0,0,0,0.45),transparent_35%)]" />
+
+      {/* Hero section — always first */}
+      {sectionMap.hero}
+
+      {/* Dynamic sections — ordered and filtered by experience config */}
+      <div className="container mx-auto max-w-7xl space-y-20 px-4 py-16 sm:space-y-24 sm:py-24">
+        {renderedSections.filter((_, i) => i > 0)}
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════
+// Helper: Derive vibeProfile badge/title/note from pipeline
+// ═══════════════════════════════════════════════════════
+
+function deriveBadge(profile: VipBikeUserProfile, experience: VipBikeExperienceConfig): string {
+  if (!profile.onboardingCompleted) {
+    return "::FaCompass:: Универсальный подбор";
+  }
+  switch (profile.segment) {
+    case "sport": return "::FaBolt:: Спортивный сценарий";
+    case "electro": return "::FaBolt:: Электро-мобильность";
+    case "retro": return "::FaWandSparkles:: Neo-retro подборка";
+    case "touring": return "::FaRoad:: Туристический маршрут";
+    case "urban": return "::FaCity:: Городской поток";
+    default: return "::FaRoute:: Персональный маршрут";
+  }
+}
+
+function deriveTitle(profile: VipBikeUserProfile, experience: VipBikeExperienceConfig): string {
+  if (!profile.onboardingCompleted) {
+    return "Подберём байк под задачу за 2 минуты";
+  }
+  switch (profile.intent) {
+    case "buy": return "Ваш сценарий: быстрый выбор и покупка";
+    case "rent": return profile.experience === "beginner"
+      ? "Ваш сценарий: безопасный первый выезд"
+      : "Ваш сценарий: скорость и адреналин";
+    case "community": return "Ваш сценарий: карта, райдеры, групповые выезды";
+    case "explore": return "Ваш сценарий: открытие и подбор";
+    default: return "Ваш сценарий: персональный маршрут";
+  }
+}
+
+function deriveNote(profile: VipBikeUserProfile, experience: VipBikeExperienceConfig): string {
+  if (!profile.onboardingCompleted) {
+    return "Пройди анкету в Telegram, чтобы увидеть персональные рекомендации.";
+  }
+  switch (experience.copyTone) {
+    case "aggressive":
+      return "Рекомендуем Supersport и быстрые слоты выдачи — система уже подобрала варианты.";
+    case "premium":
+      return "Для вас выделили подборку с маршрутами, которые выглядят хорошо и в поездке, и на фото.";
+    case "friendly":
+      return profile.experience === "beginner"
+        ? "Рекомендуем начать с контролируемого первого выезда — экип и сопровождение включены."
+        : "Персональный фильтр: меньше случайных карточек, быстрее уверенное решение.";
+    case "discovery":
+      return "Загляните в каталог — система настроила фильтры под ваши интересы.";
+    default:
+      return "Персональный фильтр: меньше случайных карточек, быстрее уверенное решение.";
+  }
+}
+
+// ═══════════════════════════════════════════════════════
+// REMOVED: deriveHeroModeFromSurvey() — replaced by resolve-experience.ts
+// REMOVED: TELEGRAM_BOT_START_LINK constant — replaced by START_LINKS.onboard
+// REMOVED: 60-line vibeProfile memo — replaced by deriveBadge/Title/Note helpers
+// REMOVED: surveyResults useMemo — replaced by resolveVipBikeProfile()
+// REMOVED: manual experience lock — now handled by useBehaviorTracker().persistExperienceLock()
+// ═══════════════════════════════════════════════════════

--- a/app/franchize/lib/onboarding/experience-types.ts
+++ b/app/franchize/lib/onboarding/experience-types.ts
@@ -1,7 +1,7 @@
 /**
  * experience-types.ts
  * ===================
- * Canonical type definitions for the VipBike adaptive onboarding → landing pipeline.
+ * Canonical type definitions for the VipBike adaptive storefront runtime.
  *
  * ARCHITECTURE CONTRACT:
  *   Telegram /start → survey → raw signals in metadata → resolve-profile → resolve-experience → UI
@@ -22,12 +22,12 @@
  *
  * These types are the ONLY shared contract between:
  *   - start.ts (server: writes raw signals to metadata)
- *   - survey-normalizer.ts (shared: interprets survey answers)
+ *   - survey-normalizer.ts (shared: interprets survey signals)
  *   - resolve-profile.ts (client: builds runtime profile from raw signals)
  *   - resolve-experience.ts (client: derives UI composition)
  *   - VipBikeRentalClient.tsx (client: renders sections)
  *
- * RULE: Components NEVER read raw survey answers directly.
+ * RULE: Components NEVER read raw survey signals directly.
  *       They always go through VipBikeUserProfile → VipBikeExperienceConfig.
  */
 
@@ -38,7 +38,7 @@
 
 /**
  * Segment: WHAT kind of rider are they?
- * Derived primarily from bike_style + purpose survey answers.
+ * Derived primarily from bike_style + purpose survey signals.
  * This is NOT a theme — it's a behavioral segment that drives
  * section ordering, copy tone, and CTA priority.
  */
@@ -52,7 +52,7 @@ export type VipBikeSegment =
 
 /**
  * Intent: WHY are they here?
- * Derived from purpose + priority survey answers + behavioral signals.
+ * Derived from purpose + priority survey signals + behavioral signals.
  * This is MORE important than segment for CTA and flow design.
  * "Intent routing, not theme routing."
  */
@@ -64,7 +64,7 @@ export type VipBikeIntent =
 
 /**
  * Experience level: HOW comfortable are they?
- * Derived from the experience survey answer.
+ * Derived from the experience survey signal.
  * Affects copy tone, safety emphasis, and first-ride guidance.
  */
 export type VipBikeExperience =
@@ -81,7 +81,7 @@ export type VipBikeExperience =
  *
  * The profile includes a confidence score because some users:
  *   - skip parts of the survey
- *   - give conflicting answers (e.g., "beginner" + "sport")
+ *   - give conflicting signals (e.g., "beginner" + "sport")
  *   - change behavior over time
  * The resolver can use confidence to decide whether to show
  * a strong personalized experience or a softer universal one.
@@ -105,7 +105,7 @@ export interface VipBikeUserProfile {
 
   /**
    * Confidence score 0-1.
-   * 1.0 = full survey completed recently, consistent answers, reinforced by behavior.
+   * 1.0 = full survey completed recently, consistent signals, reinforced by behavior.
    * 0.5 = partial survey or conflicting signals.
    * 0.0 = no survey data at all (anonymous/new user).
    *
@@ -199,19 +199,25 @@ export interface BehaviorSignals {
   buyIntentClickCount?: number;
   /** How many times user clicked rent on an item */
   rentIntentClickCount?: number;
-  /** ISO timestamp of last map interaction */
+  /** ISO timestamp of last map interaction (for per-intent decay) */
   lastMapInteractionAt?: string;
-  /** ISO timestamp of last buy-flow interaction */
+  /** ISO timestamp of last buy-flow interaction (for per-intent decay) */
   lastBuyInteractionAt?: string;
-  /** ISO timestamp of last rent-flow interaction */
+  /** ISO timestamp of last rent-flow interaction (for per-intent decay) */
   lastRentInteractionAt?: string;
-  /** Models scanned via QR code (from physical world → digital) */
+  /**
+   * Models scanned via QR code (from physical world → digital).
+   * CAPPED at 20 entries — oldest dropped first.
+   */
   scannedQrModels?: string[];
   /** Seconds spent on investment section (proxy for investor interest) */
   investSectionViewSeconds?: number;
   /** ISO timestamp of last activity (for decay calculation) */
   lastActiveAt?: string;
 }
+
+/** Maximum entries in scannedQrModels before FIFO eviction */
+export const SCANNED_QR_MODELS_CAP = 20;
 
 // ─────────────────────────────────────────────────────
 // 2. EXPERIENCE CONFIG — What the UI should show
@@ -247,6 +253,20 @@ export type SectionId =
   | "faq";               // Accordion FAQ
 
 /**
+ * Section complexity — how much cognitive load this section presents.
+ * Used to order sections by complexity for different experience levels.
+ * Beginners see low-complexity sections first.
+ */
+export type SectionComplexity = "low" | "medium" | "high";
+
+/**
+ * Emotional tone a section conveys — used for tone matching.
+ * Sections that match the user's preferred emotional tone are
+ * promoted in the ordering.
+ */
+export type EmotionalTone = "energetic" | "calm" | "premium" | "playful" | "informational";
+
+/**
  * Section capability tags — sections self-describe what they help with.
  *
  * Instead of hardcoding logic like:
@@ -271,10 +291,20 @@ export interface SectionCapabilities {
   relevantIntents?: VipBikeIntent[];
   /** Which experience levels benefit most */
   relevantExperience?: VipBikeExperience[];
+  /** Cognitive complexity of this section */
+  complexity?: SectionComplexity;
+  /** Emotional tone this section conveys */
+  emotionalTone?: EmotionalTone;
   /** Free-form tags for custom matching */
   tags?: string[];
   /** Priority weight (higher = more important for its target audience) */
   weight?: number;
+  /**
+   * Whether this section should be hidden for non-surveyed users.
+   * Sections like investSection are irrelevant for users who haven't
+   * completed onboarding — they'd just add noise.
+   */
+  hideIfNotSurveyed?: boolean;
 }
 
 /**
@@ -413,9 +443,17 @@ export interface ParsedPayload {
   raw: string;
 
   /**
+   * The /start command if present in the original text.
+   * Used by start.ts to distinguish "user typed /start with no payload"
+   * from "user typed a survey answer while in active survey".
+   * Undefined when payload was parsed without a /start prefix.
+   */
+  command?: "/start";
+
+  /**
    * A hint for the survey normalizer.
    * If the payload contains intent info (e.g., "buy.surron"),
-   * the normalizer can use this as a prior even before survey answers arrive.
+   * the normalizer can use this as a prior even before survey signals arrive.
    */
   intentHint?: VipBikeIntent;
 
@@ -428,11 +466,11 @@ export interface ParsedPayload {
 }
 
 // ─────────────────────────────────────────────────────
-// 4. SURVEY ANSWER TYPES — Raw survey data shape
+// 4. SURVEY SIGNAL TYPES — Raw survey data shape
 // ─────────────────────────────────────────────────────
 
 /**
- * The shape of survey answers as stored in metadata.survey_results.
+ * The shape of survey signals as stored in metadata.survey_results.
  * Keys match the survey question keys from start_survey_questions_bike.ts.
  *
  * IMPORTANT: Components should NEVER read these directly.
@@ -478,7 +516,7 @@ export interface BikeSurveyAnswers {
  * Persist raw signals. Derive profile at runtime.
  */
 export interface VipBikeUserMetadata {
-  /** Raw survey answers — the normalizer reads these */
+  /** Raw survey signals — the normalizer reads these */
   survey_results?: BikeSurveyAnswers;
 
   /** Promo code captured at /start time */
@@ -517,28 +555,41 @@ export interface VipBikeUserMetadata {
   /**
    * Anti-thrashing state — persisted so experience stability
    * survives across page navigations and refreshes.
-   * This is raw metadata about WHEN the experience last changed,
-   * NOT derived profile state.
+   * This stores RAW profile signals (segment/intent/experience) at the
+   * time of the last experience change, NOT derived preset names.
+   * The resolver compares current profile vs stored profile to
+   * determine stability, re-deriving the preset at runtime.
    */
   experience_lock?: {
     /** ISO timestamp of when the experience was last changed */
     lastChangedAt?: string;
-    /** The preset name that was active when the lock was set */
-    lastPresetName?: string;
-    /** Consecutive stability count — how many times the same preset was resolved */
+    /**
+     * Raw profile signals at time of last experience resolution.
+     * These are NOT derived — they're the same raw signals that
+     * the profile resolver would use. By storing them here, the
+     * anti-thrashing system can detect profile changes without
+     * persisting a derived preset name.
+     */
+    lastResolvedSegment?: VipBikeSegment;
+    lastResolvedIntent?: VipBikeIntent;
+    lastResolvedExperience?: VipBikeExperience;
+    /** Consecutive stability count — how many times the same profile resolved */
     stabilityCount?: number;
   };
 
   // ═══════════════════════════════════════════════════
   // ⚠️  DO NOT ADD DERIVED FIELDS HERE.
   //
-  // NO ui_profile, NO landing_mode, NO segment_cache.
+  // NO ui_profile, NO landing_mode, NO segment_cache,
+  // NO lastPresetName (that's a derived classification).
   // The profile is ALWAYS derived at runtime from raw signals.
   // If you need to cache, cache in React state / useMemo,
   // never in the database.
   //
-  // Exception: experience_lock is raw timing metadata,
-  // not derived profile state. It records WHEN things
-  // happened, not WHAT the profile is.
+  // Exception: experience_lock stores raw profile signals
+  // (segment/intent/experience) that happen to also exist in
+  // the derived profile. These are raw timing + comparison
+  // metadata, not derived state — they record WHAT the profile
+  // WAS at a point in time, not what the resolver DID with it.
   // ═══════════════════════════════════════════════════
 }

--- a/app/franchize/lib/onboarding/experience-types.ts
+++ b/app/franchize/lib/onboarding/experience-types.ts
@@ -1,0 +1,544 @@
+/**
+ * experience-types.ts
+ * ===================
+ * Canonical type definitions for the VipBike adaptive onboarding → landing pipeline.
+ *
+ * ARCHITECTURE CONTRACT:
+ *   Telegram /start → survey → raw signals in metadata → resolve-profile → resolve-experience → UI
+ *
+ * CRITICAL PRINCIPLE:
+ *   Metadata stores RAW SIGNALS ONLY. Never derived/interpreted state.
+ *   Profile is ALWAYS derived at runtime by resolve-profile.ts.
+ *   Experience is ALWAYS derived at runtime by resolve-experience.ts.
+ *
+ *   Why? Because:
+ *     - Resolver logic evolves → profileResolverVersion tracks which logic produced a profile
+ *     - Segmentation evolves → experienceResolverVersion tracks which logic composed an experience
+ *     - Confidence evolves → intent decay recalculates from timestamps at runtime
+ *     - Onboarding taxonomy evolves → survey version tracks which question set was used
+ *   If profile is persisted, old users get stale logic.
+ *   Persist raw signals. Derive profile at runtime.
+ *   Track resolver versions for OBSERVABILITY, not logic.
+ *
+ * These types are the ONLY shared contract between:
+ *   - start.ts (server: writes raw signals to metadata)
+ *   - survey-normalizer.ts (shared: interprets survey answers)
+ *   - resolve-profile.ts (client: builds runtime profile from raw signals)
+ *   - resolve-experience.ts (client: derives UI composition)
+ *   - VipBikeRentalClient.tsx (client: renders sections)
+ *
+ * RULE: Components NEVER read raw survey answers directly.
+ *       They always go through VipBikeUserProfile → VipBikeExperienceConfig.
+ */
+
+// ─────────────────────────────────────────────────────
+// 1. USER PROFILE — The normalized runtime view of who this user is
+//    NEVER PERSISTED. ALWAYS DERIVED AT RUNTIME.
+// ─────────────────────────────────────────────────────
+
+/**
+ * Segment: WHAT kind of rider are they?
+ * Derived primarily from bike_style + purpose survey answers.
+ * This is NOT a theme — it's a behavioral segment that drives
+ * section ordering, copy tone, and CTA priority.
+ */
+export type VipBikeSegment =
+  | "electro"      // Electric-first: quiet, modern, eco mobility
+  | "sport"        // Performance: speed, adrenaline, track
+  | "urban"        // City riding: commute, convenience, short trips
+  | "retro"        // Neo-retro: style, charisma, photo-worthy
+  | "touring"      // Long distance: comfort, reliability, gear
+  | "mixed";       // No clear segment — universal/default
+
+/**
+ * Intent: WHY are they here?
+ * Derived from purpose + priority survey answers + behavioral signals.
+ * This is MORE important than segment for CTA and flow design.
+ * "Intent routing, not theme routing."
+ */
+export type VipBikeIntent =
+  | "buy"          // Wants to purchase — fast purchase flow, financing, specs
+  | "rent"         // Wants to try — rental flow, availability, scheduling
+  | "explore"      // Browsing — discovery flow, categories, comparison
+  | "community";   // Social — map, group rides, meetups, leaderboard
+
+/**
+ * Experience level: HOW comfortable are they?
+ * Derived from the experience survey answer.
+ * Affects copy tone, safety emphasis, and first-ride guidance.
+ */
+export type VipBikeExperience =
+  | "beginner"     // < 1 year / just got license
+  | "intermediate" // 1-3 years
+  | "advanced";    // 3+ years / pro
+
+/**
+ * Complete normalized user profile.
+ * This is the ONLY object that UI components should consume
+ * to make personalization decisions.
+ *
+ * ⚠️  THIS IS DERIVED AT RUNTIME. NEVER STORED IN THE DATABASE.
+ *
+ * The profile includes a confidence score because some users:
+ *   - skip parts of the survey
+ *   - give conflicting answers (e.g., "beginner" + "sport")
+ *   - change behavior over time
+ * The resolver can use confidence to decide whether to show
+ * a strong personalized experience or a softer universal one.
+ *
+ * Confidence also DECAYS over time. A survey completed 6 months ago
+ * is less reliable than one completed yesterday. The resolver
+ * factors in intent decay when computing confidence.
+ */
+export interface VipBikeUserProfile {
+  /** Behavioral segment — drives section ordering and featured categories */
+  segment: VipBikeSegment;
+
+  /** Primary intent — drives CTA priority and flow design */
+  intent: VipBikeIntent;
+
+  /** Experience level — drives copy tone and safety emphasis */
+  experience: VipBikeExperience;
+
+  /** Whether the user has completed the onboarding survey */
+  onboardingCompleted: boolean;
+
+  /**
+   * Confidence score 0-1.
+   * 1.0 = full survey completed recently, consistent answers, reinforced by behavior.
+   * 0.5 = partial survey or conflicting signals.
+   * 0.0 = no survey data at all (anonymous/new user).
+   *
+   * USE THIS: If confidence < 0.5, prefer universal layout.
+   * Only go full-personalized when confidence >= 0.7.
+   *
+   * Confidence factors:
+   *   - Survey completeness (0-0.75)
+   *   - Answer consistency (0-0.10)
+   *   - Behavioral reinforcement (0-0.15)
+   *   - Intent decay (subtracts over time if no behavioral signals)
+   */
+  confidence: number;
+
+  /** Source tracking — how did they arrive */
+  source?: {
+    /** The promo/referral code they entered via /start payload */
+    promoCode?: string;
+    /** The raw /start payload (for debugging/audit) */
+    payload?: string;
+    /** Which onboarding version produced this profile (for migration) */
+    surveyVersion?: string;
+  };
+
+  /**
+   * Onboarding context — metadata about the survey and resolver versions.
+   * Critical for:
+   *   - Intent decay: older surveys → lower confidence
+   *   - Rerunning onboarding after redesign
+   *   - Migrating old users
+   *   - A/B testing surveys
+   *   - Identifying stale profiles
+   *   - OBSERVABILITY: which resolver versions produced this profile/experience
+   *
+   * VERSION TRACKING IS FOR OBSERVABILITY, NOT LOGIC.
+   * The resolvers always run the latest code. Versions exist so you can:
+   *   - Compare profile distributions across resolver versions
+   *   - Debug: "this user has profileResolverVersion=profile-v1, but v2 would classify differently"
+   *   - A/B test: enable new resolver for subset, compare conversion
+   *   - Analytics: "after profile-v3, electro segment conversion improved 15%"
+   */
+  onboardingContext?: {
+    /** ISO timestamp of survey completion */
+    completedAt?: string;
+    /** Survey version identifier (e.g., "bike-v1", "bike-v2-electro") */
+    version?: string;
+    /** How the user entered the survey: "telegram:start", "web:cta", etc. */
+    entryPoint?: string;
+    /** Profile resolver version that produced the current profile (e.g., "profile-v1") */
+    profileResolverVersion?: string;
+    /** Experience resolver version that produced the current experience (e.g., "exp-v1") */
+    experienceResolverVersion?: string;
+  };
+
+  /**
+   * Behavioral signals — progressive enrichment from user actions.
+   * These are accumulated over time and REINFORCE or OVERRIDE
+   * survey-derived signals.
+   *
+   * Example: A user who answered "sport" in the survey but has
+   * viewed electro bikes 7 times and never looked at sport bikes
+   * should gradually shift toward electro segment.
+   *
+   * These are RAW COUNTERS — the normalizer interprets them.
+   * They are PERSISTED in metadata (unlike the profile itself).
+   */
+  behaviorSignals?: BehaviorSignals;
+}
+
+/**
+ * Progressive enrichment signals.
+ * These accumulate from micro-interactions on the landing page
+ * and gradually shift the profile beyond what the survey captured.
+ *
+ * STORAGE: Persisted in metadata.behavior_signals (raw counts only).
+ * INTERPRETATION: Done by survey-normalizer.ts at runtime.
+ *
+ * This is where the system stops being "survey personalization"
+ * and becomes "adaptive storefront intelligence."
+ */
+export interface BehaviorSignals {
+  /** How many times user viewed electro category items */
+  viewedElectroCount?: number;
+  /** How many times user viewed sport category items */
+  viewedSportCount?: number;
+  /** How many times user viewed retro category items */
+  viewedRetroCount?: number;
+  /** How many times user opened the map */
+  openedMapCount?: number;
+  /** How many times user clicked buy/configure on an item */
+  buyIntentClickCount?: number;
+  /** How many times user clicked rent on an item */
+  rentIntentClickCount?: number;
+  /** ISO timestamp of last map interaction */
+  lastMapInteractionAt?: string;
+  /** ISO timestamp of last buy-flow interaction */
+  lastBuyInteractionAt?: string;
+  /** ISO timestamp of last rent-flow interaction */
+  lastRentInteractionAt?: string;
+  /** Models scanned via QR code (from physical world → digital) */
+  scannedQrModels?: string[];
+  /** Seconds spent on investment section (proxy for investor interest) */
+  investSectionViewSeconds?: number;
+  /** ISO timestamp of last activity (for decay calculation) */
+  lastActiveAt?: string;
+}
+
+// ─────────────────────────────────────────────────────
+// 2. EXPERIENCE CONFIG — What the UI should show
+//    ALWAYS DERIVED AT RUNTIME FROM PROFILE.
+// ─────────────────────────────────────────────────────
+
+/**
+ * Section identifiers — one per visual block on the landing page.
+ * These are the building blocks that resolve-experience.ts can
+ * reorder, show, or hide based on the user's profile.
+ *
+ * CRITICAL: Adding a new section means:
+ *   1. Add the ID here
+ *   2. Add a renderer in VipBikeRentalClient's sectionMap
+ *   3. Add capability tags in SECTION_CAPABILITIES
+ *   4. The resolver picks it up automatically
+ *
+ * That's it. No if/else spaghetti in the component.
+ */
+export type SectionId =
+  | "hero"               // Main hero with video bg + vibeProfile card
+  | "bikeShowcase"       // BikeShowcase component
+  | "conversionPilot"    // "Find your scenario in 30 seconds" decision router
+  | "electroShowcase"    // ElectroEnduroShowcase carousel
+  | "mapPreview"         // MapRidersLivePreview
+  | "gearSection"        // Helmets, gloves, armor grid
+  | "stepsProgress"      // 3-step newbie stepper
+  | "rentalQuickActions" // RentalQuickActionHub
+  | "companyServiceHub"  // VipBikeCompanyServiceHub
+  | "serviceCards"       // Requirements / What client gets / Services
+  | "howItWorks"         // 4-step "How it works" section
+  | "investSection"      // VIP Invest V2 block
+  | "faq";               // Accordion FAQ
+
+/**
+ * Section capability tags — sections self-describe what they help with.
+ *
+ * Instead of hardcoding logic like:
+ *   if (beginner) gearSection early
+ *
+ * Sections declare capabilities, and the resolver scores them
+ * against the user's profile dynamically.
+ *
+ * This unlocks:
+ *   - AI ranking later
+ *   - Experimentation
+ *   - A/B tests
+ *   - Analytics-driven ordering
+ *   - New sections auto-discovered by resolver
+ *
+ * WITHOUT rewriting orchestration.
+ */
+export interface SectionCapabilities {
+  /** Which segments this section is most relevant for */
+  relevantSegments?: VipBikeSegment[];
+  /** Which intents this section serves best */
+  relevantIntents?: VipBikeIntent[];
+  /** Which experience levels benefit most */
+  relevantExperience?: VipBikeExperience[];
+  /** Free-form tags for custom matching */
+  tags?: string[];
+  /** Priority weight (higher = more important for its target audience) */
+  weight?: number;
+}
+
+/**
+ * Hero display mode — which tab is active by default.
+ * This is the PRIMARY personalization signal on the landing.
+ *
+ * MAPPING:
+ *   segment=electro + intent=explore  → "electro-enduro"
+ *   segment=sport                     → "rent"  (rental experience first)
+ *   intent=buy                        → "buy"   (fast purchase flow)
+ *   intent=community                  → "map"   (social/routes)
+ *   default                           → "rent"  (safest default)
+ */
+export type HeroDisplayMode =
+  | "rent"           // Rental-first: availability, pricing, first ride
+  | "buy"            // Purchase-first: specs, financing, comparison
+  | "map"            // Community-first: live routes, riders, meetups
+  | "rentals"        // My rentals: active bookings, quick rebook
+  | "electro-enduro"; // Electric showcase: electro bikes front and center
+
+/**
+ * Primary CTA configuration — what the big button does.
+ * Derived from intent + segment, NOT hardcoded per section.
+ */
+export interface PrimaryCTA {
+  /** Display label (localized Russian) */
+  label: string;
+  /** Navigation target: internal path or external URL */
+  href: string;
+  /** Whether this is an internal route (Link) vs external (anchor) */
+  isExternal: boolean;
+  /** Visual variant */
+  variant: "accent" | "outline" | "brand-yellow";
+}
+
+/**
+ * The complete experience composition.
+ * This is what resolve-experience() returns.
+ * The landing page uses this to render — NO other personalization logic.
+ */
+export interface VipBikeExperienceConfig {
+  /** Which hero tab is active by default */
+  heroMode: HeroDisplayMode;
+
+  /** Primary call-to-action for the vibeProfile card */
+  primaryCTA: PrimaryCTA;
+
+  /** Ordered list of sections to render. Sections NOT in this list are hidden. */
+  sectionOrder: SectionId[];
+
+  /**
+   * Sections that should be visually emphasized (border, glow, larger).
+   * These are the user's "home base" sections — the ones they care most about.
+   */
+  featuredSections: SectionId[];
+
+  /** Which catalog category to feature in ElectroEnduroShowcase */
+  featuredCategory: "electro" | "sport" | "retro" | "all";
+
+  /** Onboarding variant for the vibeProfile card */
+  onboardingVariant: "surveyed" | "not_surveyed" | "partial";
+
+  /** Copy tone for generated text */
+  copyTone: "aggressive" | "friendly" | "premium" | "discovery";
+
+  /** Whether to show the /start deep-link CTA (non-surveyed users) */
+  showOnboardingCTA: boolean;
+
+  /** Whether to show promo code chip */
+  showPromoChip: boolean;
+
+  /** The preset name that best matches this config (for analytics/debugging) */
+  presetName?: string;
+
+  /**
+   * Anti-thrashing metadata — prevents UX from reshuffling too rapidly.
+   *
+   * Problem: Behavioral signals change frequently (view electro, view retro,
+   * view map, view electro). Without stabilization, the landing constantly
+   * reshuffles, hero changes too often, and the UX feels schizophrenic.
+   *
+   * Solution: Lock the experience for a minimum duration after it changes.
+   * Netflix, Spotify, and YouTube all do variants of this.
+   *
+   * These fields are computed by the resolver and consumed by the component
+   * to decide whether to apply a new experience or keep the old one.
+   */
+  antiThrashing?: {
+    /** ISO timestamp when this experience was first computed */
+    computedAt: string;
+    /** Minimum milliseconds before the experience can change again */
+    minimumDurationMs: number;
+    /** ISO timestamp after which a new experience can be applied */
+    lockedUntil: string;
+    /** How many consecutive times the same profile produced this experience (stability counter) */
+    stabilityCount: number;
+  };
+
+  /**
+   * Resolver version that produced this experience (for observability).
+   * NOT used for logic — always runs latest code.
+   * Used for: analytics, A/B testing, debugging.
+   */
+  experienceResolverVersion?: string;
+}
+
+// ─────────────────────────────────────────────────────
+// 3. PAYLOAD TYPES — Structured /start deep-link payloads
+// ─────────────────────────────────────────────────────
+
+/**
+ * Structured payload that can be embedded in Telegram deep-links.
+ *
+ * CONVENTION: Use dot-notation for structured payloads.
+ *
+ * Examples:
+ *   /start entry.electro          → user enters via electro campaign
+ *   /start promo.NEON2026         → user has a promo code
+ *   /start buy.surron             → user wants to buy a Surron
+ *   /start map.groupride          → user wants group rides
+ *   /start ref_ALEX2026           → referral code (legacy format)
+ *   /start VIPSTART               → bare code (legacy format)
+ *
+ * The payload parser handles both new structured format and legacy formats.
+ */
+export type PayloadType = "entry" | "promo" | "buy" | "map" | "ref" | "invite" | "code" | "bare";
+
+export interface ParsedPayload {
+  /** The type of payload (determined by prefix) */
+  type: PayloadType;
+
+  /** The code/value after the prefix (uppercased, trimmed, max 64 chars) */
+  code: string;
+
+  /** The original raw payload string (for audit/logging) */
+  raw: string;
+
+  /**
+   * A hint for the survey normalizer.
+   * If the payload contains intent info (e.g., "buy.surron"),
+   * the normalizer can use this as a prior even before survey answers arrive.
+   */
+  intentHint?: VipBikeIntent;
+
+  /**
+   * A hint for the segment resolver.
+   * If the payload contains segment info (e.g., "entry.electro"),
+   * the resolver can pre-seed the segment.
+   */
+  segmentHint?: VipBikeSegment;
+}
+
+// ─────────────────────────────────────────────────────
+// 4. SURVEY ANSWER TYPES — Raw survey data shape
+// ─────────────────────────────────────────────────────
+
+/**
+ * The shape of survey answers as stored in metadata.survey_results.
+ * Keys match the survey question keys from start_survey_questions_bike.ts.
+ *
+ * IMPORTANT: Components should NEVER read these directly.
+ * Always go through resolve-profile.ts → VipBikeUserProfile.
+ * These types exist ONLY for the normalizer to consume.
+ */
+export interface BikeSurveyAnswers {
+  /** "Новичок (до 1 года)" | "Опытный (1-3 года)" | "Профи (3+ лет)" | "Только что получил права" */
+  experience?: string;
+
+  /** "В городе, между рядами" | "На гоночном треке" | "На извилистых загородных дорогах" | "Для дальних поездок" */
+  purpose?: string;
+
+  /** "Агрессивный нейкед (стритфайтер)" | "Суперспорт (обтекатели, поза эмбриона)" | "Спорт-турист (мощность и комфорт)" | "Нео-ретро (стиль и харизма)" */
+  bike_style?: string;
+
+  /** "Бешеное ускорение и адреналин" | "Острая управляемость и маневренность" | "Внешний вид и внимание на дороге" | "Удобство посадки и технологии" */
+  priority?: string;
+
+  /** "Да, я готов(а)!" | "Нужно подумать" */
+  terms_agreement?: string;
+}
+
+// ─────────────────────────────────────────────────────
+// 5. METADATA SHAPE — What gets persisted in the database
+//    RAW SIGNALS ONLY. NO DERIVED STATE.
+// ─────────────────────────────────────────────────────
+
+/**
+ * The shape of user metadata as stored in the database.
+ * This is what dbUser.metadata looks like.
+ *
+ * ⚠️  CRITICAL: Only raw signals are persisted here.
+ *     NO derived/interpreted state (ui_profile, landing_mode, etc.)
+ *     Everything derived is computed at runtime by resolve-profile.ts.
+ *
+ * Why? Because:
+ *   - Resolver logic evolves → old persisted profiles become stale
+ *   - Segmentation evolves → old profiles get wrong segments
+ *   - Confidence evolves → old profiles have wrong confidence
+ *   - Impossible to re-interpret users globally if profile is persisted
+ *
+ * Persist raw signals. Derive profile at runtime.
+ */
+export interface VipBikeUserMetadata {
+  /** Raw survey answers — the normalizer reads these */
+  survey_results?: BikeSurveyAnswers;
+
+  /** Promo code captured at /start time */
+  onboarding_promo_code?: string;
+
+  /** Raw /start payload captured at /start time */
+  onboarding_start_payload?: string;
+
+  /**
+   * Onboarding context — when/how the survey was completed.
+   * Used for intent decay calculation (older surveys → lower confidence).
+   */
+  onboarding_context?: {
+    /** ISO timestamp of survey completion */
+    completedAt?: string;
+    /** Survey version identifier (e.g., "bike-v1") */
+    version?: string;
+    /** How the user entered the survey: "telegram:start", "web:cta", etc. */
+    entryPoint?: string;
+    /** Profile resolver version (e.g., "profile-v1") — for observability */
+    profileResolverVersion?: string;
+    /** Experience resolver version (e.g., "exp-v1") — for observability */
+    experienceResolverVersion?: string;
+  };
+
+  /**
+   * Behavioral signals — progressive enrichment from user actions.
+   * Accumulated over time. The normalizer uses these to reinforce
+   * or override survey-derived signals.
+   *
+   * These are RAW COUNTERS — no interpretation, just facts.
+   * The normalizer decides what they mean at runtime.
+   */
+  behavior_signals?: BehaviorSignals;
+
+  /**
+   * Anti-thrashing state — persisted so experience stability
+   * survives across page navigations and refreshes.
+   * This is raw metadata about WHEN the experience last changed,
+   * NOT derived profile state.
+   */
+  experience_lock?: {
+    /** ISO timestamp of when the experience was last changed */
+    lastChangedAt?: string;
+    /** The preset name that was active when the lock was set */
+    lastPresetName?: string;
+    /** Consecutive stability count — how many times the same preset was resolved */
+    stabilityCount?: number;
+  };
+
+  // ═══════════════════════════════════════════════════
+  // ⚠️  DO NOT ADD DERIVED FIELDS HERE.
+  //
+  // NO ui_profile, NO landing_mode, NO segment_cache.
+  // The profile is ALWAYS derived at runtime from raw signals.
+  // If you need to cache, cache in React state / useMemo,
+  // never in the database.
+  //
+  // Exception: experience_lock is raw timing metadata,
+  // not derived profile state. It records WHEN things
+  // happened, not WHAT the profile is.
+  // ═══════════════════════════════════════════════════
+}

--- a/app/franchize/lib/onboarding/index.ts
+++ b/app/franchize/lib/onboarding/index.ts
@@ -1,0 +1,68 @@
+/**
+ * index.ts
+ * ========
+ * Barrel export for the adaptive storefront runtime pipeline.
+ *
+ * Import everything from here:
+ *   import { resolveVipBikeProfile, resolveVipBikeExperience, START_LINKS } from "@/app/franchize/lib/onboarding";
+ *
+ * CRITICAL: This pipeline is franchise-scoped. The vip-bike normalizer
+ * and resolver live here. Other franchises should create their own
+ * onboarding/ directory with franchise-specific normalizers.
+ * Types and payload-parser are shared across franchises.
+ */
+
+// Types
+export type {
+  VipBikeUserProfile,
+  VipBikeExperienceConfig,
+  VipBikeSegment,
+  VipBikeIntent,
+  VipBikeExperience,
+  HeroDisplayMode,
+  SectionId,
+  SectionCapabilities,
+  PrimaryCTA,
+  ParsedPayload,
+  PayloadType,
+  BikeSurveyAnswers,
+  BehaviorSignals,
+  VipBikeUserMetadata,
+} from "./experience-types";
+
+// Payload parser
+export {
+  parseStartPayload,
+  parsePayload,
+  extractPromoCode,
+  buildStartLink,
+  START_LINKS,
+} from "./payload-parser";
+
+// Survey normalizer
+export {
+  normalizeSurveyToProfile,
+  createDefaultProfile,
+} from "./survey-normalizer";
+
+// Profile resolver (THE entry point for components)
+export { resolveVipBikeProfile, PROFILE_RESOLVER_VERSION } from "./resolve-profile";
+
+// Experience resolver (THE entry point for UI composition)
+export {
+  resolveVipBikeExperience,
+  resolveHero,
+  resolveSectionPriority,
+  resolveCTA,
+  resolveFeaturedSections,
+  isExperienceLocked,
+  combinePresets,
+  getAvailablePresets,
+  EXPERIENCE_RESOLVER_VERSION,
+} from "./resolve-experience";
+
+// Section capability registry (for extending section metadata)
+export { SECTION_CAPABILITIES } from "./resolve-experience";
+
+// Experience preset type (for debugging/analytics)
+export type { ExperiencePreset } from "./resolve-experience";

--- a/app/franchize/lib/onboarding/index.ts
+++ b/app/franchize/lib/onboarding/index.ts
@@ -21,6 +21,8 @@ export type {
   VipBikeExperience,
   HeroDisplayMode,
   SectionId,
+  SectionComplexity,
+  EmotionalTone,
   SectionCapabilities,
   PrimaryCTA,
   ParsedPayload,
@@ -29,6 +31,9 @@ export type {
   BehaviorSignals,
   VipBikeUserMetadata,
 } from "./experience-types";
+
+// Constants
+export { SCANNED_QR_MODELS_CAP } from "./experience-types";
 
 // Payload parser
 export {
@@ -43,6 +48,7 @@ export {
 export {
   normalizeSurveyToProfile,
   createDefaultProfile,
+  decayByAge,
 } from "./survey-normalizer";
 
 // Profile resolver (THE entry point for components)
@@ -58,11 +64,18 @@ export {
   isExperienceLocked,
   combinePresets,
   getAvailablePresets,
+  computeExperienceLockUpdate,
   EXPERIENCE_RESOLVER_VERSION,
 } from "./resolve-experience";
+
+// Experience lock type (for persisting anti-thrashing state)
+export type { ExperienceLockState } from "./resolve-experience";
 
 // Section capability registry (for extending section metadata)
 export { SECTION_CAPABILITIES } from "./resolve-experience";
 
 // Experience preset type (for debugging/analytics)
 export type { ExperiencePreset } from "./resolve-experience";
+
+// Behavior tracker hook (for progressive enrichment + lock writeback)
+export { useBehaviorTracker } from "./track-behavior";

--- a/app/franchize/lib/onboarding/payload-parser.ts
+++ b/app/franchize/lib/onboarding/payload-parser.ts
@@ -1,0 +1,214 @@
+/**
+ * payload-parser.ts
+ * =================
+ * Parses structured /start deep-link payloads for the Telegram bot.
+ *
+ * This module is used by start.ts (server-side) to interpret
+ * the payload that comes after /start in a Telegram deep-link.
+ *
+ * CONVENTION:
+ *   New format (structured):  entry.electro  promo.NEON2026  buy.surron  map.groupride
+ *   Legacy format (prefix):   ref_ALEX2026   invite:CODE     code-CODE   promo=CODE
+ *   Bare format:              VIPSTART
+ *
+ * DESIGN PRINCIPLE:
+ *   The parser produces a ParsedPayload with type + code + hints.
+ *   The hints (intentHint, segmentHint) allow the system to
+ *   pre-seed personalization BEFORE the survey even starts.
+ *
+ *   Example: /start entry.electro
+ *     → type: "entry", code: "ELECTRO", segmentHint: "electro", intentHint: "explore"
+ *
+ *   This means even if the user hasn't answered a single survey question,
+ *   the landing page can already show electro-focused content.
+ *   The survey then REFINES the profile; the payload SEEDS it.
+ *
+ * TELEGRAM DEEP-LINK FORMAT:
+ *   https://t.me/oneBikePlsBot?start=<payload>
+ *
+ * EXAMPLES IN THE WILD:
+ *   https://t.me/oneBikePlsBot?start=entry.electro        → Electro campaign landing
+ *   https://t.me/oneBikePlsBot?start=promo.NEON2026       → Promo code NEON2026
+ *   https://t.me/oneBikePlsBot?start=buy.surron           → Direct buy intent for Surron
+ *   https://t.me/oneBikePlsBot?start=map.groupride        → Community/group rides entry
+ *   https://t.me/oneBikePlsBot?start=VIPSTART             → Legacy bare code
+ */
+
+import type { ParsedPayload, PayloadType, VipBikeIntent, VipBikeSegment } from "./experience-types";
+
+// ─────────────────────────────────────────────────────
+// Structured payload prefix → (type, intent, segment) mapping
+// ─────────────────────────────────────────────────────
+
+const STRUCTURED_PREFIX_MAP: Record<
+  string,
+  { type: PayloadType; intentHint?: VipBikeIntent; segmentHint?: VipBikeSegment }
+> = {
+  // Entry points — campaign-specific onboarding
+  entry:   { type: "entry",  intentHint: "explore",   segmentHint: undefined },
+  electro: { type: "entry",  intentHint: "explore",   segmentHint: "electro"  },
+  sport:   { type: "entry",  intentHint: "rent",      segmentHint: "sport"    },
+  retro:   { type: "entry",  intentHint: "explore",   segmentHint: "retro"    },
+  touring: { type: "entry",  intentHint: "explore",   segmentHint: "touring"  },
+  urban:   { type: "entry",  intentHint: "rent",      segmentHint: "urban"    },
+
+  // Intent-specific entries
+  buy:     { type: "buy",    intentHint: "buy",       segmentHint: undefined },
+  map:     { type: "map",    intentHint: "community", segmentHint: undefined },
+  rent:    { type: "entry",  intentHint: "rent",      segmentHint: undefined },
+};
+
+// Legacy prefix patterns: "promo=CODE", "ref_CODE", "invite:CODE", "code-CODE"
+const LEGACY_PREFIX_RE = /^(promo|ref|invite|code)[:=_-](.+)$/i;
+
+// ─────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────
+
+/**
+ * Parses the raw text from a Telegram /start message into a structured payload.
+ *
+ * Examples:
+ *   "/start"               → { type: "bare", code: "", raw: "" }
+ *   "/start entry.electro" → { type: "entry", code: "ELECTRO", raw: "entry.electro", segmentHint: "electro", intentHint: "explore" }
+ *   "/start promo.NEON26"  → { type: "promo", code: "NEON26", raw: "promo.NEON26", intentHint: undefined }
+ *   "/start ref_ALEX26"    → { type: "ref", code: "ALEX26", raw: "ref_ALEX26" }
+ *   "/start VIPSTART"      → { type: "bare", code: "VIPSTART", raw: "VIPSTART" }
+ */
+export function parseStartPayload(text?: string): ParsedPayload {
+  if (!text) return { type: "bare", code: "", raw: "" };
+
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("/start")) return { type: "bare", code: "", raw: trimmed };
+
+  const [_cmd, ...rest] = trimmed.split(/\s+/);
+  const payload = rest.join(" ").trim();
+
+  if (!payload) return { type: "bare", code: "", raw: "" };
+
+  return parsePayload(payload);
+}
+
+/**
+ * Parses the payload string (without the /start prefix).
+ * This is the core parser — usable both in start.ts and in tests.
+ *
+ * Priority:
+ *   1. Structured dot-notation: "entry.electro", "buy.surron", "promo.NEON26"
+ *   2. Legacy prefix patterns:  "ref_ALEX26", "invite:CODE", "code-CODE", "promo=CODE"
+ *   3. Bare code:               "VIPSTART", "NEON2026"
+ */
+export function parsePayload(payload: string): ParsedPayload {
+  if (!payload) return { type: "bare", code: "", raw: "" };
+
+  const decoded = decodeURIComponent(payload).trim();
+
+  // 1. Structured dot-notation: "prefix.value"
+  const dotIndex = decoded.indexOf(".");
+  if (dotIndex > 0 && dotIndex < decoded.length - 1) {
+    const prefix = decoded.slice(0, dotIndex).toLowerCase();
+    const value = decoded.slice(dotIndex + 1).trim().toUpperCase().slice(0, 64);
+
+    const mapping = STRUCTURED_PREFIX_MAP[prefix];
+    if (mapping) {
+      return {
+        type: mapping.type,
+        code: value,
+        raw: decoded,
+        intentHint: mapping.intentHint,
+        segmentHint: mapping.segmentHint,
+      };
+    }
+
+    // Unknown structured prefix — treat as promo-like
+    return {
+      type: "promo",
+      code: value,
+      raw: decoded,
+      intentHint: undefined,
+      segmentHint: undefined,
+    };
+  }
+
+  // 2. Legacy prefix patterns: "promo=CODE", "ref_CODE", "invite:CODE", "code-CODE"
+  const legacyMatch = decoded.match(LEGACY_PREFIX_RE);
+  if (legacyMatch) {
+    const legacyType = legacyMatch[1].toLowerCase() as PayloadType;
+    const code = legacyMatch[2].trim().toUpperCase().slice(0, 64);
+    return {
+      type: legacyType,
+      code,
+      raw: decoded,
+    };
+  }
+
+  // 3. Bare code
+  const normalized = decoded.toUpperCase().slice(0, 64);
+  return {
+    type: "bare",
+    code: normalized,
+    raw: decoded,
+  };
+}
+
+/**
+ * Extracts just the promo/referral code from a payload.
+ * This is a convenience wrapper for backward compatibility
+ * with the existing extractPromoCode() in start.ts.
+ *
+ * Returns null if no code can be extracted.
+ */
+export function extractPromoCode(payload: string): string | null {
+  const parsed = parsePayload(payload);
+  if (!parsed.code) return null;
+
+  // All payload types with a code can be treated as a promo source
+  // except "entry" payloads which are campaign markers, not codes.
+  if (parsed.type === "entry" || parsed.type === "map" || parsed.type === "buy") {
+    // These are intent signals, not promo codes.
+    // But we still persist the raw payload for audit.
+    return null;
+  }
+
+  return parsed.code;
+}
+
+// ─────────────────────────────────────────────────────
+// Deep-link URL builder
+// ─────────────────────────────────────────────────────
+
+const BOT_USERNAME = "oneBikePlsBot";
+
+/**
+ * Builds a Telegram deep-link URL for the /start command.
+ *
+ * Examples:
+ *   buildStartLink("entry.electro")       → "https://t.me/oneBikePlsBot?start=entry.electro"
+ *   buildStartLink("promo.NEON2026")      → "https://t.me/oneBikePlsBot?start=promo.NEON2026"
+ *   buildStartLink(undefined, "onboard")  → "https://t.me/oneBikePlsBot?start=onboard"
+ */
+export function buildStartLink(payload?: string, fallback = "onboard"): string {
+  const encoded = encodeURIComponent(payload || fallback);
+  return `https://t.me/${BOT_USERNAME}?start=${encoded}`;
+}
+
+/**
+ * Pre-built deep-link constants for common use cases.
+ * Use these in components instead of hand-coding URLs.
+ */
+export const START_LINKS = {
+  /** Default onboarding entry (generic) */
+  onboard: buildStartLink("onboard"),
+  /** Electro campaign entry */
+  electro: buildStartLink("entry.electro"),
+  /** Sport campaign entry */
+  sport: buildStartLink("entry.sport"),
+  /** Retro/neo-retro campaign entry */
+  retro: buildStartLink("entry.retro"),
+  /** Map/community entry */
+  mapRide: buildStartLink("map.groupride"),
+  /** Direct buy intent */
+  buy: buildStartLink("buy.bike"),
+  /** Build a promo-specific link */
+  promo: (code: string) => buildStartLink(`promo.${code}`),
+} as const;

--- a/app/franchize/lib/onboarding/payload-parser.ts
+++ b/app/franchize/lib/onboarding/payload-parser.ts
@@ -40,6 +40,13 @@ import type { ParsedPayload, PayloadType, VipBikeIntent, VipBikeSegment } from "
 // Structured payload prefix → (type, intent, segment) mapping
 // ─────────────────────────────────────────────────────
 
+/**
+ * Maps structured prefixes to their payload type and profile hints.
+ *
+ * IMPORTANT: segmentHint drives WHAT (bike type), intentHint drives WHY.
+ * Don't conflate them — "sport" segment doesn't mean "rent" intent.
+ * A sport rider could want to buy, rent, or explore.
+ */
 const STRUCTURED_PREFIX_MAP: Record<
   string,
   { type: PayloadType; intentHint?: VipBikeIntent; segmentHint?: VipBikeSegment }
@@ -47,12 +54,12 @@ const STRUCTURED_PREFIX_MAP: Record<
   // Entry points — campaign-specific onboarding
   entry:   { type: "entry",  intentHint: "explore",   segmentHint: undefined },
   electro: { type: "entry",  intentHint: "explore",   segmentHint: "electro"  },
-  sport:   { type: "entry",  intentHint: "rent",      segmentHint: "sport"    },
+  sport:   { type: "entry",  intentHint: "explore",   segmentHint: "sport"    },
   retro:   { type: "entry",  intentHint: "explore",   segmentHint: "retro"    },
   touring: { type: "entry",  intentHint: "explore",   segmentHint: "touring"  },
-  urban:   { type: "entry",  intentHint: "rent",      segmentHint: "urban"    },
+  urban:   { type: "entry",  intentHint: "explore",   segmentHint: "urban"    },
 
-  // Intent-specific entries
+  // Intent-specific entries — the payload explicitly declares WHY they're here
   buy:     { type: "buy",    intentHint: "buy",       segmentHint: undefined },
   map:     { type: "map",    intentHint: "community", segmentHint: undefined },
   rent:    { type: "entry",  intentHint: "rent",      segmentHint: undefined },
@@ -69,11 +76,11 @@ const LEGACY_PREFIX_RE = /^(promo|ref|invite|code)[:=_-](.+)$/i;
  * Parses the raw text from a Telegram /start message into a structured payload.
  *
  * Examples:
- *   "/start"               → { type: "bare", code: "", raw: "" }
- *   "/start entry.electro" → { type: "entry", code: "ELECTRO", raw: "entry.electro", segmentHint: "electro", intentHint: "explore" }
- *   "/start promo.NEON26"  → { type: "promo", code: "NEON26", raw: "promo.NEON26", intentHint: undefined }
- *   "/start ref_ALEX26"    → { type: "ref", code: "ALEX26", raw: "ref_ALEX26" }
- *   "/start VIPSTART"      → { type: "bare", code: "VIPSTART", raw: "VIPSTART" }
+ *   "/start"               → { type: "bare", code: "", raw: "", command: "/start" }
+ *   "/start entry.electro" → { type: "entry", code: "ELECTRO", raw: "entry.electro", command: "/start", segmentHint: "electro", intentHint: "explore" }
+ *   "/start promo.NEON26"  → { type: "promo", code: "NEON26", raw: "promo.NEON26", command: "/start" }
+ *   "/start ref_ALEX26"    → { type: "ref", code: "ALEX26", raw: "ref_ALEX26", command: "/start" }
+ *   "/start VIPSTART"      → { type: "bare", code: "VIPSTART", raw: "VIPSTART", command: "/start" }
  */
 export function parseStartPayload(text?: string): ParsedPayload {
   if (!text) return { type: "bare", code: "", raw: "" };
@@ -84,9 +91,10 @@ export function parseStartPayload(text?: string): ParsedPayload {
   const [_cmd, ...rest] = trimmed.split(/\s+/);
   const payload = rest.join(" ").trim();
 
-  if (!payload) return { type: "bare", code: "", raw: "" };
+  if (!payload) return { type: "bare", code: "", raw: "", command: "/start" };
 
-  return parsePayload(payload);
+  const parsed = parsePayload(payload);
+  return { ...parsed, command: "/start" };
 }
 
 /**

--- a/app/franchize/lib/onboarding/resolve-experience.ts
+++ b/app/franchize/lib/onboarding/resolve-experience.ts
@@ -12,7 +12,7 @@
  *   - Community users see map/social flow
  *   - Renters see availability/scheduling flow
  *
- * FIVE INNOVATIONS vs v1:
+ * SIX INNOVATIONS vs v1:
  *
  *   1. SECTION CAPABILITIES: Sections self-describe what they help with.
  *      Instead of hardcoding "if beginner -> gearSection early", sections
@@ -27,6 +27,7 @@
  *   3. COMBINE PRESETS: Instead of a single if/else chain that grows
  *      into 1500 lines, the resolver composes multiple small presets
  *      and merges them. This prevents resolver entropy.
+ *      NOW ACTUALLY USED in the resolution path.
  *
  *   4. ANTI-THRASHING: Behavioral signals change rapidly (view electro,
  *      view retro, view map, view electro). Without stabilization,
@@ -36,6 +37,11 @@
  *   5. RESOLVER VERSIONING: Every resolver output includes its version
  *      for observability. NOT used for logic — always runs latest code.
  *      Used for: analytics, A/B testing, debugging.
+ *
+ *   6. NO HARDCODED RULES: All section ordering is driven by
+ *      SECTION_CAPABILITIES scoring + preset composition.
+ *      No imperative splice/filter in resolveSectionPriority.
+ *      Visibility rules (hideIfNotSurveyed) are declarative.
  *
  * MODULAR ARCHITECTURE:
  *   resolveVipBikeExperience(profile)
@@ -49,6 +55,7 @@
  *
  * CRITICAL: This function is PURE. No side effects, no I/O.
  * It should be called inside useMemo in the component.
+ * Experience lock writeback is the COMPONENT's responsibility.
  */
 
 import type {
@@ -56,6 +63,7 @@ import type {
   VipBikeExperienceConfig,
   VipBikeSegment,
   VipBikeIntent,
+  VipBikeExperience,
   HeroDisplayMode,
   SectionId,
   SectionCapabilities,
@@ -76,8 +84,7 @@ import type {
  *   - A/B testing: enable new resolver for a subset, compare conversion
  *
  * When you change section ordering logic, preset definitions, or CTA resolution,
- * bump this version. The version is included in the experience config so
- * downstream systems (analytics, logging) can attribute UX decisions.
+ * bump this version.
  */
 export const EXPERIENCE_RESOLVER_VERSION = "exp-v1" as const;
 
@@ -97,12 +104,16 @@ export const SECTION_CAPABILITIES: Record<SectionId, SectionCapabilities> = {
   hero: {
     relevantSegments: [],
     relevantIntents: [],
+    complexity: "low",
+    emotionalTone: "energetic",
     tags: ["universal", "entry"],
     weight: 100, // Always first
   },
   bikeShowcase: {
     relevantSegments: ["sport", "touring"],
     relevantIntents: ["explore", "rent"],
+    complexity: "medium",
+    emotionalTone: "energetic",
     tags: ["discovery", "catalog"],
     weight: 60,
   },
@@ -110,60 +121,83 @@ export const SECTION_CAPABILITIES: Record<SectionId, SectionCapabilities> = {
     relevantSegments: [],
     relevantIntents: ["buy", "rent"],
     relevantExperience: ["beginner"],
+    complexity: "low",
+    emotionalTone: "playful",
     tags: ["decision", "funnel"],
     weight: 80,
   },
   electroShowcase: {
     relevantSegments: ["electro"],
     relevantIntents: ["explore", "buy"],
+    complexity: "medium",
+    emotionalTone: "premium",
     tags: ["electro", "featured", "catalog"],
     weight: 85,
   },
   mapPreview: {
     relevantSegments: ["mixed", "urban"],
     relevantIntents: ["community"],
+    complexity: "low",
+    emotionalTone: "playful",
     tags: ["social", "map", "live"],
     weight: 75,
   },
   gearSection: {
     relevantExperience: ["beginner"],
+    complexity: "low",
+    emotionalTone: "calm",
     tags: ["safety", "equipment", "beginner"],
     weight: 50,
   },
   stepsProgress: {
     relevantExperience: ["beginner"],
     relevantIntents: ["rent"],
+    complexity: "low",
+    emotionalTone: "calm",
     tags: ["onboarding", "steps", "beginner"],
     weight: 40,
   },
   rentalQuickActions: {
     relevantIntents: ["rent"],
     relevantExperience: ["intermediate", "advanced"],
+    complexity: "low",
+    emotionalTone: "energetic",
     tags: ["rental", "quick-action", "availability"],
     weight: 70,
   },
   companyServiceHub: {
+    complexity: "medium",
+    emotionalTone: "informational",
     tags: ["info", "services"],
     weight: 30,
   },
   serviceCards: {
     relevantIntents: ["buy", "rent"],
+    complexity: "medium",
+    emotionalTone: "informational",
     tags: ["pricing", "requirements", "trust"],
     weight: 45,
   },
   howItWorks: {
     relevantExperience: ["beginner"],
     relevantIntents: ["rent", "buy"],
+    complexity: "low",
+    emotionalTone: "calm",
     tags: ["process", "steps"],
     weight: 35,
   },
   investSection: {
     relevantIntents: ["buy"],
     relevantExperience: ["advanced"],
+    complexity: "high",
+    emotionalTone: "premium",
+    hideIfNotSurveyed: true,
     tags: ["invest", "premium", "monetization"],
     weight: 25,
   },
   faq: {
+    complexity: "low",
+    emotionalTone: "informational",
     tags: ["info", "support"],
     weight: 20,
   },
@@ -301,6 +335,46 @@ const PRESETS: ExperiencePreset[] = [
     },
   },
   {
+    name: "urbanCommuter",
+    segment: "urban",
+    intent: "rent",
+    heroMode: "rent",
+    sectionOrder: [
+      "hero", "rentalQuickActions", "bikeShowcase", "conversionPilot",
+      "mapPreview", "electroShowcase", "serviceCards", "gearSection",
+      "stepsProgress", "howItWorks", "companyServiceHub", "investSection", "faq",
+    ],
+    featuredSections: ["rentalQuickActions", "mapPreview"],
+    featuredCategory: "all",
+    copyTone: "friendly",
+    primaryCTA: {
+      label: "Выбрать аренду",
+      href: "/franchize/vip-bike",
+      isExternal: false,
+      variant: "accent",
+    },
+  },
+  {
+    name: "touringExplorer",
+    segment: "touring",
+    intent: "explore",
+    heroMode: "rent",
+    sectionOrder: [
+      "hero", "bikeShowcase", "mapPreview", "electroShowcase", "conversionPilot",
+      "serviceCards", "gearSection", "rentalQuickActions", "howItWorks",
+      "stepsProgress", "companyServiceHub", "investSection", "faq",
+    ],
+    featuredSections: ["bikeShowcase", "mapPreview"],
+    featuredCategory: "all",
+    copyTone: "premium",
+    primaryCTA: {
+      label: "Смотреть подборку",
+      href: "/franchize/vip-bike",
+      isExternal: false,
+      variant: "outline",
+    },
+  },
+  {
     name: "universal",
     segment: "mixed",
     intent: "explore",
@@ -323,7 +397,7 @@ const PRESETS: ExperiencePreset[] = [
 ];
 
 // ─────────────────────────────────────────────────────
-// 3. Preset composition
+// 3. Preset composition (ACTUALLY USED in resolution)
 // ─────────────────────────────────────────────────────
 
 /**
@@ -405,6 +479,32 @@ function findBestPreset(profile: VipBikeUserProfile): ExperiencePreset {
   return PRESETS.find((p) => p.name === "universal")!;
 }
 
+/**
+ * Finds supplementary presets to compose with the primary preset.
+ * This is where combinePresets actually gets used.
+ *
+ * Rules:
+ *   - Beginner experience → compose with safeBeginner (promotes gearSection, stepsProgress)
+ *   - Low confidence → compose with universal (ensures all sections present)
+ *   - Only one supplementary preset composed at a time to avoid over-complexity
+ */
+function findSupplementaryPreset(profile: VipBikeUserProfile): ExperiencePreset | null {
+  // Beginners always get the safe beginner composition
+  if (profile.experience === "beginner" && profile.onboardingCompleted) {
+    const beginner = PRESETS.find((p) => p.name === "safeBeginner")!;
+    // Don't compose safeBeginner with itself
+    if (findBestPreset(profile).name === "safeBeginner") return null;
+    return beginner;
+  }
+
+  // Low confidence users get universal composition to avoid missing sections
+  if (profile.confidence < 0.5 && profile.confidence >= 0.3) {
+    return PRESETS.find((p) => p.name === "universal")!;
+  }
+
+  return null;
+}
+
 // ─────────────────────────────────────────────────────
 // 5. Modular resolvers — each independently testable
 // ─────────────────────────────────────────────────────
@@ -426,7 +526,7 @@ export function resolveHero(profile: VipBikeUserProfile): HeroDisplayMode {
   if (profile.intent === "buy") return "buy";
   if (profile.intent === "community") return "map";
 
-  // Segment-specific hero for explore intent
+  // Segment-specific hero for explore/rent intent
   if (profile.segment === "electro") return "electro-enduro";
 
   // Default
@@ -438,55 +538,54 @@ export function resolveHero(profile: VipBikeUserProfile): HeroDisplayMode {
  * This is the scoring engine — sections self-describe capabilities,
  * and this function ranks them against the profile.
  *
- * Separated from the main resolver for:
- *   - Independent testing
- *   - Experimentation with different scoring algorithms
- *   - AI-driven ranking later (swap this function, nothing else changes)
+ * NO HARDCODED RULES: All ordering is driven by:
+ *   1. Preset composition (combinePresets with primary + supplementary)
+ *   2. Capability scoring (scoreSection)
+ *   3. Declarative visibility (hideIfNotSurveyed)
+ *
+ * No imperative splice/filter for specific sections.
  */
 export function resolveSectionPriority(profile: VipBikeUserProfile): SectionId[] {
-  // Low confidence → universal order
+  // Low confidence → universal order (no personalization)
   if (profile.confidence < 0.3) {
-    return PRESETS.find((p) => p.name === "universal")!.sectionOrder;
+    const universal = PRESETS.find((p) => p.name === "universal")!;
+    return applyVisibilityRules(universal.sectionOrder, profile);
   }
 
-  // Find best preset and refine with capability scoring
-  const preset = findBestPreset(profile);
-  let sectionOrder = refineSectionOrder(preset.sectionOrder, profile);
+  // Find primary preset and optional supplementary preset
+  const primaryPreset = findBestPreset(profile);
+  const supplementaryPreset = findSupplementaryPreset(profile);
 
-  // ── Special rules (these would become preset compositions later) ──
+  // Compose presets — THIS IS WHERE combinePresets IS ACTUALLY USED
+  let sectionOrder = supplementaryPreset
+    ? combinePresets([primaryPreset, supplementaryPreset])
+    : primaryPreset.sectionOrder;
 
-  // Electro segment: ALWAYS show electro showcase early
-  if (profile.segment === "electro") {
-    const electroIndex = sectionOrder.indexOf("electroShowcase");
-    if (electroIndex > 1) {
-      sectionOrder = [
-        sectionOrder[0], // hero
-        "electroShowcase",
-        ...sectionOrder.slice(1, electroIndex),
-        ...sectionOrder.slice(electroIndex + 1),
-      ];
-    }
-  }
+  // Refine with capability scoring
+  sectionOrder = refineSectionOrder(sectionOrder, profile);
 
-  // Beginners: ensure gearSection is prominent
-  if (profile.experience === "beginner" && profile.onboardingCompleted) {
-    const gearIndex = sectionOrder.indexOf("gearSection");
-    if (gearIndex > 4) {
-      sectionOrder = [
-        ...sectionOrder.slice(0, 4),
-        "gearSection",
-        ...sectionOrder.slice(4, gearIndex),
-        ...sectionOrder.slice(gearIndex + 1),
-      ];
-    }
-  }
-
-  // Non-surveyed users: hide invest section
-  if (!profile.onboardingCompleted) {
-    sectionOrder = sectionOrder.filter((s) => s !== "investSection");
-  }
+  // Apply declarative visibility rules
+  sectionOrder = applyVisibilityRules(sectionOrder, profile);
 
   return sectionOrder;
+}
+
+/**
+ * Applies declarative visibility rules from SECTION_CAPABILITIES.
+ * Replaces the old imperative "if (!profile.onboardingCompleted) filter(investSection)".
+ */
+function applyVisibilityRules(sectionOrder: SectionId[], profile: VipBikeUserProfile): SectionId[] {
+  return sectionOrder.filter((id) => {
+    const caps = SECTION_CAPABILITIES[id];
+    if (!caps) return true;
+
+    // Hide sections marked as requiring survey completion
+    if (caps.hideIfNotSurveyed && !profile.onboardingCompleted) {
+      return false;
+    }
+
+    return true;
+  });
 }
 
 /**
@@ -494,7 +593,7 @@ export function resolveSectionPriority(profile: VipBikeUserProfile): SectionId[]
  * "Intent routing, not theme routing" — the CTA drives BEHAVIOR.
  *
  * Behavioral signals can override survey-derived CTA:
- *   - If user has 5+ buy clicks but survey says "rent" → show buy CTA
+ *   - If user has 3+ recent buy clicks but survey says "rent" → show buy CTA
  *
  * Separated from the main resolver for:
  *   - Independent testing
@@ -553,6 +652,15 @@ export function resolveCTA(profile: VipBikeUserProfile): PrimaryCTA {
  * the specific profile (not just segment/intent, but also
  * experience level and behavioral signals).
  *
+ * Scoring breakdown:
+ *   Base: caps.weight (20-100)
+ *   + Segment match: +20
+ *   + Intent match: +25
+ *   + Experience match: +15
+ *   + Complexity penalty for beginners: -10 for "high" complexity
+ *   + Behavioral reinforcement: +10-15
+ *   + Emotional tone match: +5
+ *
  * FUTURE: This is where AI-driven ranking plugs in.
  * Replace this scoring function with an ML model,
  * and nothing else in the architecture changes.
@@ -581,6 +689,17 @@ function scoreSection(
     score += 15;
   }
 
+  // Complexity penalty for beginners — they don't want high-complexity sections
+  if (profile.experience === "beginner" && caps.complexity === "high") {
+    score -= 10;
+  }
+
+  // Emotional tone match bonus
+  const preferredTone = derivePreferredTone(profile);
+  if (caps.emotionalTone === preferredTone) {
+    score += 5;
+  }
+
   // Behavioral reinforcement bonus
   if (profile.behaviorSignals) {
     const b = profile.behaviorSignals;
@@ -590,6 +709,18 @@ function scoreSection(
   }
 
   return score;
+}
+
+/**
+ * Derives the preferred emotional tone from the profile.
+ * Used to match section emotionalTone against user preferences.
+ */
+function derivePreferredTone(profile: VipBikeUserProfile): string {
+  if (profile.segment === "electro" || profile.segment === "retro") return "premium";
+  if (profile.intent === "buy") return "energetic";
+  if (profile.intent === "community") return "playful";
+  if (profile.experience === "beginner") return "calm";
+  return "informational";
 }
 
 /**
@@ -678,6 +809,19 @@ export function resolveFeaturedSections(profile: VipBikeUserProfile): SectionId[
 // ─────────────────────────────────────────────────────
 
 /**
+ * Shape of the experience_lock stored in metadata.
+ * Extracted as a proper interface (replaces the hacky conditional type).
+ * Uses RAW profile signals for stability comparison, not derived preset names.
+ */
+export interface ExperienceLockState {
+  lastChangedAt?: string;
+  lastResolvedSegment?: VipBikeSegment;
+  lastResolvedIntent?: VipBikeIntent;
+  lastResolvedExperience?: VipBikeExperience;
+  stabilityCount?: number;
+}
+
+/**
  * Default anti-thrashing configuration.
  *
  * Problem: Behavioral signals change frequently (view electro, view retro,
@@ -686,48 +830,52 @@ export function resolveFeaturedSections(profile: VipBikeUserProfile): SectionId[
  *
  * Solution: Lock the experience for a minimum duration after it changes.
  * Netflix/Spotify/YouTube all do variants of this.
- *
- * Configuration:
- *   - MINIMUM_DURATION_MS: How long before the experience can change (4 hours)
- *   - STABILITY_THRESHOLD: How many consecutive same-presets before we're "confident"
  */
 const ANTI_THRASHING_DEFAULTS = {
   /** Minimum 4 hours before experience can change */
   MINIMUM_DURATION_MS: 4 * 60 * 60 * 1000,
-  /** 3 consecutive same-presets = stable */
+  /** 3 consecutive same-profiles = stable */
   STABILITY_THRESHOLD: 3,
 } as const;
 
 /**
+ * Checks if the current profile matches the locked profile.
+ * Compares raw profile signals, NOT derived preset names.
+ * This is the fix for M6: no derived state in the lock.
+ */
+function isProfileSameAsLock(
+  profile: VipBikeUserProfile,
+  lock: ExperienceLockState,
+): boolean {
+  return (
+    profile.segment === lock.lastResolvedSegment &&
+    profile.intent === lock.lastResolvedIntent &&
+    profile.experience === lock.lastResolvedExperience
+  );
+}
+
+/**
  * Computes anti-thrashing metadata for an experience config.
- *
- * @param presetName - The preset that was resolved
- * @param experienceLock - The persisted lock state from metadata (if any)
- * @returns Anti-thrashing metadata to include in the experience config
+ * Uses proper type (no hacky conditional type).
+ * Compares raw profile signals for stability detection.
  */
 function computeAntiThrashing(
-  presetName: string,
-  experienceLock?: VipBikeUserProfile["behaviorSignals"] extends any ? {
-    lastChangedAt?: string;
-    lastPresetName?: string;
-    stabilityCount?: number;
-  } : never,
+  profile: VipBikeUserProfile,
+  experienceLock?: ExperienceLockState,
 ): VipBikeExperienceConfig["antiThrashing"] {
   const now = new Date();
-  const lock = experienceLock as {
-    lastChangedAt?: string;
-    lastPresetName?: string;
-    stabilityCount?: number;
-  } | undefined;
+  const lock = experienceLock;
 
-  // Compute stability count
+  // Compute stability by comparing current profile vs locked profile
+  const sameProfile = lock ? isProfileSameAsLock(profile, lock) : false;
   const previousStability = lock?.stabilityCount ?? 0;
-  const samePresetAsBefore = lock?.lastPresetName === presetName;
-  const stabilityCount = samePresetAsBefore ? previousStability + 1 : 1;
+  const stabilityCount = sameProfile ? previousStability + 1 : 1;
 
-  // Check if we should lock (i.e., if the experience just changed)
-  const justChanged = !samePresetAsBefore || !lock?.lastChangedAt;
-  const lastChangedAt = justChanged ? now.toISOString() : lock!.lastChangedAt!;
+  // Check if the experience just changed (profile is different from lock)
+  const justChanged = !sameProfile || !lock?.lastChangedAt;
+  const lastChangedAt = justChanged
+    ? now.toISOString()
+    : lock!.lastChangedAt!;
   const lockedUntil = new Date(
     new Date(lastChangedAt).getTime() + ANTI_THRASHING_DEFAULTS.MINIMUM_DURATION_MS,
   ).toISOString();
@@ -759,6 +907,38 @@ export function isExperienceLocked(
   return now.getTime() < lockedUntil;
 }
 
+/**
+ * Computes the updated experience_lock that should be persisted
+ * to metadata after a new experience is resolved.
+ *
+ * The COMPONENT calls this and persists it. The resolver itself is pure.
+ *
+ * @param profile - The profile that produced this experience
+ * @param experience - The newly resolved experience config
+ * @param previousLock - The previous lock state (if any)
+ * @returns Updated lock state to persist in metadata.experience_lock
+ */
+export function computeExperienceLockUpdate(
+  profile: VipBikeUserProfile,
+  experience: VipBikeExperienceConfig,
+  previousLock?: ExperienceLockState,
+): ExperienceLockState {
+  const sameProfile = previousLock
+    ? isProfileSameAsLock(profile, previousLock)
+    : false;
+  const justChanged = !sameProfile || !previousLock?.lastChangedAt;
+
+  return {
+    lastChangedAt: justChanged
+      ? new Date().toISOString()
+      : previousLock!.lastChangedAt!,
+    lastResolvedSegment: profile.segment,
+    lastResolvedIntent: profile.intent,
+    lastResolvedExperience: profile.experience,
+    stabilityCount: experience.antiThrashing?.stabilityCount ?? 1,
+  };
+}
+
 // ─────────────────────────────────────────────────────
 // PUBLIC API
 // ─────────────────────────────────────────────────────
@@ -782,6 +962,11 @@ export function isExperienceLocked(
  * and keeping the old experience. This resolver always computes
  * the LATEST experience — the lock check happens at the call site.
  *
+ * EXPERIENCE LOCK WRITEBACK: After resolving, the component should
+ * call computeExperienceLockUpdate() and persist the result to
+ * metadata.experience_lock. This resolver is pure and does NOT
+ * write to the database.
+ *
  * @param profile - The resolved user profile (from resolve-profile.ts)
  * @param experienceLock - Persisted lock state from metadata (for anti-thrashing)
  * @returns Complete experience configuration
@@ -794,18 +979,16 @@ export function isExperienceLocked(
  *   if (isExperienceLocked(currentExperience)) {
  *     return currentExperience; // keep old
  *   }
- *   return newExperience;
  *
- *   // In the render:
- *   experience.sectionOrder.map(renderSection)
+ *   // Persist lock update (component responsibility, not resolver's)
+ *   const lockUpdate = computeExperienceLockUpdate(profile, newExperience, dbUser.metadata?.experience_lock);
+ *   await updateUserSettings(userId, { experience_lock: lockUpdate });
+ *
+ *   return newExperience;
  */
 export function resolveVipBikeExperience(
   profile: VipBikeUserProfile,
-  experienceLock?: {
-    lastChangedAt?: string;
-    lastPresetName?: string;
-    stabilityCount?: number;
-  },
+  experienceLock?: ExperienceLockState,
 ): VipBikeExperienceConfig {
   // ── Low confidence: show universal layout ──
   if (profile.confidence < 0.3) {
@@ -813,7 +996,7 @@ export function resolveVipBikeExperience(
     return {
       heroMode: resolveHero(profile),
       primaryCTA: resolveCTA(profile),
-      sectionOrder: universal.sectionOrder,
+      sectionOrder: applyVisibilityRules(universal.sectionOrder, profile),
       featuredSections: [],
       featuredCategory: "all",
       onboardingVariant: "not_surveyed",
@@ -821,7 +1004,7 @@ export function resolveVipBikeExperience(
       showOnboardingCTA: true,
       showPromoChip: !!profile.source?.promoCode,
       presetName: "universal",
-      antiThrashing: computeAntiThrashing("universal", experienceLock),
+      antiThrashing: computeAntiThrashing(profile, experienceLock),
       experienceResolverVersion: EXPERIENCE_RESOLVER_VERSION,
     };
   }
@@ -853,7 +1036,7 @@ export function resolveVipBikeExperience(
     showOnboardingCTA: !profile.onboardingCompleted,
     showPromoChip: !!profile.source?.promoCode,
     presetName: preset.name,
-    antiThrashing: computeAntiThrashing(preset.name, experienceLock),
+    antiThrashing: computeAntiThrashing(profile, experienceLock),
     experienceResolverVersion: EXPERIENCE_RESOLVER_VERSION,
   };
 }

--- a/app/franchize/lib/onboarding/resolve-experience.ts
+++ b/app/franchize/lib/onboarding/resolve-experience.ts
@@ -1,0 +1,866 @@
+/**
+ * resolve-experience.ts
+ * =====================
+ * Resolves a VipBikeExperienceConfig from a VipBikeUserProfile.
+ *
+ * This is where INTENT becomes UX. The profile tells us WHO the user is;
+ * this function decides WHAT they see.
+ *
+ * DESIGN PRINCIPLE: "Intent routing, not theme routing."
+ *   - Buyers see fast purchase flow
+ *   - Explorers see discovery flow
+ *   - Community users see map/social flow
+ *   - Renters see availability/scheduling flow
+ *
+ * FIVE INNOVATIONS vs v1:
+ *
+ *   1. SECTION CAPABILITIES: Sections self-describe what they help with.
+ *      Instead of hardcoding "if beginner -> gearSection early", sections
+ *      declare capabilities, and the resolver scores them dynamically.
+ *      This unlocks AI ranking, A/B tests, analytics-driven ordering.
+ *
+ *   2. EXPERIENCE PRESETS: Named composable configs for common profiles.
+ *      Makes debugging easier ("this user has electroExplorer preset").
+ *      Enables feature flags, analytics, product discussions.
+ *      The resolver composes from presets and refines.
+ *
+ *   3. COMBINE PRESETS: Instead of a single if/else chain that grows
+ *      into 1500 lines, the resolver composes multiple small presets
+ *      and merges them. This prevents resolver entropy.
+ *
+ *   4. ANTI-THRASHING: Behavioral signals change rapidly (view electro,
+ *      view retro, view map, view electro). Without stabilization,
+ *      the landing constantly reshuffles. The resolver locks the
+ *      experience for a minimum duration after it changes.
+ *
+ *   5. RESOLVER VERSIONING: Every resolver output includes its version
+ *      for observability. NOT used for logic — always runs latest code.
+ *      Used for: analytics, A/B testing, debugging.
+ *
+ * MODULAR ARCHITECTURE:
+ *   resolveVipBikeExperience(profile)
+ *     = resolveHero(profile)
+ *     + resolveSectionPriority(profile)
+ *     + resolveCTA(profile)
+ *     + resolveFeaturedSections(profile)
+ *
+ *   Each resolver is independently testable and replaceable.
+ *   This prevents the "1500-line condition jungle" problem.
+ *
+ * CRITICAL: This function is PURE. No side effects, no I/O.
+ * It should be called inside useMemo in the component.
+ */
+
+import type {
+  VipBikeUserProfile,
+  VipBikeExperienceConfig,
+  VipBikeSegment,
+  VipBikeIntent,
+  HeroDisplayMode,
+  SectionId,
+  SectionCapabilities,
+  PrimaryCTA,
+} from "./experience-types";
+
+// ─────────────────────────────────────────────────────
+// 0. Resolver versioning
+// ─────────────────────────────────────────────────────
+
+/**
+ * Experience resolver version — bump when the experience composition logic changes.
+ *
+ * NOT used for logic (the resolver always runs latest code).
+ * It's for OBSERVABILITY:
+ *   - Analytics: "exp-v2 increased conversion on electro segment by 12%"
+ *   - Debugging: "this user's experience was composed by exp-v1"
+ *   - A/B testing: enable new resolver for a subset, compare conversion
+ *
+ * When you change section ordering logic, preset definitions, or CTA resolution,
+ * bump this version. The version is included in the experience config so
+ * downstream systems (analytics, logging) can attribute UX decisions.
+ */
+export const EXPERIENCE_RESOLVER_VERSION = "exp-v1" as const;
+
+// ─────────────────────────────────────────────────────
+// 1. Section Capability Registry
+// ─────────────────────────────────────────────────────
+
+/**
+ * Each section declares what it's good for.
+ * The resolver uses these to dynamically score and order sections
+ * based on the user's profile, instead of hardcoding rules.
+ *
+ * Adding a new section = add capabilities here + add to sectionMap.
+ * The resolver picks it up automatically.
+ */
+export const SECTION_CAPABILITIES: Record<SectionId, SectionCapabilities> = {
+  hero: {
+    relevantSegments: [],
+    relevantIntents: [],
+    tags: ["universal", "entry"],
+    weight: 100, // Always first
+  },
+  bikeShowcase: {
+    relevantSegments: ["sport", "touring"],
+    relevantIntents: ["explore", "rent"],
+    tags: ["discovery", "catalog"],
+    weight: 60,
+  },
+  conversionPilot: {
+    relevantSegments: [],
+    relevantIntents: ["buy", "rent"],
+    relevantExperience: ["beginner"],
+    tags: ["decision", "funnel"],
+    weight: 80,
+  },
+  electroShowcase: {
+    relevantSegments: ["electro"],
+    relevantIntents: ["explore", "buy"],
+    tags: ["electro", "featured", "catalog"],
+    weight: 85,
+  },
+  mapPreview: {
+    relevantSegments: ["mixed", "urban"],
+    relevantIntents: ["community"],
+    tags: ["social", "map", "live"],
+    weight: 75,
+  },
+  gearSection: {
+    relevantExperience: ["beginner"],
+    tags: ["safety", "equipment", "beginner"],
+    weight: 50,
+  },
+  stepsProgress: {
+    relevantExperience: ["beginner"],
+    relevantIntents: ["rent"],
+    tags: ["onboarding", "steps", "beginner"],
+    weight: 40,
+  },
+  rentalQuickActions: {
+    relevantIntents: ["rent"],
+    relevantExperience: ["intermediate", "advanced"],
+    tags: ["rental", "quick-action", "availability"],
+    weight: 70,
+  },
+  companyServiceHub: {
+    tags: ["info", "services"],
+    weight: 30,
+  },
+  serviceCards: {
+    relevantIntents: ["buy", "rent"],
+    tags: ["pricing", "requirements", "trust"],
+    weight: 45,
+  },
+  howItWorks: {
+    relevantExperience: ["beginner"],
+    relevantIntents: ["rent", "buy"],
+    tags: ["process", "steps"],
+    weight: 35,
+  },
+  investSection: {
+    relevantIntents: ["buy"],
+    relevantExperience: ["advanced"],
+    tags: ["invest", "premium", "monetization"],
+    weight: 25,
+  },
+  faq: {
+    tags: ["info", "support"],
+    weight: 20,
+  },
+};
+
+// ─────────────────────────────────────────────────────
+// 2. Experience Presets
+// ─────────────────────────────────────────────────────
+
+/**
+ * Named experience presets for common user profiles.
+ * These are composable building blocks — the resolver picks the
+ * best preset and refines it based on the specific profile.
+ *
+ * Benefits:
+ *   - Easier debugging: "this user has electroExplorer preset"
+ *   - Analytics: track which presets are most common
+ *   - Feature flags: enable/disable specific presets
+ *   - Product discussions: talk about presets, not code
+ *
+ * COMPOSABLE: Multiple presets can be combined via combinePresets().
+ * This prevents the "giant switch statement in 6 months" problem.
+ */
+export interface ExperiencePreset {
+  name: string;
+  segment: VipBikeSegment;
+  intent: VipBikeIntent;
+  heroMode: HeroDisplayMode;
+  sectionOrder: SectionId[];
+  featuredSections: SectionId[];
+  featuredCategory: VipBikeExperienceConfig["featuredCategory"];
+  copyTone: VipBikeExperienceConfig["copyTone"];
+  primaryCTA: PrimaryCTA;
+}
+
+const PRESETS: ExperiencePreset[] = [
+  {
+    name: "electroExplorer",
+    segment: "electro",
+    intent: "explore",
+    heroMode: "electro-enduro",
+    sectionOrder: [
+      "hero", "electroShowcase", "bikeShowcase", "conversionPilot",
+      "mapPreview", "gearSection", "rentalQuickActions", "stepsProgress",
+      "serviceCards", "howItWorks", "companyServiceHub", "investSection", "faq",
+    ],
+    featuredSections: ["electroShowcase", "mapPreview"],
+    featuredCategory: "electro",
+    copyTone: "premium",
+    primaryCTA: {
+      label: "Изучить электро",
+      href: "/franchize/vip-bike",
+      isExternal: false,
+      variant: "brand-yellow",
+    },
+  },
+  {
+    name: "fastBuyer",
+    segment: "sport",
+    intent: "buy",
+    heroMode: "buy",
+    sectionOrder: [
+      "hero", "conversionPilot", "electroShowcase", "serviceCards",
+      "howItWorks", "bikeShowcase", "gearSection", "stepsProgress",
+      "rentalQuickActions", "mapPreview", "companyServiceHub", "investSection", "faq",
+    ],
+    featuredSections: ["conversionPilot", "rentalQuickActions"],
+    featuredCategory: "sport",
+    copyTone: "aggressive",
+    primaryCTA: {
+      label: "Выбрать покупку",
+      href: "/franchize/vip-bike",
+      isExternal: false,
+      variant: "accent",
+    },
+  },
+  {
+    name: "retroCruiser",
+    segment: "retro",
+    intent: "explore",
+    heroMode: "rent",
+    sectionOrder: [
+      "hero", "electroShowcase", "bikeShowcase", "conversionPilot",
+      "mapPreview", "serviceCards", "gearSection", "stepsProgress",
+      "rentalQuickActions", "howItWorks", "companyServiceHub", "investSection", "faq",
+    ],
+    featuredSections: ["electroShowcase", "bikeShowcase"],
+    featuredCategory: "retro",
+    copyTone: "premium",
+    primaryCTA: {
+      label: "Смотреть подборку",
+      href: "/franchize/vip-bike",
+      isExternal: false,
+      variant: "outline",
+    },
+  },
+  {
+    name: "communityRider",
+    segment: "mixed",
+    intent: "community",
+    heroMode: "map",
+    sectionOrder: [
+      "hero", "mapPreview", "rentalQuickActions", "conversionPilot",
+      "electroShowcase", "bikeShowcase", "gearSection", "stepsProgress",
+      "serviceCards", "howItWorks", "companyServiceHub", "investSection", "faq",
+    ],
+    featuredSections: ["mapPreview"],
+    featuredCategory: "all",
+    copyTone: "friendly",
+    primaryCTA: {
+      label: "Открыть карту",
+      href: "/franchize/vip-bike/map-riders",
+      isExternal: false,
+      variant: "accent",
+    },
+  },
+  {
+    name: "safeBeginner",
+    segment: "mixed",
+    intent: "rent",
+    heroMode: "rent",
+    sectionOrder: [
+      "hero", "conversionPilot", "gearSection", "stepsProgress",
+      "rentalQuickActions", "electroShowcase", "bikeShowcase",
+      "mapPreview", "serviceCards", "howItWorks", "companyServiceHub", "faq",
+    ],
+    featuredSections: ["conversionPilot", "gearSection"],
+    featuredCategory: "all",
+    copyTone: "friendly",
+    primaryCTA: {
+      label: "Первый выезд",
+      href: "/franchize/vip-bike",
+      isExternal: false,
+      variant: "accent",
+    },
+  },
+  {
+    name: "universal",
+    segment: "mixed",
+    intent: "explore",
+    heroMode: "rent",
+    sectionOrder: [
+      "hero", "bikeShowcase", "conversionPilot", "electroShowcase",
+      "mapPreview", "gearSection", "stepsProgress", "rentalQuickActions",
+      "companyServiceHub", "serviceCards", "howItWorks", "investSection", "faq",
+    ],
+    featuredSections: [],
+    featuredCategory: "all",
+    copyTone: "friendly",
+    primaryCTA: {
+      label: "🚀 Начать анкету /start",
+      href: "https://t.me/oneBikePlsBot?start=onboard",
+      isExternal: true,
+      variant: "brand-yellow",
+    },
+  },
+];
+
+// ─────────────────────────────────────────────────────
+// 3. Preset composition
+// ─────────────────────────────────────────────────────
+
+/**
+ * Composes multiple presets by merging their section orders.
+ *
+ * This is the KEY mechanism to prevent resolver entropy.
+ * Instead of one giant function with 50 if/else branches,
+ * you compose small, focused presets:
+ *
+ *   combinePresets([buyerFastLane, beginnerGuided])
+ *   → sections from buyerFastLane first, then beginnerGuided additions
+ *
+ * Rules:
+ *   - First preset's order takes priority (its sections appear first)
+ *   - Subsequent presets add sections not already present
+ *   - hero is ALWAYS first regardless
+ *   - Duplicate sections are deduplicated (first occurrence wins)
+ *
+ * @param presets - Ordered list of presets to compose (first = highest priority)
+ * @returns Composed section order
+ */
+export function combinePresets(presets: ExperiencePreset[]): SectionId[] {
+  if (presets.length === 0) return [];
+  if (presets.length === 1) return presets[0].sectionOrder;
+
+  const seen = new Set<SectionId>();
+  const result: SectionId[] = [];
+
+  for (const preset of presets) {
+    for (const section of preset.sectionOrder) {
+      if (!seen.has(section)) {
+        seen.add(section);
+        result.push(section);
+      }
+    }
+  }
+
+  // Ensure hero is always first
+  const heroIndex = result.indexOf("hero");
+  if (heroIndex > 0) {
+    result.splice(heroIndex, 1);
+    result.unshift("hero");
+  } else if (heroIndex === -1) {
+    result.unshift("hero");
+  }
+
+  return result;
+}
+
+// ─────────────────────────────────────────────────────
+// 4. Preset matching
+// ─────────────────────────────────────────────────────
+
+/**
+ * Finds the best matching preset for a profile.
+ * Uses segment + intent matching, with fallback to universal.
+ */
+function findBestPreset(profile: VipBikeUserProfile): ExperiencePreset {
+  // Try exact segment + intent match
+  const exact = PRESETS.find(
+    (p) => p.segment === profile.segment && p.intent === profile.intent,
+  );
+  if (exact) return exact;
+
+  // Try intent match only (more important than segment)
+  const intentMatch = PRESETS.find((p) => p.intent === profile.intent);
+  if (intentMatch) return intentMatch;
+
+  // Try segment match only
+  const segmentMatch = PRESETS.find((p) => p.segment === profile.segment);
+  if (segmentMatch) return segmentMatch;
+
+  // Special case: beginner experience
+  if (profile.experience === "beginner") {
+    return PRESETS.find((p) => p.name === "safeBeginner")!;
+  }
+
+  // Fallback to universal
+  return PRESETS.find((p) => p.name === "universal")!;
+}
+
+// ─────────────────────────────────────────────────────
+// 5. Modular resolvers — each independently testable
+// ─────────────────────────────────────────────────────
+
+/**
+ * Resolves hero display mode from profile.
+ * Separated from the main resolver for:
+ *   - Independent testing
+ *   - A/B testing hero independently
+ *   - Replacing hero logic without touching section logic
+ *
+ * "Intent routing, not theme routing" — the hero drives FIRST IMPRESSION.
+ */
+export function resolveHero(profile: VipBikeUserProfile): HeroDisplayMode {
+  // Low confidence → safest default
+  if (profile.confidence < 0.3) return "rent";
+
+  // Intent-first routing
+  if (profile.intent === "buy") return "buy";
+  if (profile.intent === "community") return "map";
+
+  // Segment-specific hero for explore intent
+  if (profile.segment === "electro") return "electro-enduro";
+
+  // Default
+  return "rent";
+}
+
+/**
+ * Resolves section priority order from profile.
+ * This is the scoring engine — sections self-describe capabilities,
+ * and this function ranks them against the profile.
+ *
+ * Separated from the main resolver for:
+ *   - Independent testing
+ *   - Experimentation with different scoring algorithms
+ *   - AI-driven ranking later (swap this function, nothing else changes)
+ */
+export function resolveSectionPriority(profile: VipBikeUserProfile): SectionId[] {
+  // Low confidence → universal order
+  if (profile.confidence < 0.3) {
+    return PRESETS.find((p) => p.name === "universal")!.sectionOrder;
+  }
+
+  // Find best preset and refine with capability scoring
+  const preset = findBestPreset(profile);
+  let sectionOrder = refineSectionOrder(preset.sectionOrder, profile);
+
+  // ── Special rules (these would become preset compositions later) ──
+
+  // Electro segment: ALWAYS show electro showcase early
+  if (profile.segment === "electro") {
+    const electroIndex = sectionOrder.indexOf("electroShowcase");
+    if (electroIndex > 1) {
+      sectionOrder = [
+        sectionOrder[0], // hero
+        "electroShowcase",
+        ...sectionOrder.slice(1, electroIndex),
+        ...sectionOrder.slice(electroIndex + 1),
+      ];
+    }
+  }
+
+  // Beginners: ensure gearSection is prominent
+  if (profile.experience === "beginner" && profile.onboardingCompleted) {
+    const gearIndex = sectionOrder.indexOf("gearSection");
+    if (gearIndex > 4) {
+      sectionOrder = [
+        ...sectionOrder.slice(0, 4),
+        "gearSection",
+        ...sectionOrder.slice(4, gearIndex),
+        ...sectionOrder.slice(gearIndex + 1),
+      ];
+    }
+  }
+
+  // Non-surveyed users: hide invest section
+  if (!profile.onboardingCompleted) {
+    sectionOrder = sectionOrder.filter((s) => s !== "investSection");
+  }
+
+  return sectionOrder;
+}
+
+/**
+ * Resolves the primary CTA from profile.
+ * "Intent routing, not theme routing" — the CTA drives BEHAVIOR.
+ *
+ * Behavioral signals can override survey-derived CTA:
+ *   - If user has 5+ buy clicks but survey says "rent" → show buy CTA
+ *
+ * Separated from the main resolver for:
+ *   - Independent testing
+ *   - A/B testing CTAs independently
+ *   - Analytics: "CTA resolver v2 increased click-through by 20%"
+ */
+export function resolveCTA(profile: VipBikeUserProfile): PrimaryCTA {
+  // Not surveyed → onboarding CTA
+  if (!profile.onboardingCompleted && profile.confidence < 0.3) {
+    return {
+      label: "🚀 Начать анкету /start",
+      href: "https://t.me/oneBikePlsBot?start=onboard",
+      isExternal: true,
+      variant: "brand-yellow",
+    };
+  }
+
+  // Check behavioral intent override
+  const effectiveIntent = profile.behaviorSignals &&
+    shouldBehaviorOverrideCTA(profile)
+    ? deriveBehavioralIntent(profile.behaviorSignals)
+    : profile.intent;
+
+  switch (effectiveIntent) {
+    case "buy":
+      return profile.experience === "beginner"
+        ? { label: "Подобрать первый байк", href: "/franchize/vip-bike", isExternal: false, variant: "accent" }
+        : { label: "Выбрать покупку", href: "/franchize/vip-bike", isExternal: false, variant: "accent" };
+
+    case "rent":
+      return profile.experience === "beginner"
+        ? { label: "Первый выезд", href: "/franchize/vip-bike", isExternal: false, variant: "accent" }
+        : { label: "Выбрать аренду", href: "/franchize/vip-bike", isExternal: false, variant: "accent" };
+
+    case "community":
+      return { label: "Открыть карту", href: "/franchize/vip-bike/map-riders", isExternal: false, variant: "accent" };
+
+    case "explore":
+    default:
+      if (profile.segment === "electro") {
+        return { label: "Изучить электро", href: "/franchize/vip-bike", isExternal: false, variant: "brand-yellow" };
+      }
+      return { label: "Смотреть подборку", href: "/franchize/vip-bike", isExternal: false, variant: "outline" };
+  }
+}
+
+// ─────────────────────────────────────────────────────
+// 6. Dynamic section scoring
+// ─────────────────────────────────────────────────────
+
+/**
+ * Scores a section based on how well its capabilities match the profile.
+ * Higher score = more relevant = should appear earlier.
+ *
+ * This is used to REFINE the preset's section order based on
+ * the specific profile (not just segment/intent, but also
+ * experience level and behavioral signals).
+ *
+ * FUTURE: This is where AI-driven ranking plugs in.
+ * Replace this scoring function with an ML model,
+ * and nothing else in the architecture changes.
+ */
+function scoreSection(
+  sectionId: SectionId,
+  profile: VipBikeUserProfile,
+): number {
+  const caps = SECTION_CAPABILITIES[sectionId];
+  if (!caps) return 0;
+
+  let score = caps.weight ?? 50;
+
+  // Segment match bonus
+  if (caps.relevantSegments?.includes(profile.segment)) {
+    score += 20;
+  }
+
+  // Intent match bonus
+  if (caps.relevantIntents?.includes(profile.intent)) {
+    score += 25;
+  }
+
+  // Experience match bonus
+  if (caps.relevantExperience?.includes(profile.experience)) {
+    score += 15;
+  }
+
+  // Behavioral reinforcement bonus
+  if (profile.behaviorSignals) {
+    const b = profile.behaviorSignals;
+    if (sectionId === "mapPreview" && (b.openedMapCount ?? 0) >= 3) score += 10;
+    if (sectionId === "electroShowcase" && (b.viewedElectroCount ?? 0) >= 3) score += 10;
+    if (sectionId === "investSection" && (b.investSectionViewSeconds ?? 0) >= 30) score += 15;
+  }
+
+  return score;
+}
+
+/**
+ * Sorts section order by dynamic scores, but keeps hero first.
+ * Uses the preset as a base, then adjusts based on profile.
+ */
+function refineSectionOrder(
+  presetOrder: SectionId[],
+  profile: VipBikeUserProfile,
+): SectionId[] {
+  // Hero always first
+  const heroIndex = presetOrder.indexOf("hero");
+  const withoutHero = heroIndex >= 0
+    ? [...presetOrder.slice(0, heroIndex), ...presetOrder.slice(heroIndex + 1)]
+    : presetOrder;
+
+  // Score each section
+  const scored = withoutHero.map((id) => ({
+    id,
+    score: scoreSection(id, profile),
+  }));
+
+  // Sort by score (highest first), stable sort preserves preset order on ties
+  scored.sort((a, b) => b.score - a.score);
+
+  // Reconstruct with hero first
+  const result: SectionId[] = heroIndex >= 0 ? ["hero"] : [];
+  result.push(...scored.map((s) => s.id));
+  return result;
+}
+
+// ─────────────────────────────────────────────────────
+// 7. CTA helpers
+// ─────────────────────────────────────────────────────
+
+function shouldBehaviorOverrideCTA(profile: VipBikeUserProfile): boolean {
+  const b = profile.behaviorSignals;
+  if (!b) return false;
+  const buyClicks = b.buyIntentClickCount ?? 0;
+  const rentClicks = b.rentIntentClickCount ?? 0;
+  return buyClicks >= 3 || rentClicks >= 3;
+}
+
+function deriveBehavioralIntent(b: NonNullable<VipBikeUserProfile["behaviorSignals"]>): VipBikeIntent {
+  if ((b.buyIntentClickCount ?? 0) >= 3) return "buy";
+  if ((b.rentIntentClickCount ?? 0) >= 3) return "rent";
+  if ((b.openedMapCount ?? 0) >= 3) return "community";
+  return "explore";
+}
+
+// ─────────────────────────────────────────────────────
+// 8. Featured sections from capabilities
+// ─────────────────────────────────────────────────────
+
+/**
+ * Resolves which sections should be visually emphasized.
+ * A section is "featured" if it matches 2+ profile dimensions.
+ *
+ * Separated from the main resolver for:
+ *   - Independent testing
+ *   - Experimentation with featured section logic
+ *   - Analytics: "featuring gearSection increased safety purchases by 8%"
+ */
+export function resolveFeaturedSections(profile: VipBikeUserProfile): SectionId[] {
+  const featured: SectionId[] = [];
+
+  for (const [id, caps] of Object.entries(SECTION_CAPABILITIES) as [SectionId, SectionCapabilities][]) {
+    if (id === "hero") continue; // Hero is always first, not "featured"
+
+    const segmentMatch = caps.relevantSegments?.includes(profile.segment);
+    const intentMatch = caps.relevantIntents?.includes(profile.intent);
+    const expMatch = caps.relevantExperience?.includes(profile.experience);
+
+    // Feature if section matches 2+ profile dimensions
+    const matchCount = [segmentMatch, intentMatch, expMatch].filter(Boolean).length;
+    if (matchCount >= 2) {
+      featured.push(id);
+    }
+  }
+
+  return featured;
+}
+
+// ─────────────────────────────────────────────────────
+// 9. Anti-thrashing
+// ─────────────────────────────────────────────────────
+
+/**
+ * Default anti-thrashing configuration.
+ *
+ * Problem: Behavioral signals change frequently (view electro, view retro,
+ * view map, view electro). Without stabilization, the landing constantly
+ * reshuffles, hero changes too often, and the UX feels schizophrenic.
+ *
+ * Solution: Lock the experience for a minimum duration after it changes.
+ * Netflix/Spotify/YouTube all do variants of this.
+ *
+ * Configuration:
+ *   - MINIMUM_DURATION_MS: How long before the experience can change (4 hours)
+ *   - STABILITY_THRESHOLD: How many consecutive same-presets before we're "confident"
+ */
+const ANTI_THRASHING_DEFAULTS = {
+  /** Minimum 4 hours before experience can change */
+  MINIMUM_DURATION_MS: 4 * 60 * 60 * 1000,
+  /** 3 consecutive same-presets = stable */
+  STABILITY_THRESHOLD: 3,
+} as const;
+
+/**
+ * Computes anti-thrashing metadata for an experience config.
+ *
+ * @param presetName - The preset that was resolved
+ * @param experienceLock - The persisted lock state from metadata (if any)
+ * @returns Anti-thrashing metadata to include in the experience config
+ */
+function computeAntiThrashing(
+  presetName: string,
+  experienceLock?: VipBikeUserProfile["behaviorSignals"] extends any ? {
+    lastChangedAt?: string;
+    lastPresetName?: string;
+    stabilityCount?: number;
+  } : never,
+): VipBikeExperienceConfig["antiThrashing"] {
+  const now = new Date();
+  const lock = experienceLock as {
+    lastChangedAt?: string;
+    lastPresetName?: string;
+    stabilityCount?: number;
+  } | undefined;
+
+  // Compute stability count
+  const previousStability = lock?.stabilityCount ?? 0;
+  const samePresetAsBefore = lock?.lastPresetName === presetName;
+  const stabilityCount = samePresetAsBefore ? previousStability + 1 : 1;
+
+  // Check if we should lock (i.e., if the experience just changed)
+  const justChanged = !samePresetAsBefore || !lock?.lastChangedAt;
+  const lastChangedAt = justChanged ? now.toISOString() : lock!.lastChangedAt!;
+  const lockedUntil = new Date(
+    new Date(lastChangedAt).getTime() + ANTI_THRASHING_DEFAULTS.MINIMUM_DURATION_MS,
+  ).toISOString();
+
+  return {
+    computedAt: now.toISOString(),
+    minimumDurationMs: ANTI_THRASHING_DEFAULTS.MINIMUM_DURATION_MS,
+    lockedUntil,
+    stabilityCount,
+  };
+}
+
+/**
+ * Checks if the experience is currently locked (anti-thrashing).
+ * If locked, the component should keep the previous experience
+ * instead of applying the newly resolved one.
+ *
+ * @param currentExperience - The currently rendered experience (from React state)
+ * @param now - Current timestamp (injectable for testing)
+ * @returns true if the experience is locked and should NOT change
+ */
+export function isExperienceLocked(
+  currentExperience: VipBikeExperienceConfig | null,
+  now: Date = new Date(),
+): boolean {
+  if (!currentExperience?.antiThrashing) return false;
+
+  const lockedUntil = new Date(currentExperience.antiThrashing.lockedUntil).getTime();
+  return now.getTime() < lockedUntil;
+}
+
+// ─────────────────────────────────────────────────────
+// PUBLIC API
+// ─────────────────────────────────────────────────────
+
+/**
+ * Resolves the complete experience configuration from a user profile.
+ *
+ * This is the MAIN function that VipBikeRentalClient should call
+ * to determine what to render. It returns a declarative config
+ * that the component translates into section rendering.
+ *
+ * Resolution strategy (composed from modular resolvers):
+ *   1. resolveHero(profile)       → which hero tab
+ *   2. resolveSectionPriority(profile) → which sections in what order
+ *   3. resolveCTA(profile)        → which primary CTA
+ *   4. resolveFeaturedSections(profile) → which sections to emphasize
+ *   5. computeAntiThrashing()     → lock metadata
+ *
+ * ANTI-THRASHING: If the previous experience is still locked,
+ * the COMPONENT is responsible for checking isExperienceLocked()
+ * and keeping the old experience. This resolver always computes
+ * the LATEST experience — the lock check happens at the call site.
+ *
+ * @param profile - The resolved user profile (from resolve-profile.ts)
+ * @param experienceLock - Persisted lock state from metadata (for anti-thrashing)
+ * @returns Complete experience configuration
+ *
+ * @example
+ *   const profile = resolveVipBikeProfile(dbUser);
+ *   const newExperience = resolveVipBikeExperience(profile, dbUser.metadata?.experience_lock);
+ *
+ *   // Anti-thrashing: keep old experience if locked
+ *   if (isExperienceLocked(currentExperience)) {
+ *     return currentExperience; // keep old
+ *   }
+ *   return newExperience;
+ *
+ *   // In the render:
+ *   experience.sectionOrder.map(renderSection)
+ */
+export function resolveVipBikeExperience(
+  profile: VipBikeUserProfile,
+  experienceLock?: {
+    lastChangedAt?: string;
+    lastPresetName?: string;
+    stabilityCount?: number;
+  },
+): VipBikeExperienceConfig {
+  // ── Low confidence: show universal layout ──
+  if (profile.confidence < 0.3) {
+    const universal = PRESETS.find((p) => p.name === "universal")!;
+    return {
+      heroMode: resolveHero(profile),
+      primaryCTA: resolveCTA(profile),
+      sectionOrder: universal.sectionOrder,
+      featuredSections: [],
+      featuredCategory: "all",
+      onboardingVariant: "not_surveyed",
+      copyTone: "friendly",
+      showOnboardingCTA: true,
+      showPromoChip: !!profile.source?.promoCode,
+      presetName: "universal",
+      antiThrashing: computeAntiThrashing("universal", experienceLock),
+      experienceResolverVersion: EXPERIENCE_RESOLVER_VERSION,
+    };
+  }
+
+  // ── Find best preset ──
+  const preset = findBestPreset(profile);
+
+  // ── Compose from modular resolvers ──
+  const heroMode = resolveHero(profile);
+  const sectionOrder = resolveSectionPriority(profile);
+  const primaryCTA = resolveCTA(profile);
+  const featuredSections = resolveFeaturedSections(profile);
+
+  // ── Determine onboarding variant ──
+  const onboardingVariant = !profile.onboardingCompleted
+    ? "not_surveyed"
+    : profile.confidence < 0.7
+      ? "partial"
+      : "surveyed";
+
+  return {
+    heroMode,
+    primaryCTA,
+    sectionOrder,
+    featuredSections,
+    featuredCategory: preset.featuredCategory,
+    onboardingVariant,
+    copyTone: preset.copyTone,
+    showOnboardingCTA: !profile.onboardingCompleted,
+    showPromoChip: !!profile.source?.promoCode,
+    presetName: preset.name,
+    antiThrashing: computeAntiThrashing(preset.name, experienceLock),
+    experienceResolverVersion: EXPERIENCE_RESOLVER_VERSION,
+  };
+}
+
+/**
+ * Returns all available presets (for debugging / analytics / feature flags).
+ */
+export function getAvailablePresets(): ExperiencePreset[] {
+  return [...PRESETS];
+}

--- a/app/franchize/lib/onboarding/resolve-profile.ts
+++ b/app/franchize/lib/onboarding/resolve-profile.ts
@@ -1,0 +1,208 @@
+/**
+ * resolve-profile.ts
+ * ==================
+ * Resolves a VipBikeUserProfile from dbUser.metadata.
+ *
+ * This is the SINGLE ENTRY POINT that VipBikeRentalClient (and any other
+ * component) should use to get a user profile. It handles:
+ *
+ *   - Users with completed surveys → full profile from survey + behavior
+ *   - Users with partial surveys → partial profile + payload hints + behavior
+ *   - Users with only behavioral signals → behavior-derived profile
+ *   - Users with only a /start payload → pre-survey profile from hints
+ *   - Anonymous users → default universal profile
+ *
+ * CRITICAL RULE: Components call resolveVipBikeProfile(dbUser).
+ *               They NEVER read dbUser.metadata.survey_results directly.
+ *               They NEVER read dbUser.metadata.behavior_signals directly.
+ *               The resolver is the ONLY source of truth.
+ *
+ * NO CACHED PROFILE: We do NOT read a cached ui_profile from metadata.
+ * The profile is ALWAYS re-derived from raw signals at runtime.
+ * This ensures that:
+ *   - Resolver logic improvements apply immediately to all users
+ *   - Stale profiles don't persist outdated segments/intents
+ *   - Behavioral signals are always factored in
+ *   - Intent decay is computed with current timestamps
+ *
+ * PERFORMANCE: This runs client-side on every render via useMemo.
+ *   The normalizer is pure computation — no I/O, no side effects.
+ *   It should complete in < 1ms. If it ever gets slow, memoize
+ *   the result at a higher level (e.g., AppContext).
+ */
+
+import type { VipBikeUserMetadata, BikeSurveyAnswers, ParsedPayload, BehaviorSignals } from "./experience-types";
+import { normalizeSurveyToProfile, createDefaultProfile } from "./survey-normalizer";
+import { parsePayload } from "./payload-parser";
+
+// ─────────────────────────────────────────────────────
+// Resolver versioning
+// ─────────────────────────────────────────────────────
+
+/**
+ * Profile resolver version — bump when the profile derivation logic changes.
+ *
+ * This is NOT used for logic (the resolver always runs latest code).
+ * It's for OBSERVABILITY:
+ *   - Analytics: "profile-v2 produces 30% more electro segments"
+ *   - Debugging: "this user was classified by profile-v1, but v2 would classify differently"
+ *   - A/B testing: enable new resolver for a subset, compare conversion
+ *   - Migration tracking: identify users who need re-onboarding
+ *
+ * When you change the normalizer logic, bump this version.
+ * The version is included in the profile's onboardingContext so
+ * downstream systems (analytics, logging) can attribute decisions.
+ */
+export const PROFILE_RESOLVER_VERSION = "profile-v1" as const;
+
+// ─────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────
+
+/**
+ * Minimal dbUser shape that the resolver needs.
+ * This avoids coupling to the full AppContext dbUser type.
+ */
+interface DbUserForProfile {
+  metadata?: VipBikeUserMetadata | null;
+}
+
+// ─────────────────────────────────────────────────────
+// PUBLIC API
+// ─────────────────────────────────────────────────────
+
+/**
+ * Resolves a VipBikeUserProfile from the user's database metadata.
+ *
+ * ALWAYS derives from raw signals. NEVER reads a cached profile.
+ *
+ * Resolution strategy (in priority order):
+ *
+ *   1. If survey_results + behavior_signals → derive from both
+ *   2. If survey_results only → derive from survey + payload hints
+ *   3. If behavior_signals only → derive from behavior
+ *   4. If only onboarding_start_payload → derive from payload hints
+ *   5. Otherwise → return default profile
+ *
+ * @param dbUser - The user object from AppContext (or null for anonymous)
+ * @returns A fully resolved VipBikeUserProfile
+ *
+ * @example
+ *   // In VipBikeRentalClient:
+ *   const { dbUser } = useAppContext();
+ *   const profile = resolveVipBikeProfile(dbUser);
+ *
+ *   // Now use profile.segment, profile.intent, profile.confidence
+ *   // NEVER access dbUser.metadata.survey_results directly
+ */
+export function resolveVipBikeProfile(dbUser: DbUserForProfile | null | undefined): VipBikeUserProfile {
+  if (!dbUser?.metadata) {
+    return createDefaultProfile();
+  }
+
+  const meta = dbUser.metadata;
+  const surveyResults = meta.survey_results as BikeSurveyAnswers | undefined;
+  const behaviorSignals = meta.behavior_signals as BehaviorSignals | undefined;
+  const hasSurveyAnswers = surveyResults && Object.values(surveyResults).some(
+    (v) => v && typeof v === "string" && v.trim().length > 0,
+  );
+  const hasBehavior = behaviorSignals && (
+    (behaviorSignals.viewedElectroCount ?? 0) +
+    (behaviorSignals.viewedSportCount ?? 0) +
+    (behaviorSignals.openedMapCount ?? 0) +
+    (behaviorSignals.buyIntentClickCount ?? 0) +
+    (behaviorSignals.rentIntentClickCount ?? 0)
+  ) > 0;
+
+  // Parse the /start payload for hints
+  let parsedPayload: ParsedPayload | null = null;
+  if (meta.onboarding_start_payload) {
+    parsedPayload = parsePayload(meta.onboarding_start_payload);
+  }
+
+  // ── Strategy 1: Survey + Behavior → richest profile ──
+  if (hasSurveyAnswers) {
+    const onboardingCompleted = !!(
+      surveyResults!.terms_agreement &&
+      (surveyResults!.terms_agreement as string).toLowerCase().includes("да")
+    );
+
+    const profile = normalizeSurveyToProfile(
+      surveyResults!,
+      behaviorSignals,
+      parsedPayload,
+      onboardingCompleted,
+      meta.onboarding_context,
+    );
+
+    // Attach resolver version for observability
+    return {
+      ...profile,
+      onboardingContext: {
+        ...profile.onboardingContext,
+        profileResolverVersion: PROFILE_RESOLVER_VERSION,
+      },
+    };
+  }
+
+  // ── Strategy 2: Behavior only → behavior-derived profile ──
+  if (hasBehavior) {
+    const profile = normalizeSurveyToProfile(
+      {}, // no survey answers
+      behaviorSignals,
+      parsedPayload,
+      false, // no survey completed
+      undefined, // no onboarding context
+    );
+
+    return {
+      ...profile,
+      onboardingContext: {
+        ...profile.onboardingContext,
+        profileResolverVersion: PROFILE_RESOLVER_VERSION,
+      },
+    };
+  }
+
+  // ── Strategy 3: Only /start payload → pre-survey profile ──
+  if (parsedPayload && parsedPayload.code) {
+    return {
+      segment: parsedPayload.segmentHint ?? "mixed",
+      intent: parsedPayload.intentHint ?? "explore",
+      experience: "beginner",
+      onboardingCompleted: false,
+      confidence: 0.15, // Low confidence — payload hint only
+      source: {
+        promoCode: extractPromoFromPayload(parsedPayload),
+        payload: parsedPayload.raw,
+      },
+      onboardingContext: {
+        profileResolverVersion: PROFILE_RESOLVER_VERSION,
+      },
+    };
+  }
+
+  // ── Strategy 4: Nothing → default profile ──
+  const defaultProfile = createDefaultProfile();
+  return {
+    ...defaultProfile,
+    onboardingContext: {
+      ...defaultProfile.onboardingContext,
+      profileResolverVersion: PROFILE_RESOLVER_VERSION,
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────
+
+/**
+ * Extracts a promo code from a parsed payload, if applicable.
+ */
+function extractPromoFromPayload(payload: ParsedPayload): string | undefined {
+  if (["promo", "ref", "invite", "code", "bare"].includes(payload.type)) {
+    return payload.code || undefined;
+  }
+  return undefined;
+}

--- a/app/franchize/lib/onboarding/survey-normalizer.ts
+++ b/app/franchize/lib/onboarding/survey-normalizer.ts
@@ -35,6 +35,7 @@
  * The normalizer also implements INTENT DECAY:
  *   - Survey completed 6 months ago with no behavioral signals → confidence decays
  *   - Recent behavioral signals → confidence reinforced
+ *   - Per-intent decay: buy clicks from 6 months ago decay separately
  *   - This prevents permanently locking users into outdated intent
  */
 
@@ -70,6 +71,13 @@ const REINFORCEMENT_THRESHOLD = 3;
  */
 const MAX_SURVEY_AGE_DAYS = 365;
 
+/**
+ * How quickly per-intent behavioral signals decay.
+ * After this many days, a behavioral click's weight is halved.
+ * This prevents old buy clicks from permanently overriding survey signals.
+ */
+const BEHAVIOR_DECAY_HALF_LIFE_DAYS = 60;
+
 // ─────────────────────────────────────────────────────
 // Answer → Category mapping tables
 // ─────────────────────────────────────────────────────
@@ -89,24 +97,54 @@ const BIKE_STYLE_TO_SEGMENT: Array<{ keywords: string[]; segment: VipBikeSegment
 /**
  * Maps purpose survey signal → VipBikeIntent.
  * This is the PRIMARY intent driver.
+ *
+ * IMPORTANT: Purpose maps to intent ONLY when the purpose
+ * explicitly implies buying/renting/community. General riding
+ * style (track, city) is a SEGMENT signal, not an intent signal.
  */
 const PURPOSE_TO_INTENT: Array<{ keywords: string[]; intent: VipBikeIntent }> = [
-  { keywords: ["город", "между рядами", "комфорт"], intent: "rent" },
-  { keywords: ["трек", "гоночн", "прокат", "аренд"], intent: "rent" },
-  { keywords: ["дальн", "покупк", "купить", "сво"], intent: "buy" },
+  // Explicit purchase signals
+  { keywords: ["покупк", "купить", "сво"], intent: "buy" },
+  // Explicit rental/try signals
+  { keywords: ["прокат", "аренд"], intent: "rent" },
+  // Community signals
   { keywords: ["групп", "карт", "вместе", "компани", "друз"], intent: "community" },
+  // Exploration signals
   { keywords: ["загород", "извилист", "маршрут"], intent: "explore" },
 ];
 
 /**
- * Maps priority survey signal → VipBikeIntent (secondary signal).
+ * Maps purpose survey signal → VipBikeSegment (secondary segment signal).
+ * Riding LOCATION drives WHAT kind of bike, not WHY they're here.
+ */
+const PURPOSE_TO_SEGMENT: Array<{ keywords: string[]; segment: VipBikeSegment }> = [
+  { keywords: ["город", "между рядами"], segment: "urban" },
+  { keywords: ["трек", "гоночн"], segment: "sport" },
+  { keywords: ["дальн", "загород"], segment: "touring" },
+  { keywords: ["групп", "карт"], segment: "mixed" },
+];
+
+/**
+ * Maps priority survey signal → VipBikeSegment (NOT intent!).
+ *
+ * FIX: Priority is a STYLE preference, not an intent signal.
+ * "Бешеное ускорение" = sport segment, NOT rent intent.
+ * "Внешний вид" = retro segment, NOT explore intent.
+ * Only explicit purchase/rent keywords should drive intent from priority.
+ */
+const PRIORITY_TO_SEGMENT: Array<{ keywords: string[]; segment: VipBikeSegment }> = [
+  { keywords: ["ускорен", "адреналин", "скорость"], segment: "sport" },
+  { keywords: ["управля", "маневр", "остр"], segment: "sport" },
+  { keywords: ["внешн", "вниман", "стиль", "дорог"], segment: "retro" },
+  { keywords: ["удобств", "технолог", "комфорт"], segment: "touring" },
+];
+
+/**
+ * Maps priority survey signal → VipBikeIntent (only for explicit purchase signals).
+ * Most priority answers are STYLE signals and should NOT drive intent.
  */
 const PRIORITY_TO_INTENT: Array<{ keywords: string[]; intent: VipBikeIntent }> = [
-  { keywords: ["ускорен", "адреналин", "скорость"], intent: "rent" },
-  { keywords: ["управля", "маневр", "остр"], intent: "rent" },
-  { keywords: ["внешн", "вниман", "стиль", "дорог"], intent: "explore" },
   { keywords: ["покупк", "купить"], intent: "buy" },
-  { keywords: ["удобств", "технолог", "комфорт"], intent: "explore" },
 ];
 
 /**
@@ -118,15 +156,50 @@ const EXPERIENCE_MAP: Array<{ keywords: string[]; level: VipBikeExperience }> = 
   { keywords: ["профи", "3+ лет", "3 лет", "эксперт"], level: "advanced" },
 ];
 
+// ─────────────────────────────────────────────────────
+// Per-intent decay (decayByAge)
+// ─────────────────────────────────────────────────────
+
 /**
- * Maps purpose survey signal → VipBikeSegment (secondary signal).
+ * Computes a decay multiplier for a behavioral signal based on its age.
+ *
+ * A buy click from yesterday has full weight.
+ * A buy click from 60 days ago has half weight.
+ * A buy click from 120 days ago has quarter weight.
+ *
+ * This prevents old behavioral signals from permanently overriding
+ * more recent survey or behavioral data.
+ *
+ * @param lastInteractionAt - ISO timestamp of the last interaction of this type
+ * @returns Multiplier 0-1 that scales the signal's weight
  */
-const PURPOSE_TO_SEGMENT: Array<{ keywords: string[]; segment: VipBikeSegment }> = [
-  { keywords: ["город", "между рядами"], segment: "urban" },
-  { keywords: ["трек", "гоночн"], segment: "sport" },
-  { keywords: ["дальн", "загород"], segment: "touring" },
-  { keywords: ["групп", "карт"], segment: "mixed" },
-];
+export function decayByAge(lastInteractionAt: string | undefined): number {
+  if (!lastInteractionAt) return 1.0; // No timestamp = don't decay (backward compat)
+
+  const now = Date.now();
+  const interactionMs = new Date(lastInteractionAt).getTime();
+  const ageDays = (now - interactionMs) / (1000 * 60 * 60 * 24);
+
+  if (ageDays < 0) return 1.0; // Future timestamp (clock skew) → don't decay
+
+  return Math.pow(0.5, ageDays / BEHAVIOR_DECAY_HALF_LIFE_DAYS);
+}
+
+/**
+ * Computes decayed effective counts for each intent type.
+ * This is the core of per-intent decay: old signals weigh less.
+ */
+function computeEffectiveBehaviorCounts(behavior: BehaviorSignals): {
+  effectiveBuyClicks: number;
+  effectiveRentClicks: number;
+  effectiveMapOpens: number;
+} {
+  return {
+    effectiveBuyClicks: (behavior.buyIntentClickCount ?? 0) * decayByAge(behavior.lastBuyInteractionAt),
+    effectiveRentClicks: (behavior.rentIntentClickCount ?? 0) * decayByAge(behavior.lastRentInteractionAt),
+    effectiveMapOpens: (behavior.openedMapCount ?? 0) * decayByAge(behavior.lastMapInteractionAt),
+  };
+}
 
 // ─────────────────────────────────────────────────────
 // Behavioral signal interpretation
@@ -160,29 +233,30 @@ function deriveSegmentFromBehavior(behavior: BehaviorSignals | undefined): VipBi
 }
 
 /**
- * Derives intent from behavioral signals.
+ * Derives intent from behavioral signals using DECAYED counts.
  * Behavioral signals are a STRONGER signal than survey signals for intent
  * because they show what users ACTUALLY do, not what they SAY.
+ * But old behavioral signals decay — a buy click from 6 months ago
+ * should not permanently override a recent survey.
  */
 function deriveIntentFromBehavior(behavior: BehaviorSignals | undefined): VipBikeIntent | null {
   if (!behavior) return null;
 
-  const buyClicks = behavior.buyIntentClickCount ?? 0;
-  const rentClicks = behavior.rentIntentClickCount ?? 0;
-  const mapOpens = behavior.openedMapCount ?? 0;
+  const { effectiveBuyClicks, effectiveRentClicks, effectiveMapOpens } =
+    computeEffectiveBehaviorCounts(behavior);
 
   // Map interactions → community intent
-  if (mapOpens >= REINFORCEMENT_THRESHOLD && mapOpens > buyClicks && mapOpens > rentClicks) {
+  if (effectiveMapOpens >= REINFORCEMENT_THRESHOLD && effectiveMapOpens > effectiveBuyClicks && effectiveMapOpens > effectiveRentClicks) {
     return "community";
   }
 
   // Buy clicks → buy intent
-  if (buyClicks >= REINFORCEMENT_THRESHOLD && buyClicks > rentClicks) {
+  if (effectiveBuyClicks >= REINFORCEMENT_THRESHOLD && effectiveBuyClicks > effectiveRentClicks) {
     return "buy";
   }
 
   // Rent clicks → rent intent
-  if (rentClicks >= REINFORCEMENT_THRESHOLD) {
+  if (effectiveRentClicks >= REINFORCEMENT_THRESHOLD) {
     return "rent";
   }
 
@@ -191,24 +265,28 @@ function deriveIntentFromBehavior(behavior: BehaviorSignals | undefined): VipBik
 
 /**
  * Checks if behavioral signals are strong enough to override survey signals.
- * Returns true if behavior has enough data points to be authoritative.
+ * Uses DECAYED counts — old signals don't count as much.
+ * Returns true if behavior has enough recent data points to be authoritative.
  */
 function shouldBehaviorOverride(behavior: BehaviorSignals | undefined): boolean {
   if (!behavior) return false;
 
-  const totalInteractions =
+  const { effectiveBuyClicks, effectiveRentClicks, effectiveMapOpens } =
+    computeEffectiveBehaviorCounts(behavior);
+
+  const effectiveTotal =
     (behavior.viewedElectroCount ?? 0) +
     (behavior.viewedSportCount ?? 0) +
     (behavior.viewedRetroCount ?? 0) +
-    (behavior.buyIntentClickCount ?? 0) +
-    (behavior.rentIntentClickCount ?? 0) +
-    (behavior.openedMapCount ?? 0);
+    effectiveBuyClicks +
+    effectiveRentClicks +
+    effectiveMapOpens;
 
-  return totalInteractions >= REINFORCEMENT_THRESHOLD * 2; // 6+ interactions to override
+  return effectiveTotal >= REINFORCEMENT_THRESHOLD * 2; // 6+ effective interactions to override
 }
 
 // ─────────────────────────────────────────────────────
-// Intent decay
+// Intent decay (survey-level)
 // ─────────────────────────────────────────────────────
 
 /**
@@ -326,11 +404,14 @@ function computeSurveyConfidence(answers: BikeSurveyAnswers): number {
 
 /**
  * Checks if two segments are contradictory.
+ * Expanded list covering more realistic contradictions.
  */
 function areContradictory(a: VipBikeSegment, b: VipBikeSegment): boolean {
   const contradictions: Array<[VipBikeSegment, VipBikeSegment]> = [
-    ["sport", "retro"],
-    ["electro", "sport"],
+    ["sport", "retro"],       // Speed vs style
+    ["electro", "sport"],     // Quiet tech vs raw power
+    ["touring", "sport"],     // Comfort vs adrenaline
+    ["urban", "touring"],     // Short trips vs long distance
   ];
   return contradictions.some(
     ([x, y]) => (a === x && b === y) || (a === y && b === x),
@@ -388,7 +469,7 @@ function mergeIntent(
  * This is the ONLY function that should interpret raw signals.
  * All personalization logic flows from the returned profile object.
  *
- * @param answers - Raw survey answers from metadata.survey_results
+ * @param answers - Raw survey signals from metadata.survey_results
  * @param behavior - Behavioral signals from metadata.behavior_signals
  * @param payload - Optional parsed /start payload (provides pre-survey hints)
  * @param onboardingCompleted - Whether the user finished the survey
@@ -415,12 +496,16 @@ export function normalizeSurveyToProfile(
   // ── Derive segment from survey ──
   const styleMatch = matchKeywords(answers.bike_style, BIKE_STYLE_TO_SEGMENT);
   const purposeSegMatch = matchKeywords(answers.purpose, PURPOSE_TO_SEGMENT);
+  const prioritySegMatch = matchKeywords(answers.priority, PRIORITY_TO_SEGMENT);
 
   let surveySegment: VipBikeSegment | null = null;
   if (styleMatch) {
     surveySegment = styleMatch.segment;
   } else if (purposeSegMatch) {
     surveySegment = purposeSegMatch.segment;
+  } else if (prioritySegMatch) {
+    // Priority is a segment signal (style preference), not intent
+    surveySegment = prioritySegMatch.segment;
   }
 
   // ── Derive intent from survey ──

--- a/app/franchize/lib/onboarding/survey-normalizer.ts
+++ b/app/franchize/lib/onboarding/survey-normalizer.ts
@@ -1,0 +1,527 @@
+/**
+ * survey-normalizer.ts
+ * ====================
+ * Transforms raw signals (survey signals + behavioral signals + payload signals)
+ * into a normalized VipBikeUserProfile.
+ *
+ * THIS IS THE SINGLE SOURCE OF TRUTH for interpreting all raw signals.
+ * No other file should read survey signals or behavior counters
+ * and try to derive segments/intents. If the survey questions change,
+ * you update THIS file and nothing else.
+ *
+ * ARCHITECTURE (signals terminology):
+ *   Raw signals (survey + behavior + payload)
+ *       ↓ (this file)
+ *   VipBikeUserProfile (segment, intent, experience, confidence)
+ *       ↓ (resolve-experience.ts)
+ *   VipBikeExperienceConfig (heroMode, sectionOrder, CTAs)
+ *       ↓ (VipBikeRentalClient.tsx)
+ *   Rendered page
+ *
+ * FIVE SIGNAL SOURCES, MERGED WITH PRIORITY:
+ *
+ *   1. Survey signals — strongest signal, but can become stale
+ *   2. Behavioral signals — progressive enrichment, reinforces or overrides survey
+ *   3. Payload signals — weakest signal, seeds profile before survey
+ *   4. Referral signals — from referral codes (future)
+ *   5. Geo/seasonal signals — from location and time (future)
+ *
+ * SIGNALS TERMINOLOGY MATTERS:
+ *   - "signals" not "answers" — because we have multiple sources
+ *   - "survey signals" not "survey results" — because they're one input among many
+ *   - "behavioral signals" not "tracking" — because they inform, not surveil
+ *   - "payload signals" not "deep-link data" — because they carry intent
+ *
+ * The normalizer also implements INTENT DECAY:
+ *   - Survey completed 6 months ago with no behavioral signals → confidence decays
+ *   - Recent behavioral signals → confidence reinforced
+ *   - This prevents permanently locking users into outdated intent
+ */
+
+import type {
+  VipBikeUserProfile,
+  VipBikeSegment,
+  VipBikeIntent,
+  VipBikeExperience,
+  BikeSurveyAnswers,
+  BehaviorSignals,
+  ParsedPayload,
+} from "./experience-types";
+
+// ─────────────────────────────────────────────────────
+// Intent decay configuration
+// ─────────────────────────────────────────────────────
+
+/**
+ * How quickly survey-derived confidence decays without behavioral reinforcement.
+ * After this many days, survey confidence is halved.
+ */
+const DECAY_HALF_LIFE_DAYS = 90;
+
+/**
+ * How many behavioral interactions count as "reinforcement"
+ * that prevents decay.
+ */
+const REINFORCEMENT_THRESHOLD = 3;
+
+/**
+ * Maximum days before a survey signal is considered "stale"
+ * even with reinforcement. After this, only behavior matters.
+ */
+const MAX_SURVEY_AGE_DAYS = 365;
+
+// ─────────────────────────────────────────────────────
+// Answer → Category mapping tables
+// ─────────────────────────────────────────────────────
+
+/**
+ * Maps bike_style survey signal → VipBikeSegment.
+ * This is the PRIMARY segment driver.
+ */
+const BIKE_STYLE_TO_SEGMENT: Array<{ keywords: string[]; segment: VipBikeSegment }> = [
+  { keywords: ["нео-ретро", "neo", "ретро", "харизма"], segment: "retro" },
+  { keywords: ["суперспорт", "спорт", "обтекател", "эмбриона"], segment: "sport" },
+  { keywords: ["стритфайтер", "нейкед", "агрессивн"], segment: "sport" },
+  { keywords: ["спорт-турист", "мощность и комфорт", "тур"], segment: "touring" },
+  { keywords: ["электро", "электр", "electro", "enduro"], segment: "electro" },
+];
+
+/**
+ * Maps purpose survey signal → VipBikeIntent.
+ * This is the PRIMARY intent driver.
+ */
+const PURPOSE_TO_INTENT: Array<{ keywords: string[]; intent: VipBikeIntent }> = [
+  { keywords: ["город", "между рядами", "комфорт"], intent: "rent" },
+  { keywords: ["трек", "гоночн", "прокат", "аренд"], intent: "rent" },
+  { keywords: ["дальн", "покупк", "купить", "сво"], intent: "buy" },
+  { keywords: ["групп", "карт", "вместе", "компани", "друз"], intent: "community" },
+  { keywords: ["загород", "извилист", "маршрут"], intent: "explore" },
+];
+
+/**
+ * Maps priority survey signal → VipBikeIntent (secondary signal).
+ */
+const PRIORITY_TO_INTENT: Array<{ keywords: string[]; intent: VipBikeIntent }> = [
+  { keywords: ["ускорен", "адреналин", "скорость"], intent: "rent" },
+  { keywords: ["управля", "маневр", "остр"], intent: "rent" },
+  { keywords: ["внешн", "вниман", "стиль", "дорог"], intent: "explore" },
+  { keywords: ["покупк", "купить"], intent: "buy" },
+  { keywords: ["удобств", "технолог", "комфорт"], intent: "explore" },
+];
+
+/**
+ * Maps experience survey signal → VipBikeExperience.
+ */
+const EXPERIENCE_MAP: Array<{ keywords: string[]; level: VipBikeExperience }> = [
+  { keywords: ["новичок", "до 1 год", "только что получ", "прав"], level: "beginner" },
+  { keywords: ["опытн", "1-3 год", "средн"], level: "intermediate" },
+  { keywords: ["профи", "3+ лет", "3 лет", "эксперт"], level: "advanced" },
+];
+
+/**
+ * Maps purpose survey signal → VipBikeSegment (secondary signal).
+ */
+const PURPOSE_TO_SEGMENT: Array<{ keywords: string[]; segment: VipBikeSegment }> = [
+  { keywords: ["город", "между рядами"], segment: "urban" },
+  { keywords: ["трек", "гоночн"], segment: "sport" },
+  { keywords: ["дальн", "загород"], segment: "touring" },
+  { keywords: ["групп", "карт"], segment: "mixed" },
+];
+
+// ─────────────────────────────────────────────────────
+// Behavioral signal interpretation
+// ─────────────────────────────────────────────────────
+
+/**
+ * Derives segment from behavioral signals.
+ * If behavior contradicts survey signals, behavior wins when counts are high enough.
+ *
+ * "Surveys lie. Behavior doesn't."
+ * User says: "I like retro bikes" but viewedElectroCount = 27.
+ * The resolver can evolve naturally. That's how mature adaptive systems work.
+ */
+function deriveSegmentFromBehavior(behavior: BehaviorSignals | undefined): VipBikeSegment | null {
+  if (!behavior) return null;
+
+  const electroViews = behavior.viewedElectroCount ?? 0;
+  const sportViews = behavior.viewedSportCount ?? 0;
+  const retroViews = behavior.viewedRetroCount ?? 0;
+
+  // Need at least 3 views in a category to derive segment
+  const total = electroViews + sportViews + retroViews;
+  if (total < REINFORCEMENT_THRESHOLD) return null;
+
+  // Dominant category
+  if (electroViews > sportViews && electroViews > retroViews && electroViews >= REINFORCEMENT_THRESHOLD) return "electro";
+  if (sportViews > electroViews && sportViews > retroViews && sportViews >= REINFORCEMENT_THRESHOLD) return "sport";
+  if (retroViews > electroViews && retroViews > sportViews && retroViews >= REINFORCEMENT_THRESHOLD) return "retro";
+
+  return null;
+}
+
+/**
+ * Derives intent from behavioral signals.
+ * Behavioral signals are a STRONGER signal than survey signals for intent
+ * because they show what users ACTUALLY do, not what they SAY.
+ */
+function deriveIntentFromBehavior(behavior: BehaviorSignals | undefined): VipBikeIntent | null {
+  if (!behavior) return null;
+
+  const buyClicks = behavior.buyIntentClickCount ?? 0;
+  const rentClicks = behavior.rentIntentClickCount ?? 0;
+  const mapOpens = behavior.openedMapCount ?? 0;
+
+  // Map interactions → community intent
+  if (mapOpens >= REINFORCEMENT_THRESHOLD && mapOpens > buyClicks && mapOpens > rentClicks) {
+    return "community";
+  }
+
+  // Buy clicks → buy intent
+  if (buyClicks >= REINFORCEMENT_THRESHOLD && buyClicks > rentClicks) {
+    return "buy";
+  }
+
+  // Rent clicks → rent intent
+  if (rentClicks >= REINFORCEMENT_THRESHOLD) {
+    return "rent";
+  }
+
+  return null;
+}
+
+/**
+ * Checks if behavioral signals are strong enough to override survey signals.
+ * Returns true if behavior has enough data points to be authoritative.
+ */
+function shouldBehaviorOverride(behavior: BehaviorSignals | undefined): boolean {
+  if (!behavior) return false;
+
+  const totalInteractions =
+    (behavior.viewedElectroCount ?? 0) +
+    (behavior.viewedSportCount ?? 0) +
+    (behavior.viewedRetroCount ?? 0) +
+    (behavior.buyIntentClickCount ?? 0) +
+    (behavior.rentIntentClickCount ?? 0) +
+    (behavior.openedMapCount ?? 0);
+
+  return totalInteractions >= REINFORCEMENT_THRESHOLD * 2; // 6+ interactions to override
+}
+
+// ─────────────────────────────────────────────────────
+// Intent decay
+// ─────────────────────────────────────────────────────
+
+/**
+ * Computes a decay multiplier based on survey age.
+ *
+ * If the survey was completed recently → multiplier ≈ 1.0
+ * If it was completed DECAY_HALF_LIFE_DAYS ago → multiplier ≈ 0.5
+ * If it was completed MAX_SURVEY_AGE_DAYS ago → multiplier ≈ 0.0
+ *
+ * Behavioral reinforcement prevents decay:
+ *   If user has recent behavioral signals, decay is reduced.
+ *
+ * @param completedAt - ISO timestamp of survey completion
+ * @param behavior - Current behavioral signals (for reinforcement check)
+ * @returns Multiplier 0-1 that scales survey-derived confidence
+ */
+function computeDecayMultiplier(
+  completedAt: string | undefined,
+  behavior: BehaviorSignals | undefined,
+): number {
+  if (!completedAt) return 0.5; // No completion date → assume moderate freshness
+
+  const now = Date.now();
+  const completedMs = new Date(completedAt).getTime();
+  const ageDays = (now - completedMs) / (1000 * 60 * 60 * 24);
+
+  // Beyond max age → survey is effectively stale
+  if (ageDays > MAX_SURVEY_AGE_DAYS) return 0.1;
+
+  // Exponential decay
+  const decayMultiplier = Math.pow(0.5, ageDays / DECAY_HALF_LIFE_DAYS);
+
+  // Check for behavioral reinforcement
+  const totalBehavior =
+    (behavior?.viewedElectroCount ?? 0) +
+    (behavior?.viewedSportCount ?? 0) +
+    (behavior?.openedMapCount ?? 0) +
+    (behavior?.buyIntentClickCount ?? 0) +
+    (behavior?.rentIntentClickCount ?? 0);
+
+  const hasReinforcement = totalBehavior >= REINFORCEMENT_THRESHOLD;
+  const hasRecentActivity = behavior?.lastActiveAt &&
+    (now - new Date(behavior.lastActiveAt).getTime()) < 30 * 24 * 60 * 60 * 1000; // active in last 30 days
+
+  if (hasReinforcement && hasRecentActivity) {
+    // Behavioral reinforcement reduces decay by 50%
+    return Math.min(1.0, decayMultiplier + (1.0 - decayMultiplier) * 0.5);
+  }
+
+  if (hasReinforcement) {
+    // Reinforcement exists but not recent → partial reduction
+    return Math.min(1.0, decayMultiplier + (1.0 - decayMultiplier) * 0.25);
+  }
+
+  return decayMultiplier;
+}
+
+// ─────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────
+
+/**
+ * Matches a string against a keyword table, returning the first match.
+ * Case-insensitive, partial match (includes).
+ */
+function matchKeywords<T>(
+  value: string | undefined,
+  table: Array<{ keywords: string[] } & T>,
+): (T & { matchedKeyword?: string }) | null {
+  if (!value) return null;
+  const lower = value.toLowerCase();
+  for (const entry of table) {
+    for (const kw of entry.keywords) {
+      if (lower.includes(kw)) {
+        return { ...entry, matchedKeyword: kw };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Computes base confidence score from survey completeness and consistency.
+ *
+ * FACTORS:
+ *   - How many answers are present? (0-5, each +0.15)
+ *   - Are the answers consistent with each other? (+0.10)
+ *   - terms_agreement = "Да" (+0.15)
+ */
+function computeSurveyConfidence(answers: BikeSurveyAnswers): number {
+  const keys = ["experience", "purpose", "bike_style", "priority", "terms_agreement"] as const;
+  const filledCount = keys.filter((k) => answers[k] && answers[k]!.trim().length > 0).length;
+
+  let score = filledCount * 0.15;
+
+  // Bonus for affirmative terms
+  if (answers.terms_agreement?.toLowerCase().includes("да")) {
+    score += 0.15;
+  }
+
+  // Consistency check
+  const styleSegment = matchKeywords(answers.bike_style, BIKE_STYLE_TO_SEGMENT);
+  const purposeSegment = matchKeywords(answers.purpose, PURPOSE_TO_SEGMENT);
+
+  if (styleSegment && purposeSegment) {
+    if (styleSegment.segment === purposeSegment.segment) {
+      score += 0.10;
+    } else if (!areContradictory(styleSegment.segment, purposeSegment.segment)) {
+      score += 0.05;
+    }
+  }
+
+  return Math.min(1.0, score);
+}
+
+/**
+ * Checks if two segments are contradictory.
+ */
+function areContradictory(a: VipBikeSegment, b: VipBikeSegment): boolean {
+  const contradictions: Array<[VipBikeSegment, VipBikeSegment]> = [
+    ["sport", "retro"],
+    ["electro", "sport"],
+  ];
+  return contradictions.some(
+    ([x, y]) => (a === x && b === y) || (a === y && b === x),
+  );
+}
+
+/**
+ * Merges signals from multiple sources with priority:
+ *   1. Behavioral signals (if strong enough to override)
+ *   2. Survey signals (primary)
+ *   3. Payload signals (pre-survey seed)
+ *   4. Default fallback
+ *
+ * Future: referral signals, geo signals, seasonal signals
+ */
+function mergeSegment(
+  behaviorSegment: VipBikeSegment | null,
+  behaviorOverride: boolean,
+  surveySegment: VipBikeSegment | null,
+  payloadHint: VipBikeSegment | undefined,
+  defaultSegment: VipBikeSegment = "mixed",
+): VipBikeSegment {
+  // Behavior overrides survey when strong enough AND contradicts
+  if (behaviorOverride && behaviorSegment) return behaviorSegment;
+  // Survey is primary
+  if (surveySegment) return surveySegment;
+  // Behavior without override is still better than nothing
+  if (behaviorSegment) return behaviorSegment;
+  // Payload hint is weakest
+  if (payloadHint) return payloadHint;
+  return defaultSegment;
+}
+
+function mergeIntent(
+  behaviorIntent: VipBikeIntent | null,
+  behaviorOverride: boolean,
+  surveyIntent: VipBikeIntent | null,
+  payloadHint: VipBikeIntent | undefined,
+  defaultIntent: VipBikeIntent = "explore",
+): VipBikeIntent {
+  if (behaviorOverride && behaviorIntent) return behaviorIntent;
+  if (surveyIntent) return surveyIntent;
+  if (behaviorIntent) return behaviorIntent;
+  if (payloadHint) return payloadHint;
+  return defaultIntent;
+}
+
+// ─────────────────────────────────────────────────────
+// PUBLIC API
+// ─────────────────────────────────────────────────────
+
+/**
+ * Normalizes raw signals into a VipBikeUserProfile.
+ *
+ * This is the ONLY function that should interpret raw signals.
+ * All personalization logic flows from the returned profile object.
+ *
+ * @param answers - Raw survey answers from metadata.survey_results
+ * @param behavior - Behavioral signals from metadata.behavior_signals
+ * @param payload - Optional parsed /start payload (provides pre-survey hints)
+ * @param onboardingCompleted - Whether the user finished the survey
+ * @param onboardingContext - Metadata about the onboarding session (for decay)
+ *
+ * @example
+ *   const profile = normalizeSurveyToProfile(
+ *     { experience: "Новичок", purpose: "В городе", bike_style: "Нео-ретро", ... },
+ *     { viewedRetroCount: 7, openedMapCount: 5, lastActiveAt: "2026-05-20T10:00:00Z" },
+ *     { type: "entry", code: "ELECTRO", raw: "entry.electro", segmentHint: "electro" },
+ *     true,
+ *     { completedAt: "2026-05-24T10:00:00Z", version: "bike-v1", entryPoint: "telegram:start" }
+ *   );
+ *   // → { segment: "retro", intent: "explore", experience: "beginner", confidence: 0.85, ... }
+ *   //    Note: behavior (7 retro views) overrides payload hint (electro)
+ */
+export function normalizeSurveyToProfile(
+  answers: BikeSurveyAnswers,
+  behavior?: BehaviorSignals | null,
+  payload?: ParsedPayload | null,
+  onboardingCompleted?: boolean,
+  onboardingContext?: VipBikeUserProfile["onboardingContext"],
+): VipBikeUserProfile {
+  // ── Derive segment from survey ──
+  const styleMatch = matchKeywords(answers.bike_style, BIKE_STYLE_TO_SEGMENT);
+  const purposeSegMatch = matchKeywords(answers.purpose, PURPOSE_TO_SEGMENT);
+
+  let surveySegment: VipBikeSegment | null = null;
+  if (styleMatch) {
+    surveySegment = styleMatch.segment;
+  } else if (purposeSegMatch) {
+    surveySegment = purposeSegMatch.segment;
+  }
+
+  // ── Derive intent from survey ──
+  const purposeMatch = matchKeywords(answers.purpose, PURPOSE_TO_INTENT);
+  const priorityMatch = matchKeywords(answers.priority, PRIORITY_TO_INTENT);
+
+  let surveyIntent: VipBikeIntent | null = null;
+  if (purposeMatch) {
+    surveyIntent = purposeMatch.intent;
+  } else if (priorityMatch) {
+    surveyIntent = priorityMatch.intent;
+  }
+
+  // ── Derive experience level ──
+  const expMatch = matchKeywords(answers.experience, EXPERIENCE_MAP);
+  const surveyExperience: VipBikeExperience = expMatch?.level ?? "beginner";
+
+  // ── Derive from behavioral signals ──
+  const behaviorSegment = deriveSegmentFromBehavior(behavior);
+  const behaviorIntent = deriveIntentFromBehavior(behavior);
+  const behaviorOverride = shouldBehaviorOverride(behavior);
+
+  // ── Merge all signals ──
+  const segment = mergeSegment(behaviorSegment, behaviorOverride, surveySegment, payload?.segmentHint);
+  const intent = mergeIntent(behaviorIntent, behaviorOverride, surveyIntent, payload?.intentHint);
+
+  // ── Compute confidence ──
+  const hasAnswers = Object.values(answers).some((v) => v && v.trim().length > 0);
+  let confidence = 0;
+
+  if (hasAnswers) {
+    const baseConfidence = computeSurveyConfidence(answers);
+    const decayMultiplier = computeDecayMultiplier(
+      onboardingContext?.completedAt,
+      behavior,
+    );
+    confidence = baseConfidence * decayMultiplier;
+
+    // Behavioral reinforcement bonus (up to +0.15)
+    if (behavior) {
+      const totalBehavior =
+        (behavior.viewedElectroCount ?? 0) +
+        (behavior.viewedSportCount ?? 0) +
+        (behavior.viewedRetroCount ?? 0) +
+        (behavior.openedMapCount ?? 0) +
+        (behavior.buyIntentClickCount ?? 0) +
+        (behavior.rentIntentClickCount ?? 0);
+      const behaviorBonus = Math.min(0.15, totalBehavior * 0.02);
+      confidence += behaviorBonus;
+    }
+  } else if (behavior) {
+    // No survey but has behavioral signals → low but non-zero confidence
+    const totalBehavior =
+      (behavior.viewedElectroCount ?? 0) +
+      (behavior.viewedSportCount ?? 0) +
+      (behavior.openedMapCount ?? 0) +
+      (behavior.buyIntentClickCount ?? 0) +
+      (behavior.rentIntentClickCount ?? 0);
+    confidence = Math.min(0.4, totalBehavior * 0.03);
+  } else if (payload?.code) {
+    // Only payload → very low confidence
+    confidence = 0.15;
+  }
+
+  confidence = Math.min(1.0, Math.max(0, confidence));
+
+  // ── Determine onboarding status ──
+  const completed = onboardingCompleted ?? (
+    !!answers.terms_agreement && answers.terms_agreement.toLowerCase().includes("да")
+  );
+
+  return {
+    segment,
+    intent,
+    experience: surveyExperience,
+    onboardingCompleted: completed,
+    confidence,
+    source: payload
+      ? {
+          promoCode: ["promo", "ref", "invite", "code", "bare"].includes(payload.type)
+            ? payload.code
+            : undefined,
+          payload: payload.raw,
+          surveyVersion: onboardingContext?.version,
+        }
+      : undefined,
+    onboardingContext,
+    behaviorSignals: behavior,
+  };
+}
+
+/**
+ * Creates a default profile for users with no signals at all.
+ * This ensures the landing always has a valid profile to work with.
+ */
+export function createDefaultProfile(): VipBikeUserProfile {
+  return {
+    segment: "mixed",
+    intent: "explore",
+    experience: "beginner",
+    onboardingCompleted: false,
+    confidence: 0,
+  };
+}

--- a/app/franchize/lib/onboarding/track-behavior.ts
+++ b/app/franchize/lib/onboarding/track-behavior.ts
@@ -1,0 +1,281 @@
+/**
+ * track-behavior.ts
+ * =================
+ * Client-side behavioral signal tracker for progressive enrichment.
+ *
+ * This module provides functions that VipBikeRentalClient (and other
+ * franchise pages) call to accumulate micro-signals from user interactions.
+ * These signals are persisted to metadata.behavior_signals via a server action.
+ *
+ * WHY THIS MATTERS:
+ *   Survey answers capture INTENT AT ONE MOMENT.
+ *   Behavioral signals capture EVOLVING INTENT over time.
+ *
+ *   A user who answered "sport" but has viewed electro bikes 7 times
+ *   and never looked at sport bikes should gradually shift toward
+ *   electro segment. The normalizer handles this.
+ *
+ * DESIGN:
+ *   - Signals are tracked client-side and batched to the server
+ *   - Debounced to avoid hammering the API on every click
+ *   - Uses a server action to persist to metadata.behavior_signals
+ *   - The normalizer reads behavior_signals at runtime (not cached)
+ *   - Also handles experience_lock writeback for anti-thrashing
+ *
+ * USAGE in VipBikeRentalClient:
+ *   const tracker = useBehaviorTracker();
+ *   // On electro showcase view:
+ *   tracker.trackViewCategory("electro");
+ *   // On map interaction:
+ *   tracker.trackMapOpen();
+ *   // On buy click:
+ *   tracker.trackBuyClick("surron-s1");
+ *   // After resolving a new experience:
+ *   tracker.persistExperienceLock(profile, experience);
+ */
+
+"use client";
+
+import { useCallback, useRef } from "react";
+import { useAppContext } from "@/contexts/AppContext";
+import type { BehaviorSignals, VipBikeUserProfile, VipBikeExperienceConfig } from "./experience-types";
+import { SCANNED_QR_MODELS_CAP } from "./experience-types";
+import type { ExperienceLockState } from "./resolve-experience";
+import { computeExperienceLockUpdate } from "./resolve-experience";
+
+// ─────────────────────────────────────────────────────
+// Server action for persisting behavior signals
+// ─────────────────────────────────────────────────────
+
+/**
+ * Server action that merges new behavior signals into the user's metadata.
+ * Uses atomic increment to avoid race conditions.
+ *
+ * NOTE: This is a placeholder — implement as a real server action
+ * in app/franchize/actions.ts that does:
+ *
+ *   1. Read current metadata.behavior_signals
+ *   2. Merge new counts (increment, don't replace)
+ *   3. Cap scannedQrModels to SCANNED_QR_MODELS_CAP entries
+ *   4. Write back with updated lastActiveAt
+ */
+async function persistBehaviorSignals(
+  userId: string,
+  delta: Partial<BehaviorSignals>,
+): Promise<{ success: boolean }> {
+  try {
+    const response = await fetch("/api/franchize/behavior-signals", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId, delta }),
+    });
+    return { success: response.ok };
+  } catch {
+    return { success: false };
+  }
+}
+
+/**
+ * Server action that persists the updated experience_lock.
+ * Called by the component after resolving a new experience.
+ */
+async function persistExperienceLockAction(
+  userId: string,
+  lockState: ExperienceLockState,
+): Promise<{ success: boolean }> {
+  try {
+    const response = await fetch("/api/franchize/experience-lock", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId, experience_lock: lockState }),
+    });
+    return { success: response.ok };
+  } catch {
+    return { success: false };
+  }
+}
+
+// ─────────────────────────────────────────────────────
+// Debounced batch persister
+// ─────────────────────────────────────────────────────
+
+/**
+ * Accumulates behavior deltas and flushes them to the server
+ * after a debounce period (500ms). This prevents hammering
+ * the API when the user rapidly clicks through items.
+ */
+class BehaviorBatcher {
+  private pending: Partial<BehaviorSignals> = {};
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private userId: string;
+  private debounceMs: number;
+
+  constructor(userId: string, debounceMs = 500) {
+    this.userId = userId;
+    this.debounceMs = debounceMs;
+  }
+
+  add(delta: Partial<BehaviorSignals>): void {
+    // Merge numeric deltas (increment)
+    for (const [key, value] of Object.entries(delta)) {
+      if (typeof value === "number") {
+        const current = (this.pending as Record<string, unknown>)[key] as number | undefined;
+        (this.pending as Record<string, unknown>)[key] = (current ?? 0) + value;
+      } else if (typeof value === "string") {
+        // String fields: update to latest value (e.g., lastActiveAt)
+        (this.pending as Record<string, unknown>)[key] = value;
+      } else if (Array.isArray(value)) {
+        // Array fields: append (e.g., scannedQrModels)
+        const current = (this.pending as Record<string, unknown>)[key] as string[] | undefined;
+        const merged = [...(current ?? []), ...value];
+        // Cap to prevent unbounded growth
+        (this.pending as Record<string, unknown>)[key] = merged.slice(-SCANNED_QR_MODELS_CAP);
+      }
+    }
+
+    // Always update lastActiveAt
+    this.pending.lastActiveAt = new Date().toISOString();
+
+    // Debounce flush
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.flush(), this.debounceMs);
+  }
+
+  async flush(): Promise<void> {
+    if (Object.keys(this.pending).length === 0) return;
+
+    const batch = { ...this.pending };
+    this.pending = {};
+    this.timer = null;
+
+    await persistBehaviorSignals(this.userId, batch);
+  }
+
+  /** Call on page unload to flush any pending signals */
+  destroy(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.flush();
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────
+// React hook: useBehaviorTracker
+// ─────────────────────────────────────────────────────
+
+/**
+ * Hook that provides behavior tracking methods for the current user.
+ *
+ * Usage:
+ *   const tracker = useBehaviorTracker();
+ *
+ *   // Track category view (e.g., when user scrolls to electro showcase)
+ *   tracker.trackViewCategory("electro");
+ *
+ *   // Track map interaction
+ *   tracker.trackMapOpen();
+ *
+ *   // Track buy intent (e.g., clicked "Buy" or "Configure")
+ *   tracker.trackBuyClick();
+ *
+ *   // Track rent intent (e.g., clicked "Rent" or "Book")
+ *   tracker.trackRentClick();
+ *
+ *   // Track QR scan (from physical world → digital)
+ *   tracker.trackQrScan("surron-s1");
+ *
+ *   // Track time on section (e.g., invest section dwell time)
+ *   tracker.trackSectionDwell("investSection", 45); // 45 seconds
+ *
+ *   // After resolving a new experience (anti-thrashing writeback)
+ *   tracker.persistExperienceLock(profile, newExperience);
+ */
+export function useBehaviorTracker() {
+  const { dbUser } = useAppContext();
+  const batcherRef = useRef<BehaviorBatcher | null>(null);
+
+  // Initialize batcher for authenticated users
+  if (dbUser && !batcherRef.current) {
+    batcherRef.current = new BehaviorBatcher(dbUser.id ?? "");
+  }
+
+  const trackViewCategory = useCallback((category: "electro" | "sport" | "retro") => {
+    if (!batcherRef.current) return;
+
+    const key = category === "electro"
+      ? "viewedElectroCount"
+      : category === "sport"
+        ? "viewedSportCount"
+        : "viewedRetroCount";
+
+    batcherRef.current.add({ [key]: 1 } as Partial<BehaviorSignals>);
+  }, []);
+
+  const trackMapOpen = useCallback(() => {
+    batcherRef.current?.add({
+      openedMapCount: 1,
+      lastMapInteractionAt: new Date().toISOString(),
+    });
+  }, []);
+
+  const trackBuyClick = useCallback((_modelId?: string) => {
+    batcherRef.current?.add({
+      buyIntentClickCount: 1,
+      lastBuyInteractionAt: new Date().toISOString(),
+    });
+  }, []);
+
+  const trackRentClick = useCallback(() => {
+    batcherRef.current?.add({
+      rentIntentClickCount: 1,
+      lastRentInteractionAt: new Date().toISOString(),
+    });
+  }, []);
+
+  const trackQrScan = useCallback((modelId: string) => {
+    batcherRef.current?.add({
+      scannedQrModels: [modelId], // Batcher caps at SCANNED_QR_MODELS_CAP
+    });
+  }, []);
+
+  const trackSectionDwell = useCallback((sectionId: string, seconds: number) => {
+    if (!batcherRef.current) return;
+
+    if (sectionId === "investSection") {
+      batcherRef.current.add({
+        investSectionViewSeconds: seconds,
+      });
+    }
+    // Add more section-specific dwell tracking as needed
+  }, []);
+
+  /**
+   * Persists the updated experience_lock after a new experience is resolved.
+   * This is the C2 fix: the component calls this to write back the lock state.
+   *
+   * Uses computeExperienceLockUpdate from resolve-experience.ts to compute
+   * the lock update from raw profile signals (not derived preset names).
+   */
+  const persistExperienceLock = useCallback((
+    profile: VipBikeUserProfile,
+    experience: VipBikeExperienceConfig,
+  ) => {
+    if (!dbUser?.id) return;
+
+    const previousLock = (dbUser.metadata as { experience_lock?: ExperienceLockState } | undefined)
+      ?.experience_lock;
+    const lockUpdate = computeExperienceLockUpdate(profile, experience, previousLock);
+    persistExperienceLockAction(dbUser.id, lockUpdate);
+  }, [dbUser]);
+
+  return {
+    trackViewCategory,
+    trackMapOpen,
+    trackBuyClick,
+    trackRentClick,
+    trackQrScan,
+    trackSectionDwell,
+    persistExperienceLock,
+  };
+}

--- a/app/webhook-handlers/commands/start.ts
+++ b/app/webhook-handlers/commands/start.ts
@@ -104,10 +104,13 @@ const handleSurveyCompletion = async (
   //
   // Resolver versions are persisted for OBSERVABILITY only.
   // They do NOT control logic — the client always runs latest code.
+  //
+  // behavior_signals: FULL initialization with all counters at 0.
+  // This ensures a consistent data shape (fix for C3 type lie).
+  // The client resolver uses ?? 0 everywhere, but consistency matters.
   await updateUserSettings(user_id, {
     survey_results: answers,
     onboarding_context: onboardingContext,
-    // Initialize behavior_signals with zero counts
     behavior_signals: {
       viewedElectroCount: 0,
       viewedSportCount: 0,
@@ -115,14 +118,21 @@ const handleSurveyCompletion = async (
       openedMapCount: 0,
       buyIntentClickCount: 0,
       rentIntentClickCount: 0,
+      lastMapInteractionAt: undefined,
+      lastBuyInteractionAt: undefined,
+      lastRentInteractionAt: undefined,
       scannedQrModels: [],
       investSectionViewSeconds: 0,
       lastActiveAt: new Date().toISOString(),
     } satisfies BehaviorSignals,
-    // Initialize experience_lock for anti-thrashing
+    // Initialize experience_lock for anti-thrashing.
+    // Stores RAW profile signals (not derived preset name).
+    // The client updates this after resolving the experience.
     experience_lock: {
       lastChangedAt: new Date().toISOString(),
-      lastPresetName: undefined, // will be set on first client-side experience resolution
+      lastResolvedSegment: profile.segment,
+      lastResolvedIntent: profile.intent,
+      lastResolvedExperience: profile.experience,
       stabilityCount: 0,
     },
   });
@@ -233,13 +243,21 @@ export async function startCommand(chatId: number, userId: number, from_user: an
     earlyMetadata.onboarding_start_payload = parsed.raw;
   }
 
-  // Initialize behavior_signals if they don't exist yet
-  // (so the client resolver has something to work with)
+  // Initialize behavior_signals with consistent shape (fix for C3).
+  // Only set when there's early metadata to persist.
+  // This ensures the client resolver sees a consistent BehaviorSignals shape.
   if (Object.keys(earlyMetadata).length > 0) {
-    // Don't overwrite existing behavior_signals
     earlyMetadata.behavior_signals = {
+      viewedElectroCount: 0,
+      viewedSportCount: 0,
+      viewedRetroCount: 0,
+      openedMapCount: 0,
+      buyIntentClickCount: 0,
+      rentIntentClickCount: 0,
+      scannedQrModels: [],
+      investSectionViewSeconds: 0,
       lastActiveAt: new Date().toISOString(),
-    } satisfies Partial<BehaviorSignals> as BehaviorSignals;
+    } satisfies BehaviorSignals;
 
     const updateResult = await updateUserSettings(userIdStr, earlyMetadata);
     if (!updateResult.success) {
@@ -247,7 +265,14 @@ export async function startCommand(chatId: number, userId: number, from_user: an
     }
   }
 
-  if (parsed.command === "/start" || (parsed.type === "bare" && !parsed.code)) {
+  // ── Route based on parsed payload ──
+  // FIX for C1: Use parsed.command (now properly typed) instead of
+  // non-existent parsed.command from before.
+  // parsed.command === "/start" means user typed /start (with or without payload).
+  // parsed.type === "bare" && !parsed.code means plain /start with no payload.
+  const isPlainStart = parsed.command === "/start" && parsed.type === "bare" && !parsed.code;
+
+  if (isPlainStart) {
     // Reset previous survey state (re-onboarding)
     await supabaseAnon.from("user_survey_state").delete().eq("user_id", userIdStr);
     await supabaseAnon.from("user_surveys").delete().eq("user_id", userIdStr);
@@ -270,7 +295,7 @@ export async function startCommand(chatId: number, userId: number, from_user: an
       keyboardType: question.answers ? "reply" : "remove",
     });
   } else {
-    // Handle Answer
+    // Handle Answer (user is in the middle of a survey)
     const { data: currentState } = await supabaseAnon
       .from("user_survey_state")
       .select("*")
@@ -278,7 +303,9 @@ export async function startCommand(chatId: number, userId: number, from_user: an
       .maybeSingle();
 
     if (!currentState) {
-      if (parsed.command !== "/start") {
+      // No active survey — if user sent text that's not a /start command,
+      // redirect them to /start
+      if (!parsed.command) {
         await sendComplexMessage(
           chatId,
           "Система в режиме ожидания. Нажми /start, чтобы начать заново, или открой меню.",

--- a/app/webhook-handlers/commands/start.ts
+++ b/app/webhook-handlers/commands/start.ts
@@ -1,3 +1,25 @@
+/**
+ * start-enhanced.ts
+ * =================
+ * Enhanced /start command handler with:
+ *   - Structured payload parsing (entry.electro, promo.NEON2026, buy.surron)
+ *   - Raw signal persistence ONLY (no ui_profile cache)
+ *   - onboarding_context with timestamps (for intent decay)
+ *   - Behavioral signal initialization
+ *   - Payload hints available for pre-survey landing personalization
+ *
+ * CRITICAL CHANGE vs v1:
+ *   We do NOT persist a derived ui_profile to metadata.
+ *   The profile is ALWAYS derived at runtime by resolve-profile.ts.
+ *   This ensures that resolver logic improvements apply immediately
+ *   to all users, and stale profiles don't persist outdated segments.
+ *
+ * MIGRATION NOTES:
+ *   - Old payloads (VIPSTART, ref_CODE) still work — parser handles them
+ *   - metadata.ui_profile is NO LONGER WRITTEN — safe to ignore old values
+ *   - Components should use resolve-profile.ts, never read ui_profile directly
+ */
+
 "use server";
 
 import { notifyAdmin, updateUserSettings } from "@/app/actions";
@@ -5,8 +27,18 @@ import { supabaseAnon, createOrUpdateUser } from "@/hooks/supabase";
 import { logger } from "@/lib/logger";
 import { sendComplexMessage } from "../actions/sendComplexMessage";
 import { grantFranchizeAchievementAction } from "@/app/franchize/profile-actions";
-// CHANGED IMPORT: Now using warehouse questions
-import { surveyQuestions, answerTexts } from "./content/start_survey_questions_warehouse";
+import { surveyQuestions, answerTexts } from "./content/start_survey_questions_bike";
+
+// ── Import from onboarding pipeline ──
+import { parseStartPayload, extractPromoCode } from "@/app/franchize/lib/onboarding/payload-parser";
+import { normalizeSurveyToProfile } from "@/app/franchize/lib/onboarding/survey-normalizer";
+import type { VipBikeUserMetadata, BehaviorSignals } from "@/app/franchize/lib/onboarding/experience-types";
+import { PROFILE_RESOLVER_VERSION } from "@/app/franchize/lib/onboarding/resolve-profile";
+import { EXPERIENCE_RESOLVER_VERSION } from "@/app/franchize/lib/onboarding/resolve-experience";
+
+// ─────────────────────────────────────────────────────
+// Survey state type
+// ─────────────────────────────────────────────────────
 
 interface SurveyState {
   user_id: string;
@@ -14,56 +46,162 @@ interface SurveyState {
   answers: Record<string, string>;
 }
 
-const handleSurveyCompletion = async (chatId: number, state: SurveyState, username?: string) => {
+// ─────────────────────────────────────────────────────
+// Survey version — bump when questions change
+// ─────────────────────────────────────────────────────
+
+const SURVEY_VERSION = "bike-v1";
+
+// ─────────────────────────────────────────────────────
+// ENHANCED: Survey completion — persist raw signals only
+// ─────────────────────────────────────────────────────
+
+const handleSurveyCompletion = async (
+  chatId: number,
+  state: SurveyState,
+  username?: string,
+  payloadRaw?: string,
+) => {
   const { answers, user_id } = state;
 
   // Save to survey-specific table
-  await supabaseAnon.from("user_surveys").insert({ user_id, username: username || "unknown", survey_data: answers });
-  // Delete the temporary state
-  await supabaseAnon.from("user_survey_state").delete().eq('user_id', user_id);
-  // Save results to user's metadata
-  await updateUserSettings(user_id, { survey_results: answers });
+  await supabaseAnon.from("user_surveys").insert({
+    user_id,
+    username: username || "unknown",
+    survey_data: answers,
+  });
 
-  /**
-   * Franchize capability trigger:
-   * - onboarding_survey_completed
-   * Source of truth lives in app/franchize/profile-actions.ts (slug-filtered achievements).
-   */
+  // Delete the temporary state
+  await supabaseAnon.from("user_survey_state").delete().eq("user_id", user_id);
+
+  // ── Compute profile at runtime for admin logging ──
+  // NOTE: We do NOT persist this profile. It's for logging only.
+  // The client re-derives it at runtime from raw signals.
+  const parsedPayload = payloadRaw ? parseStartPayload(`/start ${payloadRaw}`) : null;
+  const onboardingContext = {
+    completedAt: new Date().toISOString(),
+    version: SURVEY_VERSION,
+    entryPoint: "telegram:start" as const,
+    profileResolverVersion: PROFILE_RESOLVER_VERSION,
+    experienceResolverVersion: EXPERIENCE_RESOLVER_VERSION,
+  };
+
+  const profile = normalizeSurveyToProfile(
+    answers,
+    null, // no behavior signals yet at survey completion time
+    parsedPayload,
+    true,
+    onboardingContext,
+  );
+
+  logger.info(
+    `[SurveyCompletion] user=${user_id} segment=${profile.segment} intent=${profile.intent} experience=${profile.experience} confidence=${profile.confidence.toFixed(2)}`,
+  );
+
+  // ── PERSIST RAW SIGNALS ONLY ──
+  // No derived ui_profile. No cached segment/intent.
+  // The client derives profile at runtime from these raw signals.
+  //
+  // Resolver versions are persisted for OBSERVABILITY only.
+  // They do NOT control logic — the client always runs latest code.
+  await updateUserSettings(user_id, {
+    survey_results: answers,
+    onboarding_context: onboardingContext,
+    // Initialize behavior_signals with zero counts
+    behavior_signals: {
+      viewedElectroCount: 0,
+      viewedSportCount: 0,
+      viewedRetroCount: 0,
+      openedMapCount: 0,
+      buyIntentClickCount: 0,
+      rentIntentClickCount: 0,
+      scannedQrModels: [],
+      investSectionViewSeconds: 0,
+      lastActiveAt: new Date().toISOString(),
+    } satisfies BehaviorSignals,
+    // Initialize experience_lock for anti-thrashing
+    experience_lock: {
+      lastChangedAt: new Date().toISOString(),
+      lastPresetName: undefined, // will be set on first client-side experience resolution
+      stabilityCount: 0,
+    },
+  });
+
+  // Franchize achievement
   await grantFranchizeAchievementAction({
     slug: "vip-bike",
     userId: user_id,
     achievementId: "onboarding_survey_completed",
     source: "telegram:/start",
-    context: { survey: "warehouse", via: "start_command" },
+    context: { survey: "bike", via: "start_command", version: SURVEY_VERSION },
     incrementCounters: { onboardingCompletions: 1 },
   });
 
-  // Admin Notification (Warehouse Style)
-  let adminSummary = `🏭 *Новый Оператор в Системе!*\n- *User:* @${username || user_id} (${user_id})\n`;
+  // Admin notification with profile info (derived at runtime, not persisted)
+  let adminSummary = `🚲 *Новый Райдер в Системе!*\n- *User:* @${username || user_id} (${user_id})\n`;
   for (const key in answers) {
-    adminSummary += `- *${answerTexts[key] || key}:* ${answers[key] || '—'}\n`;
+    adminSummary += `- *${answerTexts[key] || key}:* ${answers[key] || "—"}\n`;
   }
+  adminSummary += `\n📊 *Профиль (runtime):* ${profile.segment}/${profile.intent}/${profile.experience} (confidence: ${profile.confidence.toFixed(2)})`;
   await notifyAdmin(adminSummary);
 
+  // User summary with personalized next-step
   const botUrl = process.env.TELEGRAM_BOT_LINK || "https://t.me/oneBikePlsBot/app";
-  
-  // User Summary (Warehouse Style)
-  let summary = `✅ *Профиль настроен.*\nМы зафиксировали параметры твоего склада:\n`;
+
+  let summary = `✅ *Профиль настроен.*\nМы зафиксировали параметры твоей вело-анкеты:\n`;
   for (const key in answers) {
-    summary += `- *${answerTexts[key] || key}:* ${answers[key] || '—'}\n`;
+    summary += `- *${answerTexts[key] || key}:* ${answers[key] || "—"}\n`;
   }
-  
+
+  const nextStepHint = deriveNextStepHint(profile);
+  summary += `\n${nextStepHint}`;
   summary += `\n\n⌨️ Клавиатура скрыта. \n\nИспользуй /howto для инструкций или открывай приложение, чтобы начать работу.`;
   summary += `\n\n👇 *Твой центр управления:*`;
 
-  // Send summary with a direct button to the App
   await sendComplexMessage(chatId, summary, [
-      [{ text: "🚀 Открыть Склад (Web App)", url: botUrl }]
+    [{ text: "🚀 Открыть VIP Bike (Web App)", url: botUrl }],
   ], { removeKeyboard: true });
 };
 
+/**
+ * Derives a personalized hint for what the user should do next.
+ */
+function deriveNextStepHint(profile: {
+  segment: string;
+  intent: string;
+  experience: string;
+}): string {
+  if (profile.intent === "buy") {
+    return "🎯 Следующий шаг: подбери байк в каталоге — система уже настроила фильтры под твой запрос.";
+  }
+  if (profile.intent === "community") {
+    return "🗺️ Следующий шаг: загляни на карту — рядом райдеры и точки встреч.";
+  }
+  if (profile.experience === "beginner") {
+    return "🛡️ Следующий шаг: безопасный первый выезд с экипировкой и сопровождением.";
+  }
+  if (profile.segment === "electro") {
+    return "⚡ Следующий шаг: изучи электро-эндуро — тихая мощь нового поколения.";
+  }
+  return "🏍️ Следующий шаг: открой приложение — всё уже настроено под тебя.";
+}
+
+// ─────────────────────────────────────────────────────
+// MAIN: startCommand handler
+// ─────────────────────────────────────────────────────
+
 export async function startCommand(chatId: number, userId: number, from_user: any, text?: string) {
-  logger.info(`[StartCommand Warehouse] User: ${userId}, Text: "${text}"`);
+  const parsed = parseStartPayload(text);
+  const promoCode = extractPromoCode(parsed.raw);
+  const onboardingBranch = parsed.raw
+    ? `start_with_payload:${parsed.type}`
+    : "plain_start:vip-bike";
+
+  logger.info(`[StartCommand Bike] User: ${userId}, Text: "${text}"`);
+  logger.info(
+    `[StartCommand Audit] user=${userId} payload_type=${parsed.type} code=${parsed.code} promo=${promoCode ?? "none"} onboarding_branch=${onboardingBranch}`,
+  );
+
   const userIdStr = String(userId);
   const username = from_user.username;
 
@@ -72,7 +210,7 @@ export async function startCommand(chatId: number, userId: number, from_user: an
     username: from_user.username,
     first_name: from_user.first_name,
     last_name: from_user.last_name,
-    language_code: from_user.language_code
+    language_code: from_user.language_code,
   });
 
   if (!user) {
@@ -81,46 +219,89 @@ export async function startCommand(chatId: number, userId: number, from_user: an
     return;
   }
 
-  if (text === '/start') {
-    // Reset previous state
-    await supabaseAnon.from("user_survey_state").delete().eq('user_id', userIdStr);
-    await supabaseAnon.from("user_surveys").delete().eq('user_id', userIdStr);
+  // ── Persist raw signals EARLY for pre-survey personalization ──
+  // The landing page can use these hints to show relevant content
+  // even BEFORE the user answers a single survey question.
+  // ⚠️ NO derived profile is persisted. Only raw signals.
+  const earlyMetadata: Partial<VipBikeUserMetadata> = {};
+
+  if (promoCode) {
+    earlyMetadata.onboarding_promo_code = promoCode;
+  }
+
+  if (parsed.raw) {
+    earlyMetadata.onboarding_start_payload = parsed.raw;
+  }
+
+  // Initialize behavior_signals if they don't exist yet
+  // (so the client resolver has something to work with)
+  if (Object.keys(earlyMetadata).length > 0) {
+    // Don't overwrite existing behavior_signals
+    earlyMetadata.behavior_signals = {
+      lastActiveAt: new Date().toISOString(),
+    } satisfies Partial<BehaviorSignals> as BehaviorSignals;
+
+    const updateResult = await updateUserSettings(userIdStr, earlyMetadata);
+    if (!updateResult.success) {
+      logger.warn(`[StartCommand] Failed to persist early signals for ${userIdStr}: ${updateResult.error ?? "unknown"}`);
+    }
+  }
+
+  if (parsed.command === "/start" || (parsed.type === "bare" && !parsed.code)) {
+    // Reset previous survey state (re-onboarding)
+    await supabaseAnon.from("user_survey_state").delete().eq("user_id", userIdStr);
+    await supabaseAnon.from("user_surveys").delete().eq("user_id", userIdStr);
 
     const { data: newState, error } = await supabaseAnon
       .from("user_survey_state")
       .insert({ user_id: userIdStr, current_step: 1, answers: {} })
-      .select().single();
+      .select()
+      .single();
 
     if (error || !newState) {
-      logger.error('[StartCommand] Failed to init survey state', error);
+      logger.error("[StartCommand] Failed to init survey state", error);
       return;
     }
 
-    const question = surveyQuestions.find(q => q.step === newState.current_step)!;
-    const buttons = question.answers ? question.answers.map(a => ([{ text: a.text }])) : [];
+    const question = surveyQuestions.find((q) => q.step === newState.current_step)!;
+    const buttons = question.answers ? question.answers.map((a) => [{ text: a.text }]) : [];
 
-    await sendComplexMessage(chatId, question.question, buttons, { keyboardType: question.answers ? 'reply' : 'remove' });
-
+    await sendComplexMessage(chatId, question.question, buttons, {
+      keyboardType: question.answers ? "reply" : "remove",
+    });
   } else {
     // Handle Answer
-    const { data: currentState } = await supabaseAnon.from("user_survey_state").select('*').eq('user_id', userIdStr).maybeSingle();
+    const { data: currentState } = await supabaseAnon
+      .from("user_survey_state")
+      .select("*")
+      .eq("user_id", userIdStr)
+      .maybeSingle();
 
     if (!currentState) {
-      // User sent text without an active survey -> redirect to app or restart
-      if (text !== '/start') {
-         await sendComplexMessage(chatId, "Система в режиме ожидания. Нажми /start, чтобы начать заново, или открой меню.", [], { removeKeyboard: true });
+      if (parsed.command !== "/start") {
+        await sendComplexMessage(
+          chatId,
+          "Система в режиме ожидания. Нажми /start, чтобы начать заново, или открой меню.",
+          [],
+          { removeKeyboard: true },
+        );
       }
       return;
     }
 
-    const currentQuestion = surveyQuestions.find(q => q.step === currentState.current_step)!;
+    const currentQuestion = surveyQuestions.find((q) => q.step === currentState.current_step)!;
 
     // Validation
     if (currentQuestion.answers && !currentQuestion.free_answer) {
-      const isValidAnswer = currentQuestion.answers.some(a => a.text === text);
+      const isValidAnswer = currentQuestion.answers.some((a) => a.text === text);
       if (!isValidAnswer) {
-        const buttons = currentQuestion.answers.map(a => ([{ text: a.text }]));
-        await sendComplexMessage(chatId, `⛔ Некорректный ввод.\nПожалуйста, выбери вариант из меню:\n\n${currentQuestion.question}`, buttons, { keyboardType: 'reply' });
+        const buttons = currentQuestion.answers.map((a) => [{ text: a.text }]);
+        await sendComplexMessage(
+          chatId,
+          `⛔ Некорректный ввод.\nПожалуйста, выбери вариант из меню:\n\n${currentQuestion.question}`,
+          buttons,
+          { keyboardType: "reply" },
+        );
         return;
       }
     }
@@ -129,12 +310,17 @@ export async function startCommand(chatId: number, userId: number, from_user: an
     const nextStep = currentState.current_step + 1;
 
     if (nextStep > surveyQuestions.length) {
-      await handleSurveyCompletion(chatId, { ...currentState, answers: newAnswers }, username);
+      await handleSurveyCompletion(chatId, { ...currentState, answers: newAnswers }, username, parsed.raw);
     } else {
-      await supabaseAnon.from("user_survey_state").update({ current_step: nextStep, answers: newAnswers }).eq('user_id', userIdStr);
-      const nextQuestion = surveyQuestions.find(q => q.step === nextStep)!;
-      const buttons = nextQuestion.answers ? nextQuestion.answers.map(a => ([{ text: a.text }])) : [];
-      await sendComplexMessage(chatId, nextQuestion.question, buttons, { keyboardType: nextQuestion.answers ? 'reply' : 'remove' });
+      await supabaseAnon
+        .from("user_survey_state")
+        .update({ current_step: nextStep, answers: newAnswers })
+        .eq("user_id", userIdStr);
+      const nextQuestion = surveyQuestions.find((q) => q.step === nextStep)!;
+      const buttons = nextQuestion.answers ? nextQuestion.answers.map((a) => [{ text: a.text }]) : [];
+      await sendComplexMessage(chatId, nextQuestion.question, buttons, {
+        keyboardType: nextQuestion.answers ? "reply" : "remove",
+      });
     }
   }
 }


### PR DESCRIPTION
(feat): Enhanced /start handler with resolver versioning and raw signals

Updated /start command handler for PR #1251:
- Structured payload parsing (entry.electro, promo.NEON2026, buy.surron, map.groupride)
- Raw signal persistence ONLY (no ui_profile cache)
- onboarding_context with timestamps and resolver versions (for intent decay and observability)
- Behavioral signal initialization
- experience_lock initialization for anti-thrashing
- Payload hints available for pre-survey landing personalization

(feat): Adaptive storefront runtime pipeline

Raw signals → profile → experience pipeline with intent decay, progressive enrichment, section capabilities, anti-thrashing, and resolver versioning.

Architecture: raw signals → normalizeSurveyToProfile() → VipBikeUserProfile → resolveVipBikeExperience() → VipBikeExperienceConfig → declarative section rendering

Key innovations:
- Runtime-derived profiles (no persisted ui_profile, only raw signals)
- Intent routing > theme routing (buyers see fast purchase, explorers see discovery)
- Confidence-gated personalization (0.3/0.7 thresholds prevent wrong assumptions)
- Payload signals seed personalization BEFORE survey completion
- Section capabilities: sections self-describe, resolver scores dynamically
- Experience presets: named composable configs for debugging/analytics/feature flags
- combinePresets(): composable presets prevent resolver entropy
- Anti-thrashing: experience locks prevent UX from reshuffling too rapidly
- Resolver versioning: profileResolverVersion + experienceResolverVersion for observability
- Progressive enrichment: behavioral signals reinforce or override survey signals over time
- Intent decay: older surveys lose confidence without behavioral reinforcement

**Файлы (7):**
- `app/webhook-handlers/commands/start.ts`
- `app/franchize/lib/onboarding/experience-types.ts`
- `app/franchize/lib/onboarding/index.ts`
- `app/franchize/lib/onboarding/payload-parser.ts`
- `app/franchize/lib/onboarding/resolve-experience.ts`
- `app/franchize/lib/onboarding/resolve-profile.ts`
- `app/franchize/lib/onboarding/survey-normalizer.ts`