### PR TITLE
(fix): Catalog design alignment + generalize rental UI for non-rental

### DIFF
--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -13,7 +13,7 @@ import { catalogCardVariantStyles, crewPaletteForSurface, interactionRingStyle }
 import type { CatalogItemVM, FranchizeCrewVM } from "../actions";
 import { upsertFranchizeIntent } from "../actions";
 import { FloatingCartIconLinkBySlug } from "./FloatingCartIconLinkBySlug";
-import { ItemModal } from "../modals/Item";
+import { ItemModal, type FlowType } from "../modals/Item";
 import { useFranchizeCart } from "../hooks/useFranchizeCart";
 import { buildCatalogRentalStrip } from "../lib/catalog-rental-strip";
 
@@ -43,6 +43,23 @@ const sortWbItemLast = <T extends { category: string }>(groups: T[]) => {
 
 const hasRentPrice = (item: CatalogItemVM) => item.pricePerDay > 0;
 const hasSalePrice = (item: CatalogItemVM) => item.saleAvailable && Boolean(item.salePrice && item.salePrice > 0);
+
+// Derive flow type per-item from pricing — no need for drilled "mode" prop
+// Items with rental pricing → "rental" (shows 1/3/7 days, packages, auction)
+// Items without → "order" (simple select/purchase flow, no rental UI)
+function getItemFlowType(item: CatalogItemVM): FlowType {
+  return item.pricePerDay > 0 ? "rental" : "order";
+}
+
+// Derive CTA label per-item from pricing + saleAvailable
+function getItemCtaLabel(item: CatalogItemVM): string {
+  // Sale item that also has rental → "Купить" (buy option on rental context)
+  if (item.saleAvailable && item.pricePerDay > 0) return "Купить";
+  // Pure rental → "Забронировать"
+  if (item.pricePerDay > 0) return "Забронировать";
+  // Sale-only or order-only (svarprofi etc.) → "Выбрать"
+  return "Выбрать";
+}
 
 // ── RESTORED: Helper functions deleted by agent but still referenced in grid path ──
 
@@ -562,7 +579,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
         </div>
 
         {promoModules.length > 0 && mode !== "electro" && (
-          <div className="mb-5 flex gap-2 overflow-x-auto pb-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:grid sm:grid-cols-3 sm:overflow-visible sm:pb-0">
+          <div className="mb-5 flex gap-2 overflow-x-auto [overflow-y:clip] touch-pan-x overscroll-behavior-x-contain pb-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:grid sm:grid-cols-3 sm:overflow-visible sm:pb-0">
             {visiblePromoModules.map((module, index) => {
               const isExternal = /^(https?:|mailto:|tel:)/.test(module.href);
               return (
@@ -600,7 +617,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
           Найдено позиций: {filteredItems.length}
         </p>
 
-        <div className="mb-5 flex gap-2 overflow-x-auto pb-1 no-scrollbar [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden" role="group" aria-label="Быстрые фильтры каталога">
+        <div className="mb-5 flex gap-2 overflow-x-auto [overflow-y:clip] touch-pan-x overscroll-behavior-x-contain pb-1 no-scrollbar [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden" role="group" aria-label="Быстрые фильтры каталога">
           {QUICK_FILTERS.map((filter) => {
             const active = quickFilter === filter.key;
             return (
@@ -669,7 +686,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                       ref={(node) => {
                         carouselRefs.current[group.category] = node;
                       }}
-                      className="flex snap-x snap-mandatory gap-3 overflow-x-auto pb-2 touch-pan-x [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+                      className="flex snap-x snap-mandatory gap-3 overflow-x-auto [overflow-y:clip] pt-1 pb-2 touch-pan-x overscroll-behavior-x-contain [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
                       tabIndex={0}
                       role="region"
                       aria-label={`Карусель категории ${group.category}`}
@@ -691,19 +708,22 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                       data-catalog-item="true"
                       data-carousel-card="true"
                       data-carousel-index={index}
-                      className="group w-[65vw] max-w-[280px] shrink-0 snap-start rounded-2xl border transition-shadow hover:shadow-[0_0_0_1px_var(--catalog-accent),0_0_28px_color-mix(in_srgb,var(--catalog-accent)_35%,transparent)] sm:w-[260px]"
+                      className="group w-[46vw] max-w-[280px] shrink-0 snap-start overflow-hidden rounded-2xl border transition-shadow hover:shadow-[0_0_0_1px_var(--catalog-accent),0_0_28px_color-mix(in_srgb,var(--catalog-accent)_35%,transparent)] sm:w-[260px]"
                       style={catalogCardVariantStyles(crew.theme, item.id.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0))}
                     >
                       <button
                         type="button"
                         aria-label={`Открыть карточку ${item.title}: ${item.rentPriceLabel}`}
                         data-catalog-item-button="true"
-                        className="block w-full overflow-hidden text-left"
+                        className="block w-full rounded-2xl overflow-hidden text-left"
                         onClick={() => openItem(item)}
                         onFocus={() => setFocusedItemId(item.id)}
                         onBlur={() => setFocusedItemId((prev) => (prev === item.id ? null : prev))}
                         style={focusedItemId === item.id ? interactionRingStyle(crew.theme) : undefined}
                         onPointerMove={(event) => {
+                          // Skip parallax on touch — setState re-renders mid-scroll
+                          // confuse iOS Safari's scroll gesture decider
+                          if (event.pointerType === 'touch') return;
                           const rect = event.currentTarget.getBoundingClientRect();
                           const dx = ((event.clientX - rect.left) / rect.width - 0.5) * 2;
                           const dy = ((event.clientY - rect.top) / rect.height - 0.5) * 2;
@@ -724,7 +744,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                               src={item.imageUrl}
                               alt={item.title}
                               fill
-                              sizes="(max-width: 1279px) 65vw, 260px"
+                              sizes="(max-width: 1279px) 46vw, 260px"
                               className="object-cover transition-transform duration-300 ease-out"
                               style={{ transform: `scale(1.04) translate3d(${parallax.x * 4}px, ${parallax.y * 4}px, 0)` }}
                               onLoad={() => setCarouselLoadedByItem((prev) => ({ ...prev, [item.id]: true }))}
@@ -732,49 +752,52 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                           ) : (
                             <div className="flex h-full w-full items-center justify-center px-3 text-center text-xs" style={surface.mutedText}>Фото загружается — карточка уже доступна</div>
                           )}
-                        </div>
-                        <div className="p-3">
-                          {/* Badges */}
-                          <div className="mb-1.5 flex flex-wrap gap-1">
-                            {item.isHot && (
-                              <span className="inline-flex rounded-full bg-[color:color-mix(in_srgb,var(--catalog-accent)_86%,transparent)] px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--catalog-accent-contrast)]">
-                                Высокий спрос
-                              </span>
-                            )}
-                            <span className="inline-flex rounded-full px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em]" style={{ backgroundColor: rentalStrip.isAvailable ? "#1f7a3a3d" : "#dc262640", color: "#e6f4ea", border: rentalStrip.isAvailable ? "1px solid rgba(46, 160, 67, 0.45)" : "1px solid rgba(220, 38, 38, 0.45)" }}>{rentalStrip.availabilityLabel}</span>
-                            {item.saleAvailable && <span className="inline-flex rounded-full border border-amber-300/60 bg-amber-400/25 px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em] text-amber-100">Доступен к покупке</span>}
-                          </div>
-
-                          {/* Title */}
-                          <h3 className="text-sm font-semibold leading-5">{item.title}</h3>
-
-                          {/* Specs — icon + text rows (reference design) */}
-                          {specChips.length > 0 && (
-                            <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-[var(--catalog-muted)]">
-                              {specChips.map((spec, si) => (
-                                <span key={`${item.id}-spec-${si}`}>{spec.icon ? `${spec.icon} ` : ""}{spec.text}</span>
-                              ))}
-                            </div>
+                          {/* Gradient overlay — smooth transition from image to details */}
+                          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[55%] bg-gradient-to-t from-[color:color-mix(in_srgb,var(--catalog-card-bg)_92%,#000)] via-[color:color-mix(in_srgb,var(--catalog-card-bg)_65%,transparent)] to-transparent" />
+                          {/* Card content overlaid on image bottom */}
+                          <div className="absolute inset-x-0 bottom-0 p-3">
+                        {/* Badges */}
+                        <div className="mb-1.5 flex flex-wrap gap-1">
+                          {item.isHot && (
+                            <span className="inline-flex rounded-full bg-[color:color-mix(in_srgb,var(--catalog-accent)_86%,transparent)] px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--catalog-accent-contrast)]">
+                              Высокий спрос
+                            </span>
                           )}
+                          <span className="inline-flex rounded-full px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em]" style={{ backgroundColor: rentalStrip.isAvailable ? "#1f7a3a3d" : "#dc262640", color: "#e6f4ea", border: rentalStrip.isAvailable ? "1px solid rgba(46, 160, 67, 0.45)" : "1px solid rgba(220, 38, 38, 0.45)" }}>{rentalStrip.availabilityLabel}</span>
+                          {item.saleAvailable && <span className="inline-flex rounded-full border border-amber-300/60 bg-amber-400/25 px-2 py-0.5 text-[9px] font-semibold tracking-[0.02em] text-amber-100">Доступен к покупке</span>}
+                        </div>
 
-                          {/* Price — reference layout: large bold main price, rent/day subtext */}
-                          <div className="mt-2">
-                            {hasSalePrice(item) ? (
-                              <>
-                                <p className="text-lg font-bold text-[var(--catalog-accent)]">{item.salePrice?.toLocaleString("ru-RU")} ₽</p>
-                                {hasRentPrice(item) && (
-                                  <p className="text-[11px] text-white/60">{item.rentPriceLabel}</p>
-                                )}
-                              </>
-                            ) : hasRentPrice(item) ? (
-                              <p className="text-lg font-bold text-[var(--catalog-accent)]">{item.rentPriceLabel}</p>
-                            ) : (
-                              <p className="text-xs font-medium text-white/80">Цена по запросу</p>
-                            )}
+                        {/* Title */}
+                        <h3 className="text-sm font-semibold leading-5 text-white">{item.title}</h3>
+
+                        {/* Specs — icon + text in vertical rows (reference design) */}
+                        {specChips.length > 0 && (
+                          <div className="mt-1.5 space-y-0.5 text-[10px] text-white/75">
+                            {specChips.map((spec, si) => (
+                              <span key={`${item.id}-spec-${si}`} className="block">{spec.icon ? `${spec.icon} ` : ""}{spec.text}</span>
+                            ))}
                           </div>
+                        )}
 
-                          {/* CTA */}
-                          <div className="mt-2 flex gap-2"><span className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--catalog-accent)] px-2 py-2.5 text-xs font-bold text-[var(--catalog-accent-contrast)] transition-transform active:scale-95"><ShoppingCart className="h-4 w-4" />{item.saleAvailable ? "Закрепить" : "Забронировать выезд"}</span></div>
+                        {/* Price */}
+                        <div className="mt-2">
+                          {hasSalePrice(item) ? (
+                            <>
+                              <p className="text-lg font-bold text-[var(--catalog-accent)]">{item.salePrice?.toLocaleString("ru-RU")} ₽</p>
+                              {hasRentPrice(item) && (
+                                <p className="text-[11px] text-white/60">{item.rentPriceLabel}</p>
+                              )}
+                            </>
+                          ) : hasRentPrice(item) ? (
+                            <p className="text-lg font-bold text-[var(--catalog-accent)]">{item.rentPriceLabel}</p>
+                          ) : (
+                            <p className="text-xs font-medium text-white/80">Цена по запросу</p>
+                          )}
+                        </div>
+
+                        {/* CTA — generalized per flow type */}
+                        <div className="mt-2 flex gap-2"><span className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--catalog-accent)] px-2 py-2.5 text-xs font-bold text-[var(--catalog-accent-contrast)] transition-transform active:scale-95"><ShoppingCart className="h-4 w-4" />{getItemCtaLabel(item)}</span></div>
+                          </div>
                         </div>
                       </button>
                     </article>
@@ -813,7 +836,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                     <article
                       key={item.id}
                       data-catalog-item="true"
-                      className="group rounded-2xl border transition-shadow hover:shadow-[0_0_0_1px_var(--catalog-accent),0_0_28px_color-mix(in_srgb,var(--catalog-accent)_35%,transparent)]"
+                      className="group overflow-hidden rounded-2xl border transition-shadow hover:shadow-[0_0_0_1px_var(--catalog-accent),0_0_28px_color-mix(in_srgb,var(--catalog-accent)_35%,transparent)]"
                       style={catalogCardVariantStyles(crew.theme, item.id.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0))}
                     >
                       <button
@@ -853,9 +876,9 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                               {item.saleAvailable && <span className="inline-flex rounded-full border border-amber-300/60 bg-amber-400/25 px-1.5 py-0.5 text-[8px] font-semibold tracking-[0.02em] text-amber-100">Продажа</span>}
                             </div>
                             <h3 className="text-sm font-semibold leading-5 text-white">{item.title}</h3>
-                            <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-white/75">
+                            <div className="mt-1.5 space-y-0.5 text-[10px] text-white/75">
                               {visibleSpecs.map((spec, index) => (
-                                <span key={`${item.id}-spec-${index}`}>{spec.icon ? `${spec.icon} ` : ""}{spec.text}</span>
+                                <span key={`${item.id}-spec-${index}`} className="block">{spec.icon ? `${spec.icon} ` : ""}{spec.text}</span>
                               ))}
                             </div>
                             <div className="mt-2 space-y-0.5">
@@ -876,7 +899,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                             <div className="mt-2">
                               <span className="inline-flex min-h-10 w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--catalog-accent)] px-2 py-2 text-xs font-bold text-[var(--catalog-accent-contrast)] transition-transform active:scale-95">
                                 <ShoppingCart className="h-4 w-4" />
-                                {item.saleAvailable ? "Закрепить" : "Бронь"}
+                                {getItemCtaLabel(item)}
                               </span>
                             </div>
                           </div>
@@ -914,6 +937,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
         theme={crew.theme}
         pickupAddress={crew.contacts.address || crew.hqLocation}
         workingHours={crew.contacts.workingHours}
+        flowType={selectedItem ? getItemFlowType(selectedItem) : "order"}
         options={selectedOptions}
         auctionOptions={auctionTickOptions}
         onChangeOption={(key, value) => setSelectedOptions((prev) => ({ ...prev, [key]: value }))}

--- a/app/franchize/modals/Item.tsx
+++ b/app/franchize/modals/Item.tsx
@@ -19,6 +19,20 @@ import { buildCatalogRentalStrip } from "../lib/catalog-rental-strip";
 import { crewPaletteForSurface } from "../lib/theme";
 import { FRANCHIZE_MODAL_CLOSE_SAFE_AREA_STYLE } from "../lib/route-cta-policy";
 
+// ─────────────────────────────────────────────────────
+// Item Modal — generalized for rental & order flows
+// ─────────────────────────────────────────────────────
+// flowType controls which sections appear:
+//   "rental" → full rental UI (packages, duration, perks, auction,
+//              rental strip, deposit/tariff info, "Забронировать" CTA)
+//   "order"  → order-only UI (no rental options, simple "Выбрать" CTA,
+//              no rental strip, no deposit info)
+//
+// Default is "rental" for backward compatibility with vip-bike.
+// ─────────────────────────────────────────────────────
+
+export type FlowType = "rental" | "order";
+
 interface ItemModalProps {
   item: CatalogItemVM | null;
   items: CatalogItemVM[];
@@ -26,6 +40,8 @@ interface ItemModalProps {
   theme: FranchizeTheme;
   pickupAddress?: string;
   workingHours?: string;
+  /** Crew business flow type — "rental" shows rental options, "order" hides them */
+  flowType?: FlowType;
   options: {
     package: string;
     duration: string;
@@ -109,12 +125,14 @@ export function ItemModal({
   theme,
   pickupAddress = "",
   workingHours = "",
+  flowType = "rental",
   options,
   auctionOptions,
   onChangeOption,
   onClose,
   onAddToCart,
 }: ItemModalProps) {
+  const isRental = flowType === "rental";
   const modalRef = useRef<HTMLDivElement>(null);
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [activeMediaIndex, setActiveMediaIndex] = useState(0);
@@ -132,11 +150,12 @@ export function ItemModal({
   }, [item]);
 
   const descriptionText = useMemo(() => {
-    return (
-      item?.description ||
-      "Этот байк уже подготовлен к аренде: технический чек выполнен, документы готовы, выдача без очереди."
-    );
-  }, [item?.description]);
+    if (item?.description) return item.description;
+    // Generalized fallback — no bike-specific language
+    return isRental
+      ? "Позиция готова к аренде: технический чек выполнен, документы готовы, выдача без очереди."
+      : "Позиция доступна для заказа. Оставьте заявку, и менеджер свяжется с вами для уточнения деталей.";
+  }, [item?.description, isRental]);
 
   const surface = useMemo(() => crewPaletteForSurface(theme), [theme]);
   const themeVars = useMemo(() => getModalThemeVars(theme), [theme]);
@@ -234,12 +253,12 @@ export function ItemModal({
   const propulsionLabel = getCatalogPropulsionLabel(propulsionSegment);
 
   const rentalStrip = useMemo(() => {
-    if (!item) return null;
+    if (!item || !isRental) return null;
     return buildCatalogRentalStrip(item, {
       hqLocation: pickupAddress,
       contacts: { address: pickupAddress, workingHours },
     });
-  }, [item, pickupAddress, workingHours]);
+  }, [item, isRental, pickupAddress, workingHours]);
 
   const comparableBikes = useMemo(() => {
     if (!item) return [];
@@ -255,21 +274,44 @@ export function ItemModal({
 
   if (!item) return null;
 
-  const fallbackSpecs = [
-    { label: "Категория", value: item.category },
-    { label: "Тариф аренды", value: item.rentPriceLabel },
-    ...(item.saleAvailable && item.salePrice
-      ? [
-          {
-            label: "Цена покупки",
-            value: `${item.salePrice.toLocaleString("ru-RU")} ₽`,
-          },
-        ]
-      : []),
-    { label: "Статус", value: "Готов к выдаче" },
-  ];
+  // Generalized fallback specs — rental vs order
+  const fallbackSpecs = isRental
+    ? [
+        { label: "Категория", value: item.category },
+        { label: "Тариф аренды", value: item.rentPriceLabel },
+        ...(item.saleAvailable && item.salePrice
+          ? [
+              {
+                label: "Цена покупки",
+                value: `${item.salePrice.toLocaleString("ru-RU")} ₽`,
+              },
+            ]
+          : []),
+        { label: "Статус", value: "Готов к выдаче" },
+      ]
+    : [
+        { label: "Категория", value: item.category },
+        ...(item.salePrice
+          ? [
+              {
+                label: "Цена",
+                value: `${item.salePrice.toLocaleString("ru-RU")} ₽`,
+              },
+            ]
+          : []),
+        { label: "Статус", value: "Доступно для заказа" },
+      ];
 
   const normalizedSpecs = item.specs.length > 0 ? item.specs : fallbackSpecs;
+
+  // Generalized CTA label
+  const ctaLabel = isAdding
+    ? "Добавляем..."
+    : item.saleAvailable
+      ? "Купить"
+      : isRental
+        ? "Забронировать"
+        : "Выбрать";
 
   return (
     <div
@@ -325,22 +367,28 @@ export function ItemModal({
                 {item.subtitle}
               </p>
               <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                {/* Availability badge — generalized */}
                 <span
                   className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${
-                    rentalStrip?.isAvailable
+                    rentalStrip?.isAvailable ?? item.availabilityStatus === "available"
                       ? "border-emerald-300/50 bg-emerald-400/15 text-emerald-100"
                       : "border-amber-300/50 bg-amber-400/15 text-amber-100"
                   }`}
                 >
-                  Сегодня: {rentalStrip?.todayLabel ?? "Уточним в Telegram"}
+                  {isRental
+                    ? `Сегодня: ${rentalStrip?.todayLabel ?? "Уточним в Telegram"}`
+                    : item.availabilityStatus === "available"
+                      ? "Доступно для заказа"
+                      : "Уточните наличие"}
                 </span>
                 {item.saleAvailable && (
                   <span className="inline-flex rounded-full border border-amber-300/60 bg-amber-400/20 px-2.5 py-1 font-semibold text-amber-100">
-                    Аренда + покупка
+                    {isRental ? "Аренда + покупка" : "Доступно к покупке"}
                   </span>
                 )}
               </div>
-              {rentalStrip ? (
+              {/* Rental strip — only for rental flow */}
+              {isRental && rentalStrip ? (
                 <div
                   className="mt-3 grid gap-2 rounded-2xl border border-white/10 bg-black/15 p-3 text-xs sm:grid-cols-3"
                   aria-label={`Быстрая аренда ${item.title}`}
@@ -384,7 +432,7 @@ export function ItemModal({
               style={surface.subtleCard}
             >
               <p className="inline-flex items-center gap-1 font-medium text-[var(--item-accent)]">
-                <Info className="h-3.5 w-3.5" /> Характеристики и условия
+                <Info className="h-3.5 w-3.5" /> Характеристики{isRental ? " и условия" : ""}
               </p>
               <div
                 className="mt-2 grid grid-cols-1 gap-2 text-[11px] sm:grid-cols-2"
@@ -410,10 +458,10 @@ export function ItemModal({
               <section
                 className="rounded-2xl border p-3"
                 style={surface.subtleCard}
-                aria-label="Отзывы арендаторов"
+                aria-label={isRental ? "Отзывы арендаторов" : "Отзывы"}
               >
                 <div className="flex items-center justify-between gap-3">
-                  <p className="text-sm font-semibold text-[var(--item-text)]">Отзывы друзей</p>
+                  <p className="text-sm font-semibold text-[var(--item-text)]">Отзывы</p>
                   <span className="rounded-full bg-[var(--item-accent)] px-2.5 py-1 text-xs font-bold text-[var(--item-accent-contrast)]">
                     ★ {item.reviewSummary.average.toFixed(1)} · {item.reviewSummary.count}
                   </span>
@@ -440,30 +488,35 @@ export function ItemModal({
               </Link>
             )}
 
-            <OptionChips
-              title="Пакет"
-              options={packageOptions}
-              selected={options.package}
-              onSelect={(v) => onChangeOption("package", v)}
-            />
-            <OptionChips
-              title="Срок"
-              options={durationOptions}
-              selected={options.duration}
-              onSelect={(v) => onChangeOption("duration", v)}
-            />
-            <OptionChips
-              title="Комплект"
-              options={perkOptions}
-              selected={options.perk}
-              onSelect={(v) => onChangeOption("perk", v)}
-            />
-            <OptionChips
-              title="Аукцион / тик"
-              options={auctionOptions}
-              selected={options.auction}
-              onSelect={(v) => onChangeOption("auction", v)}
-            />
+            {/* ── Rental-only options (hidden for order flow) ── */}
+            {isRental && (
+              <>
+                <OptionChips
+                  title="Пакет"
+                  options={packageOptions}
+                  selected={options.package}
+                  onSelect={(v) => onChangeOption("package", v)}
+                />
+                <OptionChips
+                  title="Срок"
+                  options={durationOptions}
+                  selected={options.duration}
+                  onSelect={(v) => onChangeOption("duration", v)}
+                />
+                <OptionChips
+                  title="Комплект"
+                  options={perkOptions}
+                  selected={options.perk}
+                  onSelect={(v) => onChangeOption("perk", v)}
+                />
+                <OptionChips
+                  title="Аукцион / тик"
+                  options={auctionOptions}
+                  selected={options.auction}
+                  onSelect={(v) => onChangeOption("auction", v)}
+                />
+              </>
+            )}
 
             {comparableBikes.length ? (
               <details
@@ -553,11 +606,7 @@ export function ItemModal({
               aria-busy={isAdding}
               className="rounded-xl bg-[var(--item-accent)] px-3 py-2 text-sm font-semibold text-[var(--item-accent-contrast)] transition hover:brightness-105 active:scale-[0.99] disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--item-accent)]"
             >
-              {isAdding
-                ? "Добавляем..."
-                : item.saleAvailable
-                  ? `Hold this bike • Забронировать байк`
-                  : `Забронировать байк • Hold this bike`}
+              {ctaLabel}
             </button>
           </div>
         </div>

--- a/docs/sql/svarprofi-seed-examples.sql
+++ b/docs/sql/svarprofi-seed-examples.sql
@@ -48,7 +48,7 @@ insert into public.cars (
   '/franchize/svarprofi?vehicle=karkas-prom',
   false,
   jsonb_build_object(
-    'sale', false,
+    'sale', 1,
     'type', 'Каркас',
     'subtype', 'Промышленный',
     'year', NULL,
@@ -134,7 +134,7 @@ insert into public.cars (
   '/franchize/svarprofi?vehicle=karkas-kran',
   false,
   jsonb_build_object(
-    'sale', false,
+    'sale', 1,
     'type', 'Каркас',
     'subtype', 'С подкрановыми путями',
     'year', NULL,


### PR DESCRIPTION
(fix): Catalog design alignment + generalize rental UI for non-rental crews

Fixes 6 design differences from reference + generalizes catalog for non-rental crews (svarprofi).

## Design fixes
- Card corners: added overflow-hidden to article element (both carousel & grid) so rounded-2xl is visible on the whole card
- Border clipping: added pt-1 to carousel container so box-shadow highlight isn't clipped from top
- Grid card specs: changed from flex-wrap (one row) to space-y (3 rows) matching reference design

## Generalization (no more drilled mode prop for CTA/modal)
- Added getItemFlowType(): derives rental vs order from pricePerDay (>0 = rental, else order)
- Added getItemCtaLabel(): derives CTA from saleAvailable+pricePerDay (no mode prop needed)
  - saleAvailable + pricePerDay>0 → 'Купить'
  - pricePerDay>0 only → 'Забронировать'
  - pricePerDay=0 → 'Выбрать' (svarprofi, custom orders)
- Pass flowType to ItemModal based on selectedItem → rental UI (1/3/7 days, packages, auction) hidden for order flow
- mode prop kept for page-level concerns only (promo banner visibility, category naming)

## SQL seed update
- svarprofi items: sale:false → sale:1 (matching bikes SQL pattern)
  This sets saleAvailable=true during hydration, making CTA show 'Выбрать' instead of 'Забронировать'

**Файлы (2):**
- `app/franchize/components/CatalogClient.tsx`
- `docs/sql/svarprofi-seed-examples.sql`