### PR TITLE
(feat): De-bike franchize — generalize for multi-tenant + svarprofi pa

### DIFF
--- a/app/franchize/[slug]/cart/CartPageClient.tsx
+++ b/app/franchize/[slug]/cart/CartPageClient.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { CatalogItemVM, FranchizeCrewVM } from "../actions";
+import { upsertFranchizeIntent } from "../actions";
+import { useFranchizeCartLines } from "../hooks/useFranchizeCartLines";
+import { useFranchizeCart } from "../hooks/useFranchizeCart"; // Import cart state access
+import { crewPaletteForSurface } from "../lib/theme";
+import { saveUserFranchizeCartAction } from "@/contexts/actions"; // Explicit import
+import { useAppContext } from "@/contexts/AppContext";
+
+interface CartPageClientProps {
+  crew: FranchizeCrewVM;
+  slug: string;
+  items: CatalogItemVM[];
+}
+
+export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
+  const { cart, itemCount: rawItemCount, changeLineQty, removeLine } = useFranchizeCart(slug);
+  const { cartLines, subtotal, itemCount } = useFranchizeCartLines(slug, items, {
+    cart,
+    itemCount: rawItemCount,
+    changeLineQty,
+    removeLine,
+  });
+  const surface = crewPaletteForSurface(crew.theme);
+  const router = useRouter();
+  const { dbUser, user } = useAppContext();
+  const [isSaving, setIsSaving] = useState(false);
+
+  // FIX: Determine cart flow type for dynamic text
+  const saleLinesCount = cartLines.filter((line) => line.saleAvailable).length;
+  const isAllSale = saleLinesCount > 0 && saleLinesCount === cartLines.length;
+  const isMixed = saleLinesCount > 0 && !isAllSale;
+  const cartFlowLabel = isAllSale ? "sale" : isMixed ? "mixed" : "rental";
+
+  const handleProceed = async () => {
+    setIsSaving(true);
+    const flow = cartFlowLabel === "sale" ? "sale" : cartFlowLabel === "mixed" ? "mixed" : "rental";
+    const intentPromise = upsertFranchizeIntent({
+      slug,
+      bikeId: cartLines[0]?.item?.id ?? cartLines[0]?.itemId,
+      intentType: "checkout_start",
+      stage: "checkout_started",
+      sourceRoute: `/franchize/${slug}/cart`,
+      contactChannel: "web_cart",
+      urgencyScore: flow === "rental" ? 70 : 80,
+      telegramUserId: user?.id ? String(user.id) : dbUser?.user_id ? String(dbUser.user_id) : undefined,
+      phone: typeof (dbUser as { phone?: unknown } | null)?.phone === "string" ? (dbUser as { phone?: string } | null)?.phone : undefined,
+      metadata: {
+        flow,
+        itemCount,
+        subtotal,
+        cartLines: cartLines.map((line) => ({
+          itemId: line.item?.id ?? line.itemId,
+          qty: line.qty,
+          saleAvailable: line.saleAvailable,
+          lineTotal: line.lineTotal,
+        })),
+      },
+    }).catch((error) => console.warn("checkout intent tracking failed", error));
+    // Sync to DB explicitly before navigating; keep checkout-intent persistence in the same checkpoint.
+    if (dbUser?.user_id) {
+        await Promise.allSettled([saveUserFranchizeCartAction(dbUser.user_id, slug, cart), intentPromise]);
+    } else {
+        await intentPromise;
+    }
+    // Navigate even if save failed (local storage might still be used by next page if hydrated client-side)
+    router.push(`/franchize/${slug}/order/demo-order?flow=${flow}`);
+  };
+
+  // FIX: Dynamic subtotal label based on cart content
+  const subtotalLabel = isAllSale
+    ? "Сумма покупки"
+    : isMixed
+      ? "Итого (аренда + покупка)"
+      : "Сумма за 1 день аренды";
+
+  return (
+    <section
+      className="mx-auto w-full max-w-5xl px-4 py-6"
+      style={{
+        ["--cart-accent" as string]: crew.theme.palette.accentMain,
+        ["--cart-border" as string]: crew.theme.palette.borderSoft,
+      }}
+    >
+      <p className="text-xs uppercase tracking-[0.2em] text-[var(--cart-accent)]">
+        /franchize/{slug}/cart
+      </p>
+      <h1 className="mt-2 text-4xl font-semibold tracking-tight">Корзина</h1>
+      <p className="mt-2 text-sm" style={surface.mutedText}>Проверьте состав заказа, количество и итог перед оформлением.</p>
+
+      {cartLines.length === 0 && rawItemCount === 0 ? (
+        <div className="mt-6 rounded-2xl border border-dashed p-6 text-sm" style={surface.subtleCard}>
+          {/* FIX: Replaced bike-specific "Добавьте байк" with generic "Добавьте позицию" */}
+          Корзина пока пустая. Добавьте позицию из каталога, чтобы перейти к оформлению.
+          <div className="mt-4">
+             {/* Using standard anchor/button for back link to be safe */}
+             <button
+                onClick={() => router.push(`/franchize/${slug}`)}
+                className="inline-flex font-medium text-[var(--cart-accent)] underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)]"
+             >
+              Вернуться в каталог
+             </button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_360px]">
+          <div className="space-y-3">
+            {cartLines.map((line) => (
+              <article key={line.lineId} className="rounded-3xl border p-4 md:p-5" style={surface.card}>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex min-w-0 gap-3">
+                    {line.item?.imageUrl ? (
+                      <img
+                        src={line.item.imageUrl}
+                        alt={line.item.title}
+                        className="h-24 w-20 shrink-0 rounded-xl object-cover md:h-28 md:w-24"
+                      />
+                    ) : null}
+                    <div className="min-w-0">
+                    <h2 className="text-xl font-semibold">{line.item?.title ?? "Позиция недоступна"}</h2>
+                    <p className="text-xs" style={surface.mutedText}>
+                      {line.item?.subtitle ?? "Этот товар был удалён или временно недоступен в каталоге."}
+                    <span className="mt-1 block text-[11px]" style={surface.mutedText}>{line.options.package} · {line.options.duration} · {line.options.perk} · {line.options.auction}</span>
+                    </p>
+                    {/* FIX: Show both rent and sale prices when applicable */}
+                    {line.item ? (
+                      <div className="mt-1">
+                        <p className="text-sm font-medium text-[var(--cart-accent)]">
+                          {line.item.rentPriceLabel}
+                        </p>
+                        {line.saleAvailable && line.item.salePrice ? (
+                          <p className="mt-0.5 text-xs font-medium text-amber-400">
+                            Покупка: {line.item.salePrice.toLocaleString("ru-RU")} ₽
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : (
+                      <p className="mt-1 text-xs" style={surface.mutedText}>Недоступные позиции не участвуют в расчёте суммы.</p>
+                    )}
+                    </div>
+                  </div>
+                  <button className="rounded-md px-1 text-xs transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)]" style={surface.mutedText} onClick={() => removeLine(line.lineId)}>
+                    Удалить
+                  </button>
+                </div>
+                <div className="mt-4 flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-black/10 p-2">
+                  <p className="text-sm font-semibold text-[var(--cart-accent)]">{line.lineTotal.toLocaleString("ru-RU")} ₽</p>
+                  <div className="flex items-center gap-2">
+                  <button
+                    className="h-8 w-8 rounded-full border transition hover:opacity-90 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)]"
+                    style={{ borderColor: "var(--cart-border)" }}
+                    onClick={() => changeLineQty(line.lineId, -1)}
+                    aria-label="Уменьшить"
+                  >
+                    −
+                  </button>
+                  <span className="min-w-8 text-center text-lg font-medium">{line.qty}</span>
+                  <button
+                    className="h-8 w-8 rounded-full border transition hover:opacity-90 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)]"
+                    style={{ borderColor: "var(--cart-border)" }}
+                    onClick={() => changeLineQty(line.lineId, 1)}
+                    aria-label="Увеличить"
+                  >
+                    +
+                  </button>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <aside className="h-fit rounded-3xl border p-4 md:sticky md:top-24 md:p-5" style={surface.card}>
+            <p className="text-sm" style={surface.mutedText}>Итого позиций</p>
+            <p className="text-3xl font-semibold">{itemCount}</p>
+            {/* FIX: Dynamic label — "Сумма покупки" for all-sale, "Итого (аренда + покупка)" for mixed, "Сумма за 1 день аренды" for rental */}
+            <p className="mt-3 text-sm" style={surface.mutedText}>{subtotalLabel}</p>
+            <p className="text-4xl font-semibold text-[var(--cart-accent)]">
+              {subtotal.toLocaleString("ru-RU")} ₽
+            </p>
+            <div className="mt-4 grid grid-cols-3 gap-2 text-center text-[11px]">
+              <span className="rounded-full border px-2 py-1" style={surface.subtleCard}>Быстрое оформление</span>
+              <span className="rounded-full border px-2 py-1" style={surface.subtleCard}>Без скрытых платежей</span>
+              <span className="rounded-full border px-2 py-1" style={surface.subtleCard}>Поддержка 24/7</span>
+            </div>
+            <button
+              type="button"
+              disabled={isSaving}
+              onClick={handleProceed}
+              className="mt-5 inline-flex w-full justify-center rounded-2xl bg-[var(--cart-accent)] px-4 py-4 text-lg font-semibold text-[#16130A] transition hover:brightness-105 active:scale-[0.99] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)] cursor-pointer disabled:opacity-70"
+            >
+              {isSaving ? "Сохранение..." : "Перейти к оформлению"}
+            </button>
+          </aside>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/franchize/[slug]/loading.tsx
+++ b/app/franchize/[slug]/loading.tsx
@@ -22,16 +22,24 @@ export default function FranchizeSlugLoading() {
           <p className="text-xs font-semibold uppercase tracking-[0.24em]" style={surface.mutedText}>
             crew storefront
           </p>
-          <h1 className="mt-3 text-3xl font-black tracking-tight sm:text-5xl">Загрузка VIP BIKE...</h1>
+          {/* FIX: Removed hardcoded "VIP BIKE" — now generic for all tenants */}
+          <h1 className="mt-3 text-3xl font-black tracking-tight sm:text-5xl">Загрузка витрины...</h1>
+          {/* FIX: Removed bike-specific "мотопарк" — now generic "каталог" */}
           <p className="mt-3 max-w-2xl text-sm leading-6" style={surface.mutedText} role="status">
-            Подготавливаем мотопарк, цены, доступность и витрину экипажа.
+            Подготавливаем каталог, цены, доступность и витрину экипажа.
           </p>
           <div className="mt-6 grid gap-3 sm:grid-cols-[1.2fr_0.8fr]">
+            {/* FIX: Replaced bike skeleton (two wheels + frame) with generic content skeleton */}
             <div className="rounded-3xl border p-4" style={surface.card}>
               <div className="relative h-28 overflow-hidden rounded-2xl" style={{ backgroundColor: accentBackground }}>
-                <div className="absolute bottom-7 left-8 h-10 w-10 rounded-full border-4" style={{ borderColor: theme.palette.accentMain }} />
-                <div className="absolute bottom-7 right-8 h-10 w-10 rounded-full border-4" style={{ borderColor: theme.palette.accentMain }} />
-                <div className="absolute bottom-12 left-[30%] h-4 w-[38%] -skew-x-12 rounded-full" style={{ backgroundColor: theme.palette.accentMain }} />
+                {/* Generic grid pattern instead of bike wheels/frame */}
+                <div className="absolute inset-4 grid grid-cols-3 gap-2">
+                  <div className="rounded-lg opacity-30" style={{ backgroundColor: theme.palette.accentMain }} />
+                  <div className="rounded-lg opacity-20" style={{ backgroundColor: theme.palette.accentMain }} />
+                  <div className="rounded-lg opacity-25" style={{ backgroundColor: theme.palette.accentMain }} />
+                  <div className="col-span-2 rounded-lg opacity-15" style={{ backgroundColor: theme.palette.accentMain }} />
+                  <div className="rounded-lg opacity-20" style={{ backgroundColor: theme.palette.accentMain }} />
+                </div>
               </div>
               <div className="mt-4 h-3 w-2/3 animate-pulse rounded-full motion-reduce:animate-none" style={{ backgroundColor: accentBackground }} />
               <div className="mt-2 h-3 w-1/2 animate-pulse rounded-full opacity-70 motion-reduce:animate-none" style={{ backgroundColor: accentBackground }} />

--- a/app/franchize/components/CrewHeader.tsx
+++ b/app/franchize/components/CrewHeader.tsx
@@ -206,9 +206,14 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
 
   return (
     <header
-      className="sticky top-0 z-50 border-b pb-2 pt-[max(env(safe-area-inset-top),0.15rem)] backdrop-blur-2xl"
+      // FIX: Increased top padding to accommodate Telegram MiniApp native buttons
+      // (back/settings button bar ~44px). The old 0.15rem minimum was too thin.
+      // calc(env(safe-area-inset-top) + 2.25rem) adds 36px on top of safe-area,
+      // with a minimum of 2.75rem (~44px) when safe-area is 0.
+      className="sticky top-0 z-50 border-b pb-2 backdrop-blur-2xl"
       style={{
         ...FRANCHIZE_HEADER_SAFE_AREA_STYLE,
+        paddingTop: "max(calc(env(safe-area-inset-top) + 2.25rem), 2.75rem)",
         // FIX 6: isolation creates a proper stacking context for the entire header.
         isolation: "isolate",
         borderColor: crew.theme.palette.borderSoft,
@@ -326,12 +331,20 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
 
           {/*
             FIX: Wrap FranchizeProfileButton in CrewButtonErrorBoundary
-            at the CALL SITE with resetKey=pathhame for recovery.
+            at the CALL SITE with resetKey=pathname for recovery.
             v4 of FranchizeProfileButton always renders DropdownMenu
             (no more !hasUser early return), so this boundary is just
             a safety net for unexpected runtime errors.
+
+            FIX: pointerEvents conditional on isCompact.
+            When compact, the entire grid row is hidden (opacity 0, maxHeight 0)
+            and pointerEvents: "none" on the parent. But this child div
+            previously had pointerEvents: "auto" which overrode the parent's
+            "none" — causing rail pills that overlap the profile icon area
+            to click through to the invisible profile button.
+            Now it respects the compact state.
           */}
-          <div className="flex items-center gap-2 justify-self-end relative z-[2]" style={{ pointerEvents: "auto" }}>
+          <div className="flex items-center gap-2 justify-self-end relative z-[2]" style={{ pointerEvents: isCompact ? "none" : "auto" }}>
             <CrewButtonErrorBoundary
               bgColor={withAlpha(crew.theme.palette.bgBase, 0.8)}
               textColor={crew.theme.palette.textPrimary}
@@ -376,13 +389,6 @@ export function CrewHeader({ crew, activePath, groupLinks = [], sectionLinks = [
               }, 1500);
             }}
           >
-            {/*
-              FIX: Removed the sliding indicator <span>.
-              The indicator was a thin accent-colored bar under the active pill.
-              Since the active pill already has a distinct highlighted background
-              (accentMain), the indicator was redundant and visually ugly — it
-              looked like an unwanted underscore. Removed it entirely.
-            */}
             {visibleRailLinks.map((link) => {
               const isActive = link.active || (!link.href.startsWith("#") && (pathname === link.href || activePath === link.href));
               return (

--- a/app/franchize/components/FranchizeProfileButton.tsx
+++ b/app/franchize/components/FranchizeProfileButton.tsx
@@ -2,8 +2,8 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Bell, ChevronDown, LayoutDashboard, LogIn, Palette, Settings, Shield, User, IdCard, MessageCircle, Send } from "lucide-react";
-import { Component, useEffect, useMemo, useState } from "react";
+import { Bell, ChevronDown, LayoutDashboard, Palette, Settings, Shield, User, IdCard, MessageCircle, Send } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { useAppContext } from "@/contexts/AppContext";
 import { useIsAdmin } from "@/app/franchize/hooks/useIsAdmin";
 import { isMockUserModeEnabled } from "@/lib/mockUserMode";
@@ -30,7 +30,11 @@ import {
   SPOOKY_ACCENT_VAR,
 } from "@/app/franchize/lib/spooky-avatar";
 
-const TELEGRAM_WEB_APP_URL = "https://t.me/oneBikePlsBot/app";
+// FIX: Removed hardcoded "https://t.me/oneBikePlsBot/app".
+// The Telegram WebApp URL should come from crew metadata (contacts.telegramBotUsername).
+// For now, we construct it dynamically when a slug is available.
+// If no slug is available, the link simply won't render.
+const TELEGRAM_BOT_APP_URL_TEMPLATE = "https://t.me/{botUsername}/app";
 
 const DEFAULT_NOTIFICATION_PREFERENCES: FranchizeNotificationPreferences = {
   orderUpdates: true,
@@ -38,74 +42,20 @@ const DEFAULT_NOTIFICATION_PREFERENCES: FranchizeNotificationPreferences = {
   marketingDigest: false,
 };
 
+// FIX: De-biked notification option helper text.
+// Was "промо и новости VIP BIKE" — now generic "промо и новости экипажа".
 const NOTIFICATION_OPTIONS: Array<{ key: keyof FranchizeNotificationPreferences; label: string; helper: string }> = [
   { key: "orderUpdates", label: "Статусы заказов", helper: "бронь, покупка, документы" },
   { key: "mapRidersAlerts", label: "MapRiders", helper: "заезды и встречи экипажа" },
-  { key: "marketingDigest", label: "Редкие акции", helper: "промо и новости VIP BIKE" },
+  { key: "marketingDigest", label: "Редкие акции", helper: "промо и новости экипажа" },
 ];
 
+// FIX: De-biked slug fallback. Was "vip-bike" — now empty string.
+// The slug should ALWAYS come from the crew context. A fallback slug
+// would navigate users to the wrong crew's pages.
 function normalizeSlug(slug: string | undefined): string {
   const normalized = (slug || "").trim().toLowerCase();
-  return normalized || "vip-bike";
-}
-
-// ─────────────────────────────────────────────────────────
-// CrewButtonErrorBoundary — local error boundary for the
-// profile button area in CrewHeader.
-//
-// v4: Added resetKey prop. When resetKey changes (e.g.,
-// pathname change from navigation), the boundary resets
-// from error state and attempts to re-render children.
-// Previous versions had no reset — once hasError=true the
-// boundary permanently showed the fallback, even if the
-// error was transient (e.g., during SPA navigation).
-// ─────────────────────────────────────────────────────────
-interface ErrorBoundaryState {
-  hasError: boolean;
-}
-
-export class CrewButtonErrorBoundary extends Component<
-  { bgColor: string; textColor: string; borderColor: string; resetKey?: string; children: React.ReactNode },
-  ErrorBoundaryState
-> {
-  constructor(props: { bgColor: string; textColor: string; borderColor: string; resetKey?: string; children: React.ReactNode }) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  static getDerivedStateFromError(): ErrorBoundaryState {
-    return { hasError: true };
-  }
-
-  componentDidCatch(error: unknown, info: unknown) {
-    console.warn("[FranchizeProfileButton] caught render error:", error, info);
-  }
-
-  componentDidUpdate(prevProps: { resetKey?: string }) {
-    // Reset error state when resetKey changes (e.g., on navigation)
-    if (this.props.resetKey !== prevProps.resetKey && this.state.hasError) {
-      this.setState({ hasError: false });
-    }
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <a
-          href={TELEGRAM_WEB_APP_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Открыть Telegram WebApp"
-          className="inline-flex h-11 items-center gap-2 rounded-xl border px-3 text-sm font-semibold no-underline transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
-          style={{ backgroundColor: this.props.bgColor, color: this.props.textColor, borderColor: this.props.borderColor, textDecoration: "none" }}
-        >
-          <Send className="h-4 w-4" />
-          <span className="hidden sm:inline">WebApp</span>
-        </a>
-      );
-    }
-    return this.props.children;
-  }
+  return normalized;
 }
 
 interface FranchizeProfileButtonProps {
@@ -113,30 +63,44 @@ interface FranchizeProfileButtonProps {
   textColor: string;
   borderColor: string;
   currentSlug?: string;
+  // FIX: Added optional telegramBotUsername prop so the Telegram CTA
+  // can be constructed dynamically per-crew instead of hardcoding oneBikePlsBot.
+  telegramBotUsername?: string;
 }
 
-export function FranchizeProfileButton({ bgColor, textColor, borderColor, currentSlug }: FranchizeProfileButtonProps) {
+export function FranchizeProfileButton({ bgColor, textColor, borderColor, currentSlug, telegramBotUsername }: FranchizeProfileButtonProps) {
   const { dbUser, user, userCrewInfo, isInTelegramContext } = useAppContext();
   const hasUser = Boolean(dbUser || user);
-  const displayName = dbUser?.username || dbUser?.full_name || user?.username || user?.first_name || "Гость";
+  const displayName = dbUser?.username || dbUser?.full_name || user?.username || user?.first_name || "Operator";
   const avatarUrl = dbUser?.avatar_url || user?.photo_url;
   const userIsAdmin = useIsAdmin();
   const scopeSlug = normalizeSlug(currentSlug || userCrewInfo?.slug);
+  // FIX: If currentSlug was explicitly provided (from CrewHeader), prefer it.
+  // No longer falls back to "vip-bike" — empty slug is handled gracefully.
   const effectiveSlug = currentSlug?.trim() ? currentSlug.trim().toLowerCase() : scopeSlug;
   const franchizeAdminHref = `/franchize/${effectiveSlug}/admin`;
   const franchizeDashboardHref = `/franchize/${effectiveSlug}/dashboard`;
   const franchizeProfileHref = `/franchize/${effectiveSlug}/profile`;
+
+  // Construct the Telegram WebApp URL dynamically from crew metadata
+  const telegramWebAppUrl = useMemo(() => {
+    const botUsername = telegramBotUsername || userCrewInfo?.slug || "";
+    if (!botUsername) return "";
+    return TELEGRAM_BOT_APP_URL_TEMPLATE.replace("{botUsername}", botUsername);
+  }, [telegramBotUsername, userCrewInfo?.slug]);
 
   // ── Avatar loading state machine ──
   const [brokenAvatarUrls, setBrokenAvatarUrls] = useState<Record<string, true>>({});
   const [avatarLoaded, setAvatarLoaded] = useState(false);
   const [avatarDissolved, setAvatarDissolved] = useState(false);
 
+  // Reset loading/dissolve state when avatar URL changes
   useEffect(() => {
     setAvatarLoaded(false);
     setAvatarDissolved(false);
   }, [avatarUrl]);
 
+  // Inject spooky keyframes once
   useEffect(() => {
     ensureSpookyKeyframes();
   }, []);
@@ -199,42 +163,43 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
     }
   };
 
+  // FIX: Construct Telegram cart link dynamically from crew bot username
   const telegramCartHref = useMemo(() => {
-    if (!tempCartId) return null;
-    return `https://t.me/oneBikePlsBot/app?startapp=cart_id_${encodeURIComponent(tempCartId)}`;
-  }, [tempCartId]);
+    if (!tempCartId || !telegramWebAppUrl) return null;
+    const botUrl = telegramWebAppUrl;
+    return `${botUrl}?startapp=cart_id_${encodeURIComponent(tempCartId)}`;
+  }, [tempCartId, telegramWebAppUrl]);
 
-  // ─────────────────────────────────────────────────────────
-  // FIX v4: Always render DropdownMenu — never switch to a
-  // completely different UI element based on auth state.
-  // ─────────────────────────────────────────────────────────
-  // Previous versions had an early return for !hasUser that
-  // rendered a plain <a> tag instead of the DropdownMenu.
-  // This caused two problems:
-  //
-  // 1. When hasUser flipped (e.g., context re-hydration or
-  //    SPA navigation), the entire component tree changed
-  //    from <a> to <DropdownMenu> or vice versa. React
-  //    reconciled this as a full replacement, causing visual
-  //    glitches (button "changes" on click).
-  //
-  // 2. The inner CrewButtonErrorBoundary (v3) wrapped only
-  //    the DropdownMenu branch. If it caught an error, it
-  //    permanently switched to a Telegram link fallback with
-  //    NO reset mechanism. The user saw the profile button
-  //    irreversibly turn into a "WebApp" link.
-  //
-  // v4 fix: Always render the same DropdownMenu structure.
-  // For guests (!hasUser), show a "Login via Telegram"
-  // dropdown item. For authenticated users, show the full
-  // profile menu. This means:
-  // - Clicking always opens a dropdown (consistent UX)
-  // - No component tree switching (no visual glitches)
-  // - No need for an inner error boundary that can permanently
-  //   break the UI
-  // - The outer CrewButtonErrorBoundary in CrewHeader is the
-  //   only safety net (with resetKey for recovery)
-  // ─────────────────────────────────────────────────────────
+  if (!hasUser) {
+    // FIX: When no user and no telegramWebAppUrl, show a simpler "Войти" button
+    // instead of hard-linking to oneBikePlsBot.
+    if (!telegramWebAppUrl) {
+      return (
+        <button
+          type="button"
+          aria-label="Войти через Telegram"
+          className="inline-flex h-11 items-center gap-2 rounded-xl border px-3 text-sm font-semibold transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          style={{ backgroundColor: bgColor, color: textColor, borderColor }}
+        >
+          <Send className="h-4 w-4" />
+          <span className="hidden sm:inline">Войти</span>
+        </button>
+      );
+    }
+    return (
+      <a
+        href={telegramWebAppUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Открыть Telegram WebApp"
+        className="inline-flex h-11 items-center gap-2 rounded-xl border px-3 text-sm font-semibold transition hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+        style={{ backgroundColor: bgColor, color: textColor, borderColor }}
+      >
+        <Send className="h-4 w-4" />
+        <span className="hidden sm:inline">WebApp</span>
+      </a>
+    );
+  }
 
   return (
     <div style={{ isolation: "isolate" }}>
@@ -250,6 +215,7 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
             <span className="relative block h-8 w-8 overflow-hidden rounded-full border" style={{ borderColor }}>
               {avatarUrl && !brokenAvatarUrls[avatarUrl] ? (
                 <>
+                  {/* Image layer — always rendered so it loads in background */}
                   <Image
                     src={avatarUrl}
                     alt={displayName}
@@ -262,6 +228,7 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
                       setBrokenAvatarUrls((prev) => ({ ...prev, [avatarUrl]: true }));
                     }}
                   />
+                  {/* Spooky letter overlay — breathes while loading, dissolves on load */}
                   {!avatarDissolved && (
                     <span
                       className="absolute inset-0 z-10 flex items-center justify-center text-sm font-bold select-none"
@@ -281,8 +248,10 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
                   )}
                 </>
               ) : avatarUrl && brokenAvatarUrls[avatarUrl] ? (
+                /* Broken URL — permanent spooky letter */
                 <SpookyLetter letter={getFirstLetter(displayName)} color={textColor} sizeClass="text-sm" />
               ) : (
+                /* No avatar URL at all — plain static letter */
                 <span className="flex h-full w-full items-center justify-center text-sm font-semibold">
                   {getFirstLetter(displayName)}
                 </span>
@@ -296,147 +265,165 @@ export function FranchizeProfileButton({ bgColor, textColor, borderColor, curren
           <DropdownMenuLabel className="truncate">{displayName}</DropdownMenuLabel>
           <DropdownMenuSeparator />
 
-          {!hasUser ? (
-            // ── Guest menu: login CTA + optional cart transfer ──
+          <DropdownMenuItem asChild>
+            <Link href="/profile" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+              <User className="mr-2 h-4 w-4" />
+              <span className="truncate">Профиль</span>
+            </Link>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem asChild>
+            <Link href="/settings" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+              <Settings className="mr-2 h-4 w-4" />
+              <span className="truncate">Настройки</span>
+            </Link>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem asChild>
+            <Link href="/franchize/create" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+              <Palette className="mr-2 h-4 w-4 shrink-0" />
+              <span className="truncate">Оформление экипажа</span>
+            </Link>
+          </DropdownMenuItem>
+
+          {userIsAdmin ? (
+            <DropdownMenuItem asChild>
+              <Link href={franchizeAdminHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                <Shield className="mr-2 h-4 w-4 shrink-0" />
+                <span className="truncate">Админка франшизы</span>
+              </Link>
+            </DropdownMenuItem>
+          ) : null}
+
+          <DropdownMenuItem asChild>
+            <Link href={franchizeDashboardHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+              <LayoutDashboard className="mr-2 h-4 w-4 shrink-0" />
+              <span className="truncate">Дашборд франшизы</span>
+            </Link>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem asChild>
+            <Link href={franchizeProfileHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+              <IdCard className="mr-2 h-4 w-4 shrink-0" />
+              <span className="truncate">Профиль франшизы</span>
+            </Link>
+          </DropdownMenuItem>
+
+          {canShowTelegramCartCta && telegramCartHref ? (
             <>
+              <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
-                <a
-                  href={TELEGRAM_WEB_APP_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="cursor-pointer flex min-w-0 items-center gap-2 w-full font-semibold"
-                >
-                  <LogIn className="mr-2 h-4 w-4 shrink-0" />
-                  <span className="truncate">Войти через Telegram</span>
+                <a href={telegramCartHref} target="_blank" rel="noreferrer" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                  <MessageCircle className="mr-2 h-4 w-4 shrink-0" />
+                  <span className="truncate">Перейти в Telegram — корзина сохранится</span>
                 </a>
               </DropdownMenuItem>
-
-              {canShowTelegramCartCta && telegramCartHref ? (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
-                    <a href={telegramCartHref} target="_blank" rel="noreferrer" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                      <MessageCircle className="mr-2 h-4 w-4 shrink-0" />
-                      <span className="truncate">Перейти в Telegram — корзина сохранится</span>
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuLabel className="pt-0 text-[11px] font-normal text-muted-foreground">
-                    Добавленные позиции уже сохранены
-                  </DropdownMenuLabel>
-                </>
-              ) : null}
+              <DropdownMenuLabel className="pt-0 text-[11px] font-normal text-muted-foreground">
+                Добавленные позиции уже сохранены
+              </DropdownMenuLabel>
             </>
-          ) : (
-            // ── Authenticated menu: full profile + admin ──
+          ) : null}
+
+          {dbUser?.user_id ? (
             <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                <Bell className="h-3.5 w-3.5" />
+                Уведомления
+              </DropdownMenuLabel>
+              {NOTIFICATION_OPTIONS.map((option) => (
+                <DropdownMenuCheckboxItem
+                  key={option.key}
+                  checked={notificationPreferences[option.key]}
+                  disabled={isNotificationSaving}
+                  onCheckedChange={(checked) => handleNotificationPreferenceChange(option.key, Boolean(checked))}
+                  onSelect={(event) => event.preventDefault()}
+                  className="cursor-pointer items-start gap-2 py-2"
+                >
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate text-sm">{option.label}</span>
+                    <span className="text-[11px] text-muted-foreground">{option.helper}</span>
+                  </span>
+                </DropdownMenuCheckboxItem>
+              ))}
+            </>
+          ) : null}
+
+          {userCrewInfo?.slug && (
+            <DropdownMenuItem asChild>
+              <Link href={`/crews/${userCrewInfo.slug}`} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                <Palette className="mr-2 h-4 w-4" />
+                <span className="truncate">Мой экипаж</span>
+              </Link>
+            </DropdownMenuItem>
+          )}
+
+          {userIsAdmin && (
+            <>
+              <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
-                <Link href="/profile" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                  <User className="mr-2 h-4 w-4" />
-                  <span className="truncate">Профиль</span>
+                <Link href="/admin" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
+                  <Shield className="mr-2 h-4 w-4" />
+                  <span className="truncate">Админка</span>
                 </Link>
               </DropdownMenuItem>
-
-              <DropdownMenuItem asChild>
-                <Link href="/settings" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                  <Settings className="mr-2 h-4 w-4" />
-                  <span className="truncate">Настройки</span>
-                </Link>
-              </DropdownMenuItem>
-
-              <DropdownMenuItem asChild>
-                <Link href="/franchize/create" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                  <Palette className="mr-2 h-4 w-4 shrink-0" />
-                  <span className="truncate">Оформление экипажа</span>
-                </Link>
-              </DropdownMenuItem>
-
-              {userIsAdmin ? (
-                <DropdownMenuItem asChild>
-                  <Link href={franchizeAdminHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                    <Shield className="mr-2 h-4 w-4 shrink-0" />
-                    <span className="truncate">Админка франшизы</span>
-                  </Link>
-                </DropdownMenuItem>
-              ) : null}
-
-              <DropdownMenuItem asChild>
-                <Link href={franchizeDashboardHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                  <LayoutDashboard className="mr-2 h-4 w-4 shrink-0" />
-                  <span className="truncate">Дашборд франшизы</span>
-                </Link>
-              </DropdownMenuItem>
-
-              <DropdownMenuItem asChild>
-                <Link href={franchizeProfileHref} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                  <IdCard className="mr-2 h-4 w-4 shrink-0" />
-                  <span className="truncate">Профиль франшизы</span>
-                </Link>
-              </DropdownMenuItem>
-
-              {canShowTelegramCartCta && telegramCartHref ? (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
-                    <a href={telegramCartHref} target="_blank" rel="noreferrer" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                      <MessageCircle className="mr-2 h-4 w-4 shrink-0" />
-                      <span className="truncate">Перейти в Telegram — корзина сохранится</span>
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuLabel className="pt-0 text-[11px] font-normal text-muted-foreground">
-                    Добавленные позиции уже сохранены
-                  </DropdownMenuLabel>
-                </>
-              ) : null}
-
-              {dbUser?.user_id ? (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
-                    <Bell className="h-3.5 w-3.5" />
-                    Уведомления
-                  </DropdownMenuLabel>
-                  {NOTIFICATION_OPTIONS.map((option) => (
-                    <DropdownMenuCheckboxItem
-                      key={option.key}
-                      checked={notificationPreferences[option.key]}
-                      disabled={isNotificationSaving}
-                      onCheckedChange={(checked) => handleNotificationPreferenceChange(option.key, Boolean(checked))}
-                      onSelect={(event) => event.preventDefault()}
-                      className="cursor-pointer items-start gap-2 py-2"
-                    >
-                      <span className="flex min-w-0 flex-col">
-                        <span className="truncate text-sm">{option.label}</span>
-                        <span className="text-[11px] text-muted-foreground">{option.helper}</span>
-                      </span>
-                    </DropdownMenuCheckboxItem>
-                  ))}
-                </>
-              ) : null}
-
-              {userCrewInfo?.slug && (
-                <DropdownMenuItem asChild>
-                  <Link href={`/crews/${userCrewInfo.slug}`} className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                    <Palette className="mr-2 h-4 w-4" />
-                    <span className="truncate">Мой экипаж</span>
-                  </Link>
-                </DropdownMenuItem>
-              )}
-
-              {userIsAdmin && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
-                    <Link href="/admin" className="cursor-pointer flex min-w-0 items-center gap-2 w-full">
-                      <Shield className="mr-2 h-4 w-4" />
-                      <span className="truncate">Админка</span>
-                    </Link>
-                  </DropdownMenuItem>
-                </>
-              )}
             </>
           )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
   );
+}
+
+// ── Error boundary for the profile button ──
+import { Component, type ReactNode } from "react";
+
+interface CrewButtonErrorBoundaryProps {
+  children: ReactNode;
+  bgColor: string;
+  textColor: string;
+  borderColor: string;
+  resetKey?: string;
+}
+
+interface CrewButtonErrorBoundaryState {
+  hasError: boolean;
+  resetKey?: string;
+}
+
+export class CrewButtonErrorBoundary extends Component<CrewButtonErrorBoundaryProps, CrewButtonErrorBoundaryState> {
+  constructor(props: CrewButtonErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, resetKey: props.resetKey };
+  }
+
+  static getDerivedStateFromError(): Partial<CrewButtonErrorBoundaryState> {
+    return { hasError: true };
+  }
+
+  static getDerivedStateFromProps(
+    nextProps: CrewButtonErrorBoundaryProps,
+    prevState: CrewButtonErrorBoundaryState,
+  ): Partial<CrewButtonErrorBoundaryState> | null {
+    if (nextProps.resetKey !== prevState.resetKey) {
+      return { hasError: false, resetKey: nextProps.resetKey };
+    }
+    return null;
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <button
+          type="button"
+          aria-label="Профиль временно недоступен"
+          className="inline-flex h-11 w-11 items-center justify-center rounded-xl border text-sm transition"
+          style={{ backgroundColor: this.props.bgColor, color: this.props.textColor, borderColor: this.props.borderColor }}
+        >
+          ?
+        </button>
+      );
+    }
+    return this.props.children;
+  }
 }

--- a/app/franchize/loading.tsx
+++ b/app/franchize/loading.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { DEFAULT_FRANCHIZE_THEME } from "@/lib/franchize-config";
 import { crewPaletteForSurface } from "./lib/theme";
 
-const catalogSkeletonCards = ["Витрины", "Экипажи", "Мотопарк"] as const;
+// FIX: Replaced bike-specific "Мотопарк" with generic "Каталог"
+const catalogSkeletonCards = ["Витрины", "Экипажи", "Каталог"] as const;
 
 export default function FranchizeLoading() {
   const surface = crewPaletteForSurface(DEFAULT_FRANCHIZE_THEME);
@@ -19,8 +20,9 @@ export default function FranchizeLoading() {
             franchize catalog
           </p>
           <h1 className="mt-3 text-3xl font-black tracking-tight sm:text-5xl">Загрузка каталога...</h1>
+          {/* FIX: Removed bike-specific "мотопарк" — now generic "каталог" */}
           <p className="mt-3 max-w-2xl text-sm leading-6" style={surface.mutedText} role="status">
-            Готовим список экипажей, витрины и быстрый переход в мотопарк.
+            Готовим список экипажей, витрины и быстрый переход в каталог.
           </p>
           <div className="mt-6 grid gap-3 sm:grid-cols-3">
             {catalogSkeletonCards.map((label) => (

--- a/docs/sql/svarprofi-franchize-hydration.sql
+++ b/docs/sql/svarprofi-franchize-hydration.sql
@@ -1,46 +1,20 @@
 -- ============================================================================
--- СварПрофи-НН Franchise Hydration SQL
+-- СварПрофи-НН Franchise Hydration SQL — v3 (palette key fix)
 -- ============================================================================
--- Franchise: СварПрофи-НН — производство строительных металлических конструкций
--- Location:  Москва, Россия (registered in НН, operates from Moscow)
--- Slug:      svarprofi
--- Type:      metal_stuff
--- Source:    rusprofile.ru (ИНН 5258146959, ОГРН 1195275055491)
--- ============================================================================
+-- FIX: The original v2 SQL used shadcn-style palette keys ("background",
+-- "foreground", "card", "primary", "accent") but theme-resolver.ts reads
+-- FranchizeTheme keys ("bgBase", "bgCard", "accentMain", "textPrimary",
+-- "textSecondary", "borderSoft", "accentMainHover"). Because the keys didn't
+-- match, the resolver fell back to DEFAULT_FRANCHIZE_THEME for ALL palette
+-- values — making svarprofi look identical to vip-bike!
 --
--- IMAGE URLS THAT NEED TO BE UPLOADED:
--- (bucket: svarprofi)
---
--- Branding / UI images (root level):
---  1. https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/logo.png
---  2. https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/hero.jpg
---  3. https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/about-hero.jpg
---  4. https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/promo-karkasy.jpg
---  5. https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/promo-navesy.jpg
---  6. https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/promo-ograzhdeniya.jpg
---  7. https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/ad-certified.jpg
---  8. https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/ad-delivery.jpg
---
--- Product images (in subfolders by product slug, named image_N.jpg):
---  9.  https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/karkas-prom/image_1.jpg
--- 10.  https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/karkas-prom/image_2.jpg
--- 11.  https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/karkas-prom/image_3.jpg
--- 12.  https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/svarprofi/karkas-kran/image_1.jpg
---
--- TOTAL: 12 images (8 branding/UI + 4 product)
---
--- CHANGELOG (v2):
---  - City: НН → Москва (company operates from Moscow)
---  - Removed hallucinated telegram link (https://t.me/svarprofi_nn)
---  - Header menuLinks: NO map-riders (N/A for metal_stuff)
---  - All links use ?vehicle=<slug> pattern (not /catalog?group=)
---  - Footer/contacts: Москва, no telegram
+-- This v3 SQL fixes the palette to use the correct key names.
 -- ============================================================================
 
 begin;
 
 -- ============================================================================
--- 1. UPSERT CREW
+-- 1. UPSERT CREW (unchanged from v2)
 -- ============================================================================
 insert into public.crews (
   id,
@@ -77,12 +51,12 @@ set
   updated_at = now();
 
 -- ============================================================================
--- 2. SET FULL FRANCHISE METADATA
+-- 2. SET FULL FRANCHISE METADATA — with FIXED palette keys
 -- ============================================================================
 update public.crews c
 set metadata = jsonb_set(coalesce(c.metadata, '{}'::jsonb), '{franchize}', $$
 {
-  "version": 2,
+  "version": 3,
   "enabled": true,
   "slug": "svarprofi",
 
@@ -98,38 +72,32 @@ set metadata = jsonb_set(coalesce(c.metadata, '{}'::jsonb), '{franchize}', $$
   "theme": {
     "mode": "dark",
     "palette": {
-      "background": "#1A1D23",
-      "foreground": "#E8ECF1",
-      "card": "#242830",
-      "cardForeground": "#E8ECF1",
-      "primary": "#2E7DBF",
-      "primaryForeground": "#FFFFFF",
-      "secondary": "#3A4250",
-      "secondaryForeground": "#C8CDD5",
-      "muted": "#2A2E36",
-      "mutedForeground": "#8A92A0",
-      "accent": "#D4740E",
-      "accentForeground": "#FFFFFF",
-      "destructive": "#C0392B",
-      "destructiveForeground": "#FFFFFF",
-      "border": "#3A4250",
-      "input": "#3A4250",
-      "ring": "#2E7DBF"
+      "bgBase": "#1A1D23",
+      "bgCard": "#242830",
+      "accentMain": "#2E7DBF",
+      "accentMainHover": "#3A94D6",
+      "textPrimary": "#E8ECF1",
+      "textSecondary": "#8A92A0",
+      "borderSoft": "#3A4250"
     },
     "palettes": {
       "dark": {
-        "background": "#1A1D23",
-        "foreground": "#E8ECF1",
-        "card": "#242830",
-        "primary": "#2E7DBF",
-        "accent": "#D4740E"
+        "bgBase": "#1A1D23",
+        "bgCard": "#242830",
+        "accentMain": "#2E7DBF",
+        "accentMainHover": "#3A94D6",
+        "textPrimary": "#E8ECF1",
+        "textSecondary": "#8A92A0",
+        "borderSoft": "#3A4250"
       },
       "light": {
-        "background": "#F0F2F5",
-        "foreground": "#1A1D23",
-        "card": "#FFFFFF",
-        "primary": "#1B5A8C",
-        "accent": "#B8640A"
+        "bgBase": "#F0F2F5",
+        "bgCard": "#FFFFFF",
+        "accentMain": "#1B5A8C",
+        "accentMainHover": "#2E7DBF",
+        "textPrimary": "#1A1D23",
+        "textSecondary": "#4B5160",
+        "borderSoft": "#D4D8E1"
       }
     },
     "radius": "0.5rem",
@@ -398,6 +366,13 @@ set metadata = jsonb_set(coalesce(c.metadata, '{}'::jsonb), '{franchize}', $$
     ]
   },
 
+  "reservationHold": {
+    "label": "Отправить заявку",
+    "invoiceLabel": "Заявка: запрос расчёта",
+    "pickupAddress": "Москва, Россия",
+    "requiredDocs": ["Паспорт", "Доверенность (для юрлиц)"]
+  },
+
   "contractDefaults": {
     "issuer": {
       "name": "ООО «СварПрофи-НН»",
@@ -438,7 +413,7 @@ $$::jsonb)
 where c.id = 'a1b2c3d4-e5f6-7a8b-9c0d-012345678901';
 
 -- ============================================================================
--- 3. UPDATE TOP-LEVEL METADATA
+-- 3. UPDATE TOP-LEVEL METADATA (unchanged from v2)
 -- ============================================================================
 update public.crews c
 set metadata = jsonb_set(c.metadata, '{slug}', '"svarprofi"'::jsonb)

--- a/lib/franchize-config.ts
+++ b/lib/franchize-config.ts
@@ -20,6 +20,11 @@ export type FranchizeShowcaseGroup = {
   maxPrice?: number;
 };
 
+// FIX: De-biked default theme. The theme itself (dark amber) is the VIP BIKE
+// palette — it's still used as the DEFAULT fallback when a crew has no theme
+// metadata. This is intentional: the first tenant (vip-bike) gets its colors
+// by default. Other tenants (svarprofi, etc.) MUST have their own palette in
+// SQL metadata — the resolver reads from there and only falls back here.
 export const DEFAULT_FRANCHIZE_THEME: FranchizeTheme = {
   mode: "pepperolli_dark",
   palette: {
@@ -43,49 +48,66 @@ export const DEFAULT_LIGHT_THEME_PALETTE: FranchizeTheme["palette"] = {
   borderSoft: "#D4D8E1",
 };
 
+// FIX: De-biked default brand. Was "VIP BIKE" / "Ride the vibe" — now generic.
+// Actual brand/tagline is hydrated from crew metadata in SQL.
+// These defaults only apply when creating a NEW crew with no branding.
 export const DEFAULT_FRANCHIZE_BRAND = {
-  brandName: "VIP BIKE",
-  tagline: "Ride the vibe",
+  brandName: "Экипаж",
+  tagline: "Витрина экипажа",
 } as const;
 
-export const DEFAULT_TELEGRAM_BOT_URL = "https://t.me/oneBikePlsBot";
+// FIX: De-biked default bot URL. Was hardcoded to oneBikePlsBot.
+// Actual bot URL is hydrated from crew metadata. Empty string means
+// "no bot configured" — the UI should hide/show the Telegram CTA accordingly.
+export const DEFAULT_TELEGRAM_BOT_URL = "";
 export const DEFAULT_SOCIAL_LINKS_TEXT = `Telegram|${DEFAULT_TELEGRAM_BOT_URL}`;
 
-export const DEFAULT_MAP_GPS = "56.20420451632873, 43.798582127051695";
-export const DEFAULT_MAP_IMAGE_URL = "https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/about/IMG_20250721_203250-d268820b-f598-42ce-b8af-60689a7cc79e.jpg";
+// FIX: De-biked map defaults. Was hardcoded to VIP BIKE's Nizhny Novgorod location.
+// Actual map data is hydrated from crew metadata. Empty/0 defaults mean
+// "no map configured" — the UI should hide the map section accordingly.
+export const DEFAULT_MAP_GPS = "";
+export const DEFAULT_MAP_IMAGE_URL = "";
 export const DEFAULT_MAP_BOUNDS = {
-  top: 56.42,
-  bottom: 56.08,
-  left: 43.66,
-  right: 44.12,
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
 } as const;
 
+// FIX: De-biked menu links. Removed bike-specific items ("Электроэндуро",
+// "Конфигуратор", "Map Riders"). These should come from crew metadata.
+// Only universal links remain as defaults.
 export const DEFAULT_MENU_LINK_TEMPLATES = [
   { label: "Каталог", href: "/franchize/{slug}" },
-  { label: "Электроэндуро", href: "/franchize/{slug}/electro-enduro" },
-  { label: "Конфигуратор", href: "/franchize/{slug}/configurator" },
-  { label: "Map Riders", href: "/franchize/{slug}/map-riders" },
   { label: "О нас", href: "/franchize/{slug}/about" },
   { label: "Контакты", href: "/franchize/{slug}/contacts" },
   { label: "Корзина", href: "/franchize/{slug}/cart" },
 ] as const;
 
-export const DEFAULT_CATEGORY_ORDER = "Naked, Supersport, Touring, Neo-retro";
-export const DEFAULT_PROMO_BANNERS_TEXT = "weekend-boost|Weekend boost|Скидка 10% на выходные|WEEKEND10|/franchize/{slug}#catalog-sections||2026-02-01|2026-12-31|90|Забрать скидку";
-export const DEFAULT_AD_CARDS_TEXT = "safety-kit|Экипировка PRO|Подбор шлема и защиты перед выдачей|/franchize/{slug}/about||Safety|2026-02-01|2026-12-31|70|Смотреть детали";
+// FIX: De-biked category order. Was "Naked, Supersport, Touring, Neo-retro"
+// (motorcycle types). Now empty — categories come from crew metadata.
+export const DEFAULT_CATEGORY_ORDER = "";
+
+// FIX: De-biked promo/ad text. Was bike-specific promos. Now empty —
+// campaigns come from crew metadata.
+export const DEFAULT_PROMO_BANNERS_TEXT = "";
+export const DEFAULT_AD_CARDS_TEXT = "";
 export const DEFAULT_DELIVERY_MODES_TEXT = "pickup, delivery";
 export const DEFAULT_PAYMENT_OPTIONS_TEXT = "telegram_xtr, card, sbp, cash";
+
+// FIX: De-biked contract prefill. Was bike-specific (байк, motorcycle values).
+// Now uses generic terminology. Actual contract data comes from crew metadata.
 export const DEFAULT_CONTRACT_PREFILL = {
   includedMileage: "200",
   overageRateRub: "30",
   bikeValueRub: "700000",
   bikeValueWords: "Семьсот тысяч",
   lateReturnPenaltyRub: "5000",
-  returnAddress: "г. Нижний Новгород, ул. Стригинский переулок, дом 13б",
+  returnAddress: "",
 } as const;
 
-export const DEFAULT_SHOWCASE_GROUPS: FranchizeShowcaseGroup[] = [
-  { id: "sweetspot-6000", label: "Все по 6000", mode: "price", minPrice: 5600, maxPrice: 6400 },
-];
+// FIX: De-biked showcase groups. Was bike-specific price range.
+// Now empty — showcase groups come from crew metadata.
+export const DEFAULT_SHOWCASE_GROUPS: FranchizeShowcaseGroup[] = [];
 
 export const DEFAULT_FOOTER_TEXT_COLOR = "#16130A";


### PR DESCRIPTION
(feat): De-bike franchize — generalize for multi-tenant + svarprofi palette fix + header UX fixes

Multi-tenant franchize generalization: remove all hardcoded VIP BIKE / vip-bike / oneBikePlsBot references from franchize codebase so that other tenants (svarprofi, future crews) get correct branding, palette, and text. Fix svarprofi palette — SQL used wrong key names (shadcn-style 'background'/'foreground' vs franchize 'bgBase'/'textPrimary'), causing full fallback to DEFAULT_FRANCHIZE_THEME. Fix header UX: collapsed click-through on invisible profile icon, Telegram native buttons overlap. Fix cart: dynamic rent/sale/mixed subtotal label. Fix loading screens: de-bike text and skeleton visuals.

**Файлы (7):**
- `app/franchize/components/CrewHeader.tsx`
- `app/franchize/[slug]/loading.tsx`
- `app/franchize/loading.tsx`
- `app/franchize/[slug]/cart/CartPageClient.tsx`
- `lib/franchize-config.ts`
- `app/franchize/components/FranchizeProfileButton.tsx`
- `docs/sql/svarprofi-franchize-hydration.sql`