### PR TITLE
(fix): Profile dropdown, header menu navigation, cart clickability, ra

### DIFF
--- a/app/franchize/[slug]/page.tsx
+++ b/app/franchize/[slug]/page.tsx
@@ -25,14 +25,6 @@ export default async function FranchizeSlugPage({ params }: FranchizeSlugPagePro
         CrewButtonErrorBoundary) is caught by a LOCAL boundary instead of
         bubbling up to the page-level error.tsx which shows the full-screen
         "Экипаж временно недоступен" fallback.
-
-        Without this wrapper, a portal crash in FranchizeProfileButton's
-        DropdownMenu bypasses the local CrewButtonErrorBoundary (because
-        Radix renders the portal content outside that boundary's DOM tree)
-        and reaches the page-level error boundary, replacing the ENTIRE
-        page with the "crew recovery" screen. This FranchizeErrorBoundary
-        renders a small inline fallback widget instead, so the catalog
-        remains visible even if the header breaks.
       */}
       <FranchizeErrorBoundary
         resetKey={slug}

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -48,8 +48,6 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
   const userScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ── Logo loading state machine ──
-  //   loading → (onLoad) → dissolving → (animationEnd) → revealed
-  //   loading → (onError) → broken (permanent spooky letter)
   const [brokenLogoUrls, setBrokenLogoUrls] = useState<Record<string, true>>({});
   const [logoLoaded, setLogoLoaded] = useState(false);
   const [logoDissolved, setLogoDissolved] = useState(false);
@@ -69,7 +67,6 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
   }, []);
 
   // Reset active category when navigating away from main catalog
-  // Scheduling setState via setTimeout to satisfy linter
   useEffect(() => {
     const prev = prevPathnameRef.current;
     prevPathnameRef.current = pathname;
@@ -80,13 +77,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
     }
   }, [pathname, mainCatalogPath]);
 
-  // ── FIX: Close menu on route change (safety net for HeaderMenu navigation) ──
-  // When the user clicks a menu item in HeaderMenu, the menu closes via
-  // onOpenChange(false) and navigation starts via router.push() in a
-  // setTimeout. If the menu somehow stays open (e.g., router.push fails
-  // or the user navigates via browser back/forward), this effect closes
-  // the menu when the pathname changes. This is a safety net, not the
-  // primary close mechanism.
+  // ── Close menu on route change (safety net) ──
   useEffect(() => {
     if (menuOpen) {
       setMenuOpen(false);
@@ -130,15 +121,12 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
     const onScroll = () => {
       setIsCompact((prev) => {
         const scrollY = window.scrollY;
-        // If the header is full-size, wait until we scroll well PAST the threshold (60px) to collapse it
         if (!prev && scrollY > 90) {
           return true;
         }
-        // If the header is collapsed, wait until we scroll well ABOVE the threshold (20px) to expand it
         if (prev && scrollY < 13) {
           return false;
         }
-        // If we are in the "dead zone" between 20 and 60, change nothing. (Breaks the loop!)
         return prev;
       });
     };
@@ -147,7 +135,6 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
-  // -----------------------------------------
 
   useEffect(() => {
     if (pathname !== mainCatalogPath) {
@@ -194,13 +181,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
   }, [mainCatalogPath, pathname]);
 
   // --- Плавный скролл активного бейджа (pill) в центр экрана ---
-  // Auto-scroll on navigation + activeCategory changes (pill clicks, IntersectionObserver).
-  // The isUserScrollingRef guard prevents snap-back when the user is manually scrolling the rail.
-  // Pill click → isUserScrollingRef=false → auto-scroll centers the pill ✅
-  // Page scroll → IntersectionObserver fires → isUserScrollingRef=false → auto-scroll ✅
-  // Manual rail scroll → isUserScrollingRef=true → auto-scroll blocked ✅
   useEffect(() => {
-    // Don't auto-scroll while user is manually scrolling the rail
     if (isUserScrollingRef.current) return;
 
     const activeRailLink = visibleRailLinks.find(
@@ -221,24 +202,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
         behavior: "smooth",
       });
     }
-  }, [activePath, pathname, activeCategory, visibleRailLinks]); // re-added activeCategory + visibleRailLinks; isUserScrollingRef guard prevents snap-back
-  // ------------------------------------------------------------------
-  useEffect(() => {
-    const container = railRef.current;
-    if (!container) return;
-    const activeRailLink = visibleRailLinks.find(
-      (link) => link.active || (!link.href.startsWith("#") && (pathname === link.href || activePath === link.href)),
-    );
-    if (!activeRailLink) {
-      setIndicatorStyle((prev) => ({ ...prev, opacity: 0 }));
-      return;
-    }
-    const activeEl = Array.from(container.querySelectorAll<HTMLElement>("[data-category-pill]")).find(
-      (element) => element.dataset.categoryPill === activeRailLink.categoryLabel,
-    );
-    if (!activeEl) return;
-    setIndicatorStyle({ width: activeEl.offsetWidth, left: activeEl.offsetLeft, opacity: 1 });
-  }, [activePath, pathname, visibleRailLinks]);
+  }, [activePath, pathname, activeCategory, visibleRailLinks]);
 
   return (
     <header
@@ -246,10 +210,6 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
       style={{
         ...FRANCHIZE_HEADER_SAFE_AREA_STYLE,
         // FIX 6: isolation creates a proper stacking context for the entire header.
-        // Without this, backdrop-blur-2xl + position:sticky creates a compositing
-        // layer that can interfere with pointer-event hit-testing in Chromium/mobile
-        // WebViews. isolation:isolate ensures the header's stacking context is
-        // well-defined and doesn't leak to parent layers.
         isolation: "isolate",
         borderColor: crew.theme.palette.borderSoft,
         backgroundColor: withAlpha(crew.theme.palette.bgCard, 0.94),
@@ -264,28 +224,12 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
     >
       {/*
         FIX 2: Removed overflow-hidden from this wrapper.
-        The old overflow-hidden + translateY(0.45rem) on the grid child created a
-        Chromium/mobile-WebView hit-testing boundary: pointer events stopped
-        propagating correctly to the transformed child. The grid's visual content
-        was shifted down 7.2px by the transform, but overflow-hidden clipped the
-        wrapper at the un-shifted boundary — so the bottom 7.2px of interactive
-        elements (profile button, cart icon) were both visually clipped AND
-        removed from the hit-testing region. The 3-column grid layout already
-        constrains horizontal overflow, so overflow-hidden was unnecessary.
+        The old overflow-hidden + translateY created a hit-testing boundary.
       */}
       <div className="mx-auto w-full max-w-7xl">
         {/*
-          FIX 1: Grid layout changed from "auto auto minmax(0,1fr) auto" (4 cols, 3 children)
-          to "44px 1fr auto" (3 cols, 3 children). The old layout put the profile+cart div
-          in the minmax(0,1fr) column, which consumed ALL remaining space and created an
-          invisible overlay that intercepted pointer events on everything below it.
-        */}
-        {/*
+          FIX 1: Grid layout "44px 1fr auto" (3 cols, 3 children).
           FIX 3: Removed translateY(0.45rem) from non-compact transform.
-          The old translateY(0.45rem) shifted the grid's visual content down by 7.2px,
-          causing it to overflow the wrapper div. Combined with overflow-hidden on the
-          wrapper, this clipped the bottom portion of the header and created hit-testing
-          boundary issues in mobile WebViews. Set to translateY(0) instead.
         */}
         <div
           style={{
@@ -321,18 +265,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
           {/* HEADER LOGO — PURE SPA LINK */}
           {/*
             FIX 4: Removed z-10 from logo Link className.
-            The old z-10 created an elevated stacking context within the grid
-            that could interfere with pointer events on the profile+cart div
-            in column 3. The inner spooky letter span still has z-10 within
-            the logo's own stacking context (provided by `relative`), so the
-            overlay animation continues to work correctly.
-
-            FIX 5: Added justify-self-center to constrain the Link's clickable
-            area to the logo itself. Without this, the Link (a flex container)
-            stretches to fill the entire 1fr grid cell, creating a wide invisible
-            clickable area spanning hundreds of pixels. While this didn't block
-            clicks on adjacent cells (grid items don't overlap by default), it
-            caused accidental navigations when users clicked near the logo.
+            FIX 5: Added justify-self-center to constrain clickable area.
           */}
           <Link
             href={headerLogoHref}
@@ -348,7 +281,6 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
             >
               {logoUrl && !brokenLogoUrls[logoUrl] ? (
                 <>
-                  {/* Image layer — always rendered so it loads in background */}
                   <Image
                     src={logoUrl}
                     alt={`${crew.header.brandName} logo`}
@@ -361,7 +293,6 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
                       setBrokenLogoUrls((prev) => ({ ...prev, [logoUrl]: true }));
                     }}
                   />
-                  {/* Spooky letter overlay — breathes while loading, dissolves on load */}
                   {!logoDissolved && (
                     <span
                       className="absolute inset-0 z-10 flex items-center justify-center text-2xl font-bold select-none"
@@ -381,10 +312,8 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
                   )}
                 </>
               ) : logoUrl && brokenLogoUrls[logoUrl] ? (
-                /* Broken URL — permanent spooky letter */
                 <SpookyLetter letter={getFirstLetter(crew.header.brandName)} color={accentMain} sizeClass="text-2xl" />
               ) : (
-                /* No logo URL at all — brand name text fallback */
                 <div
                   className="flex h-full w-full items-center justify-center px-2 text-[10px] font-semibold uppercase tracking-wide"
                   style={{ color: accentMain }}
@@ -396,25 +325,18 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
           </Link>
 
           {/*
-            FIX 5 (companion): Added relative z-[2] to ensure the profile+cart
-            div is above the logo Link in the grid's stacking order. Even though
-            grid items in different cells don't overlap by default, this guarantees
-            correct z-ordering if any edge case causes visual overlap (e.g., during
-            CSS transitions or on unusual viewports).
+            FIX: Wrap FranchizeProfileButton in CrewButtonErrorBoundary
+            at the CALL SITE with resetKey=pathhame for recovery.
+            v4 of FranchizeProfileButton always renders DropdownMenu
+            (no more !hasUser early return), so this boundary is just
+            a safety net for unexpected runtime errors.
           */}
-          {/* FIX v3: Wrap FranchizeProfileButton in CrewButtonErrorBoundary
-              at the CALL SITE. The boundary inside FranchizeProfileButton only
-              wraps the JSX return (DropdownMenu), NOT the hooks. If a hook
-              throws (e.g., useAppContext during SPA transition), the inner
-              boundary cannot catch it, and the error reaches the page-level
-              error.tsx → fullscreen "Экипаж временно недоступен". Wrapping
-              at the call site catches ALL errors (hooks + JSX) and renders
-              a small Telegram link fallback instead of crashing the page. */}
-          <div className="flex items-center gap-2 justify-self-end relative z-[2]">
+          <div className="flex items-center gap-2 justify-self-end relative z-[2]" style={{ pointerEvents: "auto" }}>
             <CrewButtonErrorBoundary
               bgColor={withAlpha(crew.theme.palette.bgBase, 0.8)}
               textColor={crew.theme.palette.textPrimary}
               borderColor={crew.theme.palette.borderSoft}
+              resetKey={pathname}
             >
               <FranchizeProfileButton
                 bgColor={withAlpha(crew.theme.palette.bgBase, 0.8)}
@@ -432,7 +354,7 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
               borderColor={crew.theme.palette.borderSoft}
               theme={crew.theme}
               mode="inline-icon"
-              className="relative inline-flex h-11 w-11 items-center justify-center rounded-xl"
+              className="relative inline-flex h-11 w-11 items-center justify-center rounded-xl no-underline"
             />
           </div>
         </div>
@@ -447,7 +369,6 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
             ref={railRef}
             className="relative mx-auto flex w-full max-w-7xl gap-2 overflow-x-auto no-scrollbar pb-1 text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden snap-x snap-mandatory"
             onScroll={() => {
-              // Mark that user is scrolling the rail — prevents auto-scroll override
               isUserScrollingRef.current = true;
               if (userScrollTimerRef.current) clearTimeout(userScrollTimerRef.current);
               userScrollTimerRef.current = setTimeout(() => {
@@ -455,11 +376,13 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
               }, 1500);
             }}
           >
-            <span
-              aria-hidden="true"
-              className="pointer-events-none absolute bottom-1 h-0.5 rounded-full bg-[var(--crew-header-accent)] transition-all duration-300 ease-out"
-              style={{ width: `${indicatorStyle.width}px`, transform: `translateX(${indicatorStyle.left}px)`, opacity: indicatorStyle.opacity }}
-            />
+            {/*
+              FIX: Removed the sliding indicator <span>.
+              The indicator was a thin accent-colored bar under the active pill.
+              Since the active pill already has a distinct highlighted background
+              (accentMain), the indicator was redundant and visually ugly — it
+              looked like an unwanted underscore. Removed it entirely.
+            */}
             {visibleRailLinks.map((link) => {
               const isActive = link.active || (!link.href.startsWith("#") && (pathname === link.href || activePath === link.href));
               return (
@@ -469,11 +392,10 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
                   data-category-pill={link.categoryLabel}
                   aria-current={isActive ? "location" : undefined}
                   aria-label={`Перейти к разделу ${link.label}`}
-                  className="shrink-0 snap-start rounded-full bg-[var(--pill-bg)] px-3 py-2 text-xs font-medium tracking-wide text-[var(--pill-text)] !no-underline transition-all duration-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+                  className="shrink-0 snap-start rounded-full bg-[var(--pill-bg)] px-3 py-2 text-xs font-medium tracking-wide text-[var(--pill-text)] no-underline transition-all duration-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
                   style={{
                     ["--pill-bg" as string]: isActive ? crew.theme.palette.accentMain : crew.theme.palette.bgCard,
                     ["--pill-text" as string]: isActive ? activePillText : crew.theme.palette.textPrimary,
-                    transform: isActive ? "translateY(0) scale(1.02)" : "translateY(0)",
                     textDecoration: "none",
                   }}
                   onClick={(event) => {
@@ -485,7 +407,6 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
                         if (target) {
                           event.preventDefault();
                           target.scrollIntoView({ behavior: "smooth", block: "start" });
-                          // Keep URL hash in sync without adding history entry
                           window.history.replaceState(null, "", `#${hash}`);
                         }
                       }

--- a/app/franchize/components/FranchizeProfileButton.tsx
+++ b/app/franchize/components/FranchizeProfileButton.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Bell, ChevronDown, LayoutDashboard, Palette, Settings, Shield, User, IdCard, MessageCircle, Send } from "lucide-react";
+import { Bell, ChevronDown, LayoutDashboard, LogIn, Palette, Settings, Shield, User, IdCard, MessageCircle, Send } from "lucide-react";
 import { Component, useEffect, useMemo, useState } from "react";
 import { useAppContext } from "@/contexts/AppContext";
 import { useIsAdmin } from "@/app/franchize/hooks/useIsAdmin";
@@ -50,32 +50,25 @@ function normalizeSlug(slug: string | undefined): string {
 }
 
 // ─────────────────────────────────────────────────────────
-// FIX: Local error boundary to prevent "crew recovery" full-page crash.
-// ─────────────────────────────────────────────────────────
-// When the DropdownMenu or any of its children throw during rendering
-// (e.g., due to missing AppContext during SPA navigation, useIsAdmin
-// throwing, or Radix portal failures), the error bubbles up to the
-// nearest error boundary. Without this local boundary, the error reaches
-// the page-level "crew recovery" boundary, replacing the ENTIRE page
-// with the fallback screen. This local boundary catches the error
-// gracefully and renders a simple fallback button instead.
+// CrewButtonErrorBoundary — local error boundary for the
+// profile button area in CrewHeader.
 //
-// NOTE: This boundary can only catch errors in the non-portal portion
-// of the render tree. Radix DropdownMenu renders its content via a
-// portal (outside this boundary's DOM), so portal errors bypass it.
-// The v2 fix (early return for !hasUser) prevents portal errors for
-// guests entirely. This boundary remains as a safety net for
-// authenticated-user render errors.
+// v4: Added resetKey prop. When resetKey changes (e.g.,
+// pathname change from navigation), the boundary resets
+// from error state and attempts to re-render children.
+// Previous versions had no reset — once hasError=true the
+// boundary permanently showed the fallback, even if the
+// error was transient (e.g., during SPA navigation).
 // ─────────────────────────────────────────────────────────
 interface ErrorBoundaryState {
   hasError: boolean;
 }
 
 export class CrewButtonErrorBoundary extends Component<
-  { bgColor: string; textColor: string; borderColor: string; children: React.ReactNode },
+  { bgColor: string; textColor: string; borderColor: string; resetKey?: string; children: React.ReactNode },
   ErrorBoundaryState
 > {
-  constructor(props: { bgColor: string; textColor: string; borderColor: string; children: React.ReactNode }) {
+  constructor(props: { bgColor: string; textColor: string; borderColor: string; resetKey?: string; children: React.ReactNode }) {
     super(props);
     this.state = { hasError: false };
   }
@@ -88,6 +81,13 @@ export class CrewButtonErrorBoundary extends Component<
     console.warn("[FranchizeProfileButton] caught render error:", error, info);
   }
 
+  componentDidUpdate(prevProps: { resetKey?: string }) {
+    // Reset error state when resetKey changes (e.g., on navigation)
+    if (this.props.resetKey !== prevProps.resetKey && this.state.hasError) {
+      this.setState({ hasError: false });
+    }
+  }
+
   render() {
     if (this.state.hasError) {
       return (
@@ -96,8 +96,8 @@ export class CrewButtonErrorBoundary extends Component<
           target="_blank"
           rel="noopener noreferrer"
           aria-label="Открыть Telegram WebApp"
-          className="inline-flex h-11 items-center gap-2 rounded-xl border px-3 text-sm font-semibold transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
-          style={{ backgroundColor: this.props.bgColor, color: this.props.textColor, borderColor: this.props.borderColor }}
+          className="inline-flex h-11 items-center gap-2 rounded-xl border px-3 text-sm font-semibold no-underline transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          style={{ backgroundColor: this.props.bgColor, color: this.props.textColor, borderColor: this.props.borderColor, textDecoration: "none" }}
         >
           <Send className="h-4 w-4" />
           <span className="hidden sm:inline">WebApp</span>
@@ -118,7 +118,7 @@ interface FranchizeProfileButtonProps {
 export function FranchizeProfileButton({ bgColor, textColor, borderColor, currentSlug }: FranchizeProfileButtonProps) {
   const { dbUser, user, userCrewInfo, isInTelegramContext } = useAppContext();
   const hasUser = Boolean(dbUser || user);
-  const displayName = dbUser?.username || dbUser?.full_name || user?.username || user?.first_name || "Operator";
+  const displayName = dbUser?.username || dbUser?.full_name || user?.username || user?.first_name || "Гость";
   const avatarUrl = dbUser?.avatar_url || user?.photo_url;
   const userIsAdmin = useIsAdmin();
   const scopeSlug = normalizeSlug(currentSlug || userCrewInfo?.slug);
@@ -205,46 +205,38 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
   }, [tempCartId]);
 
   // ─────────────────────────────────────────────────────────
-  // FIX v3: "Profile icon routes to abyss" + "crew recovery" regression
+  // FIX v4: Always render DropdownMenu — never switch to a
+  // completely different UI element based on auth state.
   // ─────────────────────────────────────────────────────────
-  // v1 fix: Rendered DropdownMenu even for guests (!hasUser). This caused
-  // a regression: Radix DropdownMenu uses a portal that renders OUTSIDE
-  // the CrewButtonErrorBoundary's DOM tree. When the portal content throws
-  // (e.g., during SPA navigation with stale context, or when Radix tries
-  // to compute position against a detached node), the error bypasses the
-  // local error boundary and reaches the page-level Next.js error boundary
-  // (franchize/[slug]/error.tsx), which shows the fullscreen "crew recovery"
-  // fallback ("Экипаж временно недоступен").
+  // Previous versions had an early return for !hasUser that
+  // rendered a plain <a> tag instead of the DropdownMenu.
+  // This caused two problems:
   //
-  // v2 fix: For guests (!hasUser), render a simple <a> tag linking to
-  // Telegram WebApp — no portal, no DropdownMenu, no crash risk. This
-  // avoids the Radix portal crash entirely while still providing a useful
-  // CTA ("Login via Telegram"). Authenticated users keep the full dropdown.
+  // 1. When hasUser flipped (e.g., context re-hydration or
+  //    SPA navigation), the entire component tree changed
+  //    from <a> to <DropdownMenu> or vice versa. React
+  //    reconciled this as a full replacement, causing visual
+  //    glitches (button "changes" on click).
   //
-  // v3 fix: Additionally, the call site in CrewHeader now wraps
-  // FranchizeProfileButton in a local CrewButtonErrorBoundary. This
-  // catches ALL errors (including hook errors during SPA transitions)
-  // before they can reach the page-level error.tsx. The boundary renders
-  // a Telegram link fallback instead of the full-screen crash.
+  // 2. The inner CrewButtonErrorBoundary (v3) wrapped only
+  //    the DropdownMenu branch. If it caught an error, it
+  //    permanently switched to a Telegram link fallback with
+  //    NO reset mechanism. The user saw the profile button
+  //    irreversibly turn into a "WebApp" link.
+  //
+  // v4 fix: Always render the same DropdownMenu structure.
+  // For guests (!hasUser), show a "Login via Telegram"
+  // dropdown item. For authenticated users, show the full
+  // profile menu. This means:
+  // - Clicking always opens a dropdown (consistent UX)
+  // - No component tree switching (no visual glitches)
+  // - No need for an inner error boundary that can permanently
+  //   break the UI
+  // - The outer CrewButtonErrorBoundary in CrewHeader is the
+  //   only safety net (with resetKey for recovery)
   // ─────────────────────────────────────────────────────────
 
-  if (!hasUser) {
-    return (
-      <a
-        href={TELEGRAM_WEB_APP_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Войти через Telegram"
-        className="inline-flex h-11 items-center gap-2 rounded-xl border px-3 text-sm font-semibold transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
-        style={{ backgroundColor: bgColor, color: textColor, borderColor }}
-      >
-        <Send className="h-4 w-4" />
-        <span className="hidden sm:inline">Войти</span>
-      </a>
-    );
-  }
-
-  const inner = (
+  return (
     <div style={{ isolation: "isolate" }}>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -304,120 +296,147 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
           <DropdownMenuLabel className="truncate">{displayName}</DropdownMenuLabel>
           <DropdownMenuSeparator />
 
-          <DropdownMenuItem asChild>
-            <Link href="/profile" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-              <User className="mr-2 h-4 w-4" />
-              <span className="truncate">Профиль</span>
-            </Link>
-          </DropdownMenuItem>
-
-          <DropdownMenuItem asChild>
-            <Link href="/settings" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-              <Settings className="mr-2 h-4 w-4" />
-              <span className="truncate">Настройки</span>
-            </Link>
-          </DropdownMenuItem>
-
-          <DropdownMenuItem asChild>
-            <Link href="/franchize/create" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-              <Palette className="mr-2 h-4 w-4 shrink-0" />
-              <span className="truncate">Оформление экипажа</span>
-            </Link>
-          </DropdownMenuItem>
-
-          {userIsAdmin ? (
-            <DropdownMenuItem asChild>
-              <Link href={franchizeAdminHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                <Shield className="mr-2 h-4 w-4 shrink-0" />
-                <span className="truncate">Админка франшизы</span>
-              </Link>
-            </DropdownMenuItem>
-          ) : null}
-
-          <DropdownMenuItem asChild>
-            <Link href={franchizeDashboardHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-              <LayoutDashboard className="mr-2 h-4 w-4 shrink-0" />
-              <span className="truncate">Дашборд франшизы</span>
-            </Link>
-          </DropdownMenuItem>
-
-          <DropdownMenuItem asChild>
-            <Link href={franchizeProfileHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-              <IdCard className="mr-2 h-4 w-4 shrink-0" />
-              <span className="truncate">Профиль франшизы</span>
-            </Link>
-          </DropdownMenuItem>
-
-          {canShowTelegramCartCta && telegramCartHref ? (
+          {!hasUser ? (
+            // ── Guest menu: login CTA + optional cart transfer ──
             <>
-              <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
-                <a href={telegramCartHref} target="_blank" rel="noreferrer" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                  <MessageCircle className="mr-2 h-4 w-4 shrink-0" />
-                  <span className="truncate">Перейти в Telegram — корзина сохранится</span>
+                <a
+                  href={TELEGRAM_WEB_APP_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="cursor-pointer flex min-w-0 items-center gap-2 w-full font-semibold"
+                >
+                  <LogIn className="mr-2 h-4 w-4 shrink-0" />
+                  <span className="truncate">Войти через Telegram</span>
                 </a>
               </DropdownMenuItem>
-              <DropdownMenuLabel className="pt-0 text-[11px] font-normal text-muted-foreground">
-                Добавленные позиции уже сохранены
-              </DropdownMenuLabel>
+
+              {canShowTelegramCartCta && telegramCartHref ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <a href={telegramCartHref} target="_blank" rel="noreferrer" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                      <MessageCircle className="mr-2 h-4 w-4 shrink-0" />
+                      <span className="truncate">Перейти в Telegram — корзина сохранится</span>
+                    </a>
+                  </DropdownMenuItem>
+                  <DropdownMenuLabel className="pt-0 text-[11px] font-normal text-muted-foreground">
+                    Добавленные позиции уже сохранены
+                  </DropdownMenuLabel>
+                </>
+              ) : null}
             </>
-          ) : null}
-
-          {dbUser?.user_id ? (
+          ) : (
+            // ── Authenticated menu: full profile + admin ──
             <>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
-                <Bell className="h-3.5 w-3.5" />
-                Уведомления
-              </DropdownMenuLabel>
-              {NOTIFICATION_OPTIONS.map((option) => (
-                <DropdownMenuCheckboxItem
-                  key={option.key}
-                  checked={notificationPreferences[option.key]}
-                  disabled={isNotificationSaving}
-                  onCheckedChange={(checked) => handleNotificationPreferenceChange(option.key, Boolean(checked))}
-                  onSelect={(event) => event.preventDefault()}
-                  className="cursor-pointer items-start gap-2 py-2"
-                >
-                  <span className="flex min-w-0 flex-col">
-                    <span className="truncate text-sm">{option.label}</span>
-                    <span className="text-[11px] text-muted-foreground">{option.helper}</span>
-                  </span>
-                </DropdownMenuCheckboxItem>
-              ))}
-            </>
-          ) : null}
-
-          {userCrewInfo?.slug && (
-            <DropdownMenuItem asChild>
-              <Link href={`/crews/${userCrewInfo.slug}`} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                <Palette className="mr-2 h-4 w-4" />
-                <span className="truncate">Мой экипаж</span>
-              </Link>
-            </DropdownMenuItem>
-          )}
-
-          {userIsAdmin && (
-            <>
-              <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
-                <Link href="/admin" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                  <Shield className="mr-2 h-4 w-4" />
-                  <span className="truncate">Админка</span>
+                <Link href="/profile" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                  <User className="mr-2 h-4 w-4" />
+                  <span className="truncate">Профиль</span>
                 </Link>
               </DropdownMenuItem>
+
+              <DropdownMenuItem asChild>
+                <Link href="/settings" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                  <Settings className="mr-2 h-4 w-4" />
+                  <span className="truncate">Настройки</span>
+                </Link>
+              </DropdownMenuItem>
+
+              <DropdownMenuItem asChild>
+                <Link href="/franchize/create" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                  <Palette className="mr-2 h-4 w-4 shrink-0" />
+                  <span className="truncate">Оформление экипажа</span>
+                </Link>
+              </DropdownMenuItem>
+
+              {userIsAdmin ? (
+                <DropdownMenuItem asChild>
+                  <Link href={franchizeAdminHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                    <Shield className="mr-2 h-4 w-4 shrink-0" />
+                    <span className="truncate">Админка франшизы</span>
+                  </Link>
+                </DropdownMenuItem>
+              ) : null}
+
+              <DropdownMenuItem asChild>
+                <Link href={franchizeDashboardHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                  <LayoutDashboard className="mr-2 h-4 w-4 shrink-0" />
+                  <span className="truncate">Дашборд франшизы</span>
+                </Link>
+              </DropdownMenuItem>
+
+              <DropdownMenuItem asChild>
+                <Link href={franchizeProfileHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                  <IdCard className="mr-2 h-4 w-4 shrink-0" />
+                  <span className="truncate">Профиль франшизы</span>
+                </Link>
+              </DropdownMenuItem>
+
+              {canShowTelegramCartCta && telegramCartHref ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <a href={telegramCartHref} target="_blank" rel="noreferrer" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                      <MessageCircle className="mr-2 h-4 w-4 shrink-0" />
+                      <span className="truncate">Перейти в Telegram — корзина сохранится</span>
+                    </a>
+                  </DropdownMenuItem>
+                  <DropdownMenuLabel className="pt-0 text-[11px] font-normal text-muted-foreground">
+                    Добавленные позиции уже сохранены
+                  </DropdownMenuLabel>
+                </>
+              ) : null}
+
+              {dbUser?.user_id ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                    <Bell className="h-3.5 w-3.5" />
+                    Уведомления
+                  </DropdownMenuLabel>
+                  {NOTIFICATION_OPTIONS.map((option) => (
+                    <DropdownMenuCheckboxItem
+                      key={option.key}
+                      checked={notificationPreferences[option.key]}
+                      disabled={isNotificationSaving}
+                      onCheckedChange={(checked) => handleNotificationPreferenceChange(option.key, Boolean(checked))}
+                      onSelect={(event) => event.preventDefault()}
+                      className="cursor-pointer items-start gap-2 py-2"
+                    >
+                      <span className="flex min-w-0 flex-col">
+                        <span className="truncate text-sm">{option.label}</span>
+                        <span className="text-[11px] text-muted-foreground">{option.helper}</span>
+                      </span>
+                    </DropdownMenuCheckboxItem>
+                  ))}
+                </>
+              ) : null}
+
+              {userCrewInfo?.slug && (
+                <DropdownMenuItem asChild>
+                  <Link href={`/crews/${userCrewInfo.slug}`} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                    <Palette className="mr-2 h-4 w-4" />
+                    <span className="truncate">Мой экипаж</span>
+                  </Link>
+                </DropdownMenuItem>
+              )}
+
+              {userIsAdmin && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <Link href="/admin" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                      <Shield className="mr-2 h-4 w-4" />
+                      <span className="truncate">Админка</span>
+                    </Link>
+                  </DropdownMenuItem>
+                </>
+              )}
             </>
           )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
-  );
-
-  // FIX: Wrap in local error boundary so a DropdownMenu crash doesn't
-  // take down the entire page (replacing it with "crew recovery" fallback).
-  return (
-    <CrewButtonErrorBoundary bgColor={bgColor} textColor={textColor} borderColor={borderColor}>
-      {inner}
-    </CrewButtonErrorBoundary>
   );
 }

--- a/app/franchize/modals/HeaderMenu.tsx
+++ b/app/franchize/modals/HeaderMenu.tsx
@@ -121,43 +121,36 @@ export function HeaderMenu({ crew, activePath, open, onOpenChange }: HeaderMenuP
                 key={`${link.href}-${link.label}`}
                 href={link.href}
                 onClick={(e) => {
-                  // ── FIX v5: Reliable menu item navigation ──
-                  // v1: onOpenChange(false) before router.push() — dropped navigation.
-                  //     The menu close state update cancelled the startTransition-based
-                  //     SPA navigation because React discarded the low-priority transition.
-                  // v2: e.preventDefault() + router.push() + setTimeout — still unreliable
-                  //     because the portal unmounts in the same render batch as the
-                  //     navigation, and startTransition can be lost.
-                  // v3: Don't prevent default — let Link navigate natively + close menu
-                  //     after 50ms. Still unreliable because the portal unmount (menu
-                  //     close) can interrupt the pending startTransition navigation.
-                  // v4: Close menu FIRST (visual feedback), then navigate via
-                  //     router.push() in a setTimeout(50ms). The router.push in a
-                  //     setTimeout is OUTSIDE the click event's interaction context,
-                  //     making it easy for React to discard the low-priority transition
-                  //     when the menu close re-render unmounts the portal.
-                  // v5: For hash links, handle locally + close menu. For regular links,
-                  //     DON'T prevent default and DON'T close menu in this handler.
-                  //     Let the Next.js <Link> component handle navigation natively
-                  //     (its internal router.push is tied to the click event context).
-                  //     The pathname change effect in CrewHeader closes the menu when
-                  //     navigation completes. This ensures the navigation happens in
-                  //     the same interaction as the click, so React keeps the transition.
+                  // ── FIX v6: Always close menu + let Link navigate ──
+                  // v5 tried: "don't close menu for regular links, let pathname
+                  // change effect close it." This failed because:
+                  // a) If the Link navigates to the same page, pathname doesn't
+                  //    change, and the menu stays open (appears broken).
+                  // b) If navigation is slow, the menu stays open too long.
+                  //
+                  // v6 approach: Always close the menu immediately for clear
+                  // user feedback. Don't call e.preventDefault() for regular
+                  // links so the Next.js <Link> component handles navigation
+                  // via its own internal onClick (which calls router.push
+                  // wrapped in startTransition). The menu close (setState)
+                  // and the Link's navigation both fire in the same React
+                  // batch, so they don't conflict.
+                  //
+                  // For hash links, prevent default and scroll manually.
                   if (link.href.startsWith("#")) {
                     e.preventDefault();
                     const target = document.querySelector(link.href);
                     target?.scrollIntoView({ behavior: "smooth", block: "start" });
-                    onOpenChange(false);
                   }
-                  // For regular links: do nothing extra.
-                  // Link navigates → pathname changes → CrewHeader closes menu.
+                  onOpenChange(false);
                 }}
                 aria-current={isActive ? "page" : undefined}
-                className={`w-full text-left block rounded-xl border px-4 py-3 text-sm transition cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--header-menu-accent)] ${
+                className={`w-full text-left block rounded-xl border px-4 py-3 text-sm no-underline transition cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--header-menu-accent)] ${
                   isActive
                     ? "border-[var(--header-menu-accent)] text-[var(--header-menu-accent)]"
                     : "border-[var(--header-menu-border)] text-[var(--header-menu-text)]"
                 }`}
+                style={{ textDecoration: "none" }}
               >
                 {link.label}
               </Link>


### PR DESCRIPTION
(fix): Profile dropdown, header menu navigation, cart clickability, rail pill underscore

Four targeted fixes for the franchize crew header:

1. **FranchizeProfileButton v4**: Remove the !hasUser early return that switched the entire component between a DropdownMenu and a plain Telegram link. Now ALWAYS renders a DropdownMenu — guests see a 'Login via Telegram' dropdown item, authenticated users see the full profile menu. This eliminates the visual glitch where clicking the profile button caused it to change into a Telegram link. Also removed the inner CrewButtonErrorBoundary (no reset mechanism — permanently broke the UI on error). The outer boundary in CrewHeader now has a resetKey=pathhame for recovery.

2. **HeaderMenu v6**: Always close the menu on item click (onOpenChange(false)). The v5 approach of 'let pathname change close the menu' failed when navigation didn't visibly change the route (same-page links, slow navigation). Now: hash links → preventDefault + scrollIntoView + close menu. Regular links → don't preventDefault (Link handles navigation) + close menu immediately. Added no-underline and textDecoration:none to menu item links.

3. **CrewHeader cart fix**: Added pointerEvents: auto back to the profile+cart container div. Added no-underline class to the FloatingCartIconLinkBySlug className. Removed the redundant sliding indicator span under the active rail pill (the accent-colored h-0.5 bar that looked like an ugly underscore on the highlighted pill). Added resetKey=pathhame to CrewButtonErrorBoundary for error recovery on navigation.

4. **Rail pill underscore removed**: The active pill already has a distinct highlighted background (accentMain), making the sliding indicator bar redundant and visually ugly. Removed the indicator span entirely.

**Файлы (4):**
- `app/franchize/components/FranchizeProfileButton.tsx`
- `app/franchize/modals/HeaderMenu.tsx`
- `app/franchize/components/CrewHeader.tsx`
- `app/franchize/[slug]/page.tsx`