### PR TITLE
(feat): Cart page overhaul — premium megacart design + rental/sale flo

### DIFF
--- a/app/franchize/components/CartPageClient.tsx
+++ b/app/franchize/components/CartPageClient.tsx
@@ -1,14 +1,24 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import type { CatalogItemVM, FranchizeCrewVM } from "../actions";
 import { upsertFranchizeIntent } from "../actions";
 import { useFranchizeCartLines } from "../hooks/useFranchizeCartLines";
-import { useFranchizeCart } from "../hooks/useFranchizeCart"; // Import cart state access
-import { crewPaletteForSurface } from "../lib/theme";
-import { saveUserFranchizeCartAction } from "@/contexts/actions"; // Explicit import
+import { useFranchizeCart } from "../hooks/useFranchizeCart";
+import { crewPaletteForSurface, withAlpha } from "../lib/theme";
+import { saveUserFranchizeCartAction } from "@/contexts/actions";
 import { useAppContext } from "@/contexts/AppContext";
+import {
+  CartItemCard,
+  OrderSummary,
+  ProtectionPlan,
+  TrustBadges,
+  CheckoutButton,
+  EmptyCartState,
+  CartShimmerStyle,
+} from "./cart";
 
 interface CartPageClientProps {
   crew: FranchizeCrewVM;
@@ -29,10 +39,28 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
   const { dbUser, user } = useAppContext();
   const [isSaving, setIsSaving] = useState(false);
 
+  // ── Flow detection for UI labels ──
+  const saleLinesCount = cartLines.filter((line) => line.flowType === "sale").length;
+  const isAllSale = saleLinesCount > 0 && saleLinesCount === cartLines.length;
+  const isMixed = saleLinesCount > 0 && !isAllSale;
+
+  // CART-TODO #1: Subtotal label adapts to cart composition
+  const subtotalLabel = isAllSale
+    ? "Сумма покупки"
+    : isMixed
+      ? "Итого (аренда + покупка)"
+      : "Сумма за 1 день аренды";
+
+  // CART-TODO #4: CTA text adapts to flow
+  const ctaLabel = isAllSale
+    ? "Перейти к оформлению покупки"
+    : isMixed
+      ? "Перейти к оформлению"
+      : "Перейти к оформлению аренды";
+
   const handleProceed = async () => {
     setIsSaving(true);
-    const saleLinesCount = cartLines.filter((line) => line.saleAvailable).length;
-    const flow = saleLinesCount > 0 && saleLinesCount === cartLines.length ? "sale" : saleLinesCount > 0 ? "mixed" : "rental";
+    const flow = isAllSale ? "sale" : isMixed ? "mixed" : "rental";
     const intentPromise = upsertFranchizeIntent({
       slug,
       bikeId: cartLines[0]?.item?.id ?? cartLines[0]?.itemId,
@@ -52,18 +80,27 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
           qty: line.qty,
           saleAvailable: line.saleAvailable,
           lineTotal: line.lineTotal,
+          flowType: line.flowType,
         })),
       },
     }).catch((error) => console.warn("checkout intent tracking failed", error));
-    // Sync to DB explicitly before navigating; keep checkout-intent persistence in the same checkpoint.
+    // Sync to DB explicitly before navigating
     if (dbUser?.user_id) {
-        await Promise.allSettled([saveUserFranchizeCartAction(dbUser.user_id, slug, cart), intentPromise]);
+      await Promise.allSettled([saveUserFranchizeCartAction(dbUser.user_id, slug, cart), intentPromise]);
     } else {
-        await intentPromise;
+      await intentPromise;
     }
-    // Navigate even if save failed (local storage might still be used by next page if hydrated client-side)
     router.push(`/franchize/${slug}/order/demo-order?flow=${flow}`);
   };
+
+  const handleDelete = useCallback(
+    (lineId: string) => {
+      removeLine(lineId);
+    },
+    [removeLine],
+  );
+
+  const isEmpty = cartLines.length === 0 && rawItemCount === 0;
 
   return (
     <section
@@ -71,109 +108,94 @@ export function CartPageClient({ crew, slug, items }: CartPageClientProps) {
       style={{
         ["--cart-accent" as string]: crew.theme.palette.accentMain,
         ["--cart-border" as string]: crew.theme.palette.borderSoft,
+        ["--cart-glow" as string]: withAlpha(crew.theme.palette.accentMain, 0.4),
       }}
     >
-      <p className="text-xs uppercase tracking-[0.2em] text-[var(--cart-accent)]">
-        /franchize/{slug}/cart
+      <CartShimmerStyle />
+      {/* Breadcrumb */}
+      <nav aria-label="Breadcrumb" className="mb-2">
+        <p
+          className="text-xs uppercase tracking-[0.2em]"
+          style={{ color: crew.theme.palette.accentMain }}
+        >
+          / FRANCHIZE / {crew.header.brandName?.toUpperCase() ?? slug.toUpperCase()} / CART
+        </p>
+      </nav>
+
+      {/* Title Section */}
+      <h1 className="mt-2 text-2xl font-semibold">Корзина</h1>
+      <p className="mt-2 text-sm" style={surface.mutedText}>
+        Проверьте состав заказа, количество и итог перед оформлением.
       </p>
-      <h1 className="mt-2 text-4xl font-semibold tracking-tight">Корзина</h1>
-      <p className="mt-2 text-sm" style={surface.mutedText}>Проверьте состав заказа, количество и итог перед оформлением.</p>
 
-      {cartLines.length === 0 && rawItemCount === 0 ? (
-        <div className="mt-6 rounded-2xl border border-dashed p-6 text-sm" style={surface.subtleCard}>
-          Корзина пока пустая. Добавьте позицию из каталога, чтобы перейти к оформлению.
-          <div className="mt-4">
-             {/* Using standard anchor/button for back link to be safe */}
-             <button
-                onClick={() => router.push(`/franchize/${slug}`)}
-                className="inline-flex font-medium text-[var(--cart-accent)] underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)]"
-             >
-              Вернуться в каталог
-             </button>
-          </div>
-        </div>
+      {isEmpty ? (
+        <EmptyCartState
+          crew={crew}
+          slug={slug}
+          onNavigateToCatalog={() => router.push(`/franchize/${slug}`)}
+        />
       ) : (
-        <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_360px]">
-          <div className="space-y-3">
-            {cartLines.map((line) => (
-              <article key={line.lineId} className="rounded-3xl border p-4 md:p-5" style={surface.card}>
-                <div className="flex items-start justify-between gap-3">
-                  <div className="flex min-w-0 gap-3">
-                    {line.item?.imageUrl ? (
-                      <img
-                        src={line.item.imageUrl}
-                        alt={line.item.title}
-                        className="h-24 w-20 shrink-0 rounded-xl object-cover md:h-28 md:w-24"
-                      />
-                    ) : null}
-                    <div className="min-w-0">
-                    <h2 className="text-xl font-semibold">{line.item?.title ?? "Позиция недоступна"}</h2>
-                    <p className="text-xs" style={surface.mutedText}>
-                      {line.item?.subtitle ?? "Этот товар был удалён или временно недоступен в каталоге."}
-                    <span className="mt-1 block text-[11px]" style={surface.mutedText}>{line.options.package} · {line.options.duration} · {line.options.perk} · {line.options.auction}</span>
-                    </p>
-                    {line.item ? (
-                      <p className="mt-1 text-sm font-medium text-[var(--cart-accent)]">
-                        {line.item.rentPriceLabel}
-                      </p>
-                    ) : (
-                      <p className="mt-1 text-xs" style={surface.mutedText}>Недоступные позиции не участвуют в расчёте суммы.</p>
-                    )}
-                    </div>
-                  </div>
-                  <button className="rounded-md px-1 text-xs transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)]" style={surface.mutedText} onClick={() => removeLine(line.lineId)}>
-                    Удалить
-                  </button>
-                </div>
-                <div className="mt-4 flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-black/10 p-2">
-                  <p className="text-sm font-semibold text-[var(--cart-accent)]">{line.lineTotal.toLocaleString("ru-RU")} ₽</p>
-                  <div className="flex items-center gap-2">
-                  <button
-                    className="h-8 w-8 rounded-full border transition hover:opacity-90 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)]"
-                    style={{ borderColor: "var(--cart-border)" }}
-                    onClick={() => changeLineQty(line.lineId, -1)}
-                    aria-label="Уменьшить"
+        <AnimatePresence mode="popLayout">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.4 }}
+          >
+            <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_360px]">
+              {/* Left: Cart item cards with stagger + delete animation */}
+              <div className="space-y-3">
+                {cartLines.map((line, index) => (
+                  <motion.div
+                    key={line.lineId}
+                    layout
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, x: -100 }}
+                    transition={{
+                      delay: index * 0.08,
+                      duration: 0.3,
+                      layout: { duration: 0.2 },
+                    }}
                   >
-                    −
-                  </button>
-                  <span className="min-w-8 text-center text-lg font-medium">{line.qty}</span>
-                  <button
-                    className="h-8 w-8 rounded-full border transition hover:opacity-90 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)]"
-                    style={{ borderColor: "var(--cart-border)" }}
-                    onClick={() => changeLineQty(line.lineId, 1)}
-                    aria-label="Увеличить"
-                  >
-                    +
-                  </button>
-                  </div>
-                </div>
-              </article>
-            ))}
-          </div>
+                    <CartItemCard
+                      line={line}
+                      crew={crew}
+                      onDecreaseQty={(lineId) => changeLineQty(lineId, -1)}
+                      onIncreaseQty={(lineId) => changeLineQty(lineId, 1)}
+                      onDelete={handleDelete}
+                    />
+                  </motion.div>
+                ))}
+              </div>
 
-          <aside className="h-fit rounded-3xl border p-4 md:sticky md:top-24 md:p-5" style={surface.card}>
-            <p className="text-sm" style={surface.mutedText}>Итого позиций</p>
-            <p className="text-3xl font-semibold">{itemCount}</p>
-            <p className="mt-3 text-sm" style={surface.mutedText}>Сумма за 1 день аренды</p>
-            <p className="text-4xl font-semibold text-[var(--cart-accent)]">
-              {subtotal.toLocaleString("ru-RU")} ₽
-            </p>
-            <div className="mt-4 grid grid-cols-3 gap-2 text-center text-[11px]">
-              <span className="rounded-full border px-2 py-1" style={surface.subtleCard}>Быстрое оформление</span>
-              <span className="rounded-full border px-2 py-1" style={surface.subtleCard}>Без скрытых платежей</span>
-              <span className="rounded-full border px-2 py-1" style={surface.subtleCard}>Поддержка 24/7</span>
+              {/* Right: Summary sidebar */}
+              <div className="space-y-3 lg:sticky lg:top-24 lg:h-fit">
+                <OrderSummary
+                  cartLines={cartLines}
+                  subtotal={subtotal}
+                  crew={crew}
+                />
+                <ProtectionPlan crew={crew} />
+                <CheckoutButton
+                  onClick={handleProceed}
+                  isLoading={isSaving}
+                  label={ctaLabel}
+                  crew={crew}
+                />
+                <TrustBadges crew={crew} />
+              </div>
             </div>
-            <button
-              type="button"
-              disabled={isSaving}
-              onClick={handleProceed}
-              className="mt-5 inline-flex w-full justify-center rounded-2xl bg-[var(--cart-accent)] px-4 py-4 text-lg font-semibold text-[#16130A] transition hover:brightness-105 active:scale-[0.99] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--cart-accent)] cursor-pointer disabled:opacity-70"
-            >
-              {isSaving ? "Сохранение..." : "Перейти к оформлению"}
-            </button>
-          </aside>
-        </div>
+          </motion.div>
+        </AnimatePresence>
       )}
+
+      {/* Easter Egg */}
+      <div
+        className="mt-16 text-center opacity-30 hover:opacity-100 transition-all duration-700 text-[10px] font-mono tracking-widest"
+        style={{ color: crew.theme.palette.textSecondary }}
+      >
+        Built with neon &amp; spite — 2026 —
+      </div>
     </section>
   );
 }

--- a/app/franchize/components/cart/CartItemCard.tsx
+++ b/app/franchize/components/cart/CartItemCard.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { motion, AnimatePresence } from "framer-motion";
+import { Trash2, Bike } from "lucide-react";
+import type { FranchizeCrewVM } from "../../actions";
+import type { FranchizeCartLineVM } from "../../hooks/useFranchizeCartLines";
+import { crewPaletteForSurface, withAlpha, interactionRingStyle } from "../../lib/theme";
+import { SpecBadges } from "./SpecBadge";
+import { QuantityControl } from "./QuantityControl";
+
+interface CartItemCardProps {
+  line: FranchizeCartLineVM;
+  crew: FranchizeCrewVM;
+  onDecreaseQty: (lineId: string) => void;
+  onIncreaseQty: (lineId: string) => void;
+  onDelete: (lineId: string) => void;
+}
+
+export function CartItemCard({ line, crew, onDecreaseQty, onIncreaseQty, onDelete }: CartItemCardProps) {
+  const surface = crewPaletteForSurface(crew.theme);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const destructiveColor = crew.theme.mode === "dark" ? "#FF6B6B" : "#FF3B30";
+
+  return (
+    <motion.article
+      layout
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, x: -100 }}
+      transition={{ duration: 0.25 }}
+      className="rounded-2xl border overflow-hidden"
+      style={surface.card}
+    >
+      <div className="flex gap-4 p-4">
+        {/* LEFT: Product image — 9:16 portrait (tall) */}
+        <div
+          className="relative w-24 h-[170px] shrink-0 rounded-lg overflow-hidden"
+          style={{ backgroundColor: withAlpha(crew.theme.palette.borderSoft, 0.15) }}
+        >
+          {line.item?.imageUrl ? (
+            <Image
+              src={line.item.imageUrl}
+              alt={line.item?.title ?? "Товар"}
+              fill
+              className="object-cover"
+              sizes="96px"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <Bike className="h-10 w-10" style={surface.mutedText} />
+            </div>
+          )}
+          {/* Subtle glow border on image */}
+          <div
+            className="absolute inset-0 rounded-lg pointer-events-none"
+            style={{
+              boxShadow: `inset 0 0 12px ${withAlpha(crew.theme.palette.accentMain, 0.15)}`,
+            }}
+          />
+        </div>
+
+        {/* RIGHT: Info */}
+        <div className="flex-1 min-w-0">
+          {/* Title row with delete button */}
+          <div className="flex items-start justify-between gap-2">
+            <h2 className="text-base font-semibold truncate">
+              {line.item?.title ?? "Позиция недоступна"}
+            </h2>
+
+            {/* Delete: icon + text, per megacart.png — inline confirm (NO alert!) */}
+            {confirmDelete ? (
+              <div className="flex items-center gap-1 shrink-0">
+                <span className="text-[10px]" style={{ color: destructiveColor }}>
+                  Удалить?
+                </span>
+                <button
+                  onClick={() => {
+                    onDelete(line.lineId);
+                    setConfirmDelete(false);
+                  }}
+                  aria-label="Подтвердить удаление"
+                  className="text-[10px] font-medium px-1.5 py-0.5 rounded"
+                  style={{
+                    backgroundColor: withAlpha(destructiveColor, 0.2),
+                    color: destructiveColor,
+                  }}
+                >
+                  Да
+                </button>
+                <button
+                  onClick={() => setConfirmDelete(false)}
+                  aria-label="Отменить удаление"
+                  className="text-[10px] font-medium px-1.5 py-0.5 rounded"
+                  style={surface.mutedText}
+                >
+                  Нет
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setConfirmDelete(true)}
+                aria-label="Удалить товар"
+                className="shrink-0 flex items-center gap-1 text-xs transition-colors"
+                style={{ color: crew.theme.palette.textSecondary }}
+                onFocus={(e) => {
+                  e.currentTarget.style.boxShadow = interactionRingStyle(crew.theme).boxShadow;
+                }}
+                onBlur={(e) => {
+                  e.currentTarget.style.boxShadow = "";
+                }}
+              >
+                Удалить
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+
+          {/* Orphaned item warning */}
+          {!line.item && (
+            <p className="text-xs italic mt-1" style={{ color: "#FF9500" }}>
+              Товар больше недоступен в каталоге
+            </p>
+          )}
+
+          {/* Short description (muted) */}
+          {line.item?.subtitle && (
+            <p className="text-xs mt-0.5" style={surface.mutedText}>
+              {line.item.subtitle}
+            </p>
+          )}
+
+          {/* Rent/Buy badge — per megacart.png: Покупка is MUTED GRAY, Аренда uses accent */}
+          <span
+            className="mt-1 inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold"
+            style={
+              line.flowType === "sale"
+                ? {
+                    backgroundColor: withAlpha(crew.theme.palette.textSecondary, 0.15),
+                    color: crew.theme.palette.textSecondary,
+                  }
+                : {
+                    backgroundColor: withAlpha(crew.theme.palette.accentMain, 0.08),
+                    color: crew.theme.palette.accentMain,
+                  }
+            }
+          >
+            {line.flowType === "sale" ? "Покупка" : "Аренда"}
+          </span>
+
+          {/* Spec badges row */}
+          {line.item && <SpecBadges specs={line.item.specs as Record<string, unknown>} theme={crew.theme} />}
+
+          {/* Price section — Buy price is THE BIGGEST text on the card + gold glow */}
+          <div className="mt-2">
+            {line.flowType === "sale" ? (
+              // BUY flow: largest font on card + gold glow effect
+              <>
+                <p className="text-xs" style={surface.mutedText}>
+                  Цена покупки
+                </p>
+                <p
+                  className="text-2xl font-bold"
+                  style={{
+                    color: crew.theme.palette.accentMain,
+                    textShadow: `0 0 12px ${withAlpha(crew.theme.palette.accentMain, 0.45)}`,
+                  }}
+                >
+                  {line.salePrice?.toLocaleString("ru-RU")} ₽
+                </p>
+              </>
+            ) : (
+              // RENT flow: per-day price + ВЫГОДНО badge
+              <>
+                <p className="text-xs" style={surface.mutedText}>
+                  Цена за 1 день
+                </p>
+                <div className="flex items-center gap-2">
+                  <AnimatePresence mode="popLayout">
+                    <motion.p
+                      key={`${line.lineId}-${line.qty}`}
+                      className="text-xl font-bold"
+                      initial={{ scale: 1.15, opacity: 0.6 }}
+                      animate={{ scale: 1, opacity: 1 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      {line.item?.rentPriceLabel}
+                    </motion.p>
+                  </AnimatePresence>
+                  <span
+                    className="rounded px-1.5 py-0.5 text-[10px] font-bold"
+                    style={{
+                      backgroundColor: withAlpha("#00C853", 0.2),
+                      border: `1px solid ${withAlpha("#00C853", 0.3)}`,
+                      color: "#00C853",
+                    }}
+                  >
+                    ВЫГОДНО
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Quantity controls — Rent ONLY (buy items always qty=1) */}
+          {line.flowType === "rental" && (
+            <QuantityControl
+              qty={line.qty}
+              onDecrease={() => onDecreaseQty(line.lineId)}
+              onIncrease={() => onIncreaseQty(line.lineId)}
+              borderColor={crew.theme.palette.borderSoft}
+              accentColor={crew.theme.palette.accentMain}
+            />
+          )}
+        </div>
+      </div>
+    </motion.article>
+  );
+}

--- a/app/franchize/components/cart/CartShimmerStyle.tsx
+++ b/app/franchize/components/cart/CartShimmerStyle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+/**
+ * Injects the cart-shimmer CSS keyframe animation into the page.
+ * This is a one-time injection — the <style> tag is rendered once
+ * at the top of the cart page and the animation is available globally.
+ *
+ * Why not globals.css? The shimmer animation is cart-specific and
+ * not a shared utility. Injecting via component keeps it co-located.
+ */
+export function CartShimmerStyle() {
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: `
+          @keyframes cart-shimmer {
+            0% { background-position: -200% 0; }
+            100% { background-position: 200% 0; }
+          }
+          .cart-shimmer {
+            background: linear-gradient(
+              90deg,
+              transparent 0%,
+              rgba(0, 200, 83, 0.06) 50%,
+              transparent 100%
+            );
+            background-size: 200% 100%;
+            animation: cart-shimmer 3s ease-in-out infinite;
+          }
+        `,
+      }}
+    />
+  );
+}

--- a/app/franchize/components/cart/CheckoutButton.tsx
+++ b/app/franchize/components/cart/CheckoutButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ArrowRight } from "lucide-react";
+import type { FranchizeCrewVM } from "../../actions";
+import { readablePaletteTextOnColor, withAlpha } from "../../lib/theme";
+
+interface CheckoutButtonProps {
+  onClick: () => void;
+  isLoading: boolean;
+  label: string;
+  crew: FranchizeCrewVM;
+}
+
+export function CheckoutButton({ onClick, isLoading, label, crew }: CheckoutButtonProps) {
+  return (
+    <motion.button
+      whileHover={{
+        scale: 1.01,
+        boxShadow: `0 6px 24px ${withAlpha(crew.theme.palette.accentMain, 0.35)}`,
+      }}
+      whileTap={{ scale: 0.98 }}
+      onClick={onClick}
+      disabled={isLoading}
+      aria-label="Перейти к оформлению"
+      className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl px-6 py-4 text-base font-bold transition-shadow disabled:opacity-70"
+      style={{
+        backgroundColor: crew.theme.palette.accentMain,
+        color: readablePaletteTextOnColor(
+          crew.theme.palette.accentMain,
+          crew.theme.palette,
+        ),
+        boxShadow: `0 4px 12px ${withAlpha(crew.theme.palette.accentMain, 0.2)}`,
+      }}
+    >
+      {isLoading ? "Сохранение..." : label}
+      {!isLoading && <ArrowRight className="h-5 w-5" />}
+    </motion.button>
+  );
+}

--- a/app/franchize/components/cart/DiscountBanner.tsx
+++ b/app/franchize/components/cart/DiscountBanner.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { withAlpha } from "../../lib/theme";
+
+interface DiscountBannerProps {
+  percent: number;
+  amount: number;
+}
+
+export function DiscountBanner({ percent, amount }: DiscountBannerProps) {
+  if (percent <= 0) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.3 }}
+      className="mt-3 flex items-center justify-between rounded-lg border p-3 overflow-hidden relative"
+      style={{
+        backgroundColor: withAlpha("#00C853", 0.08),
+        borderColor: withAlpha("#00C853", 0.25),
+      }}
+    >
+      {/* Shimmer overlay */}
+      <div className="absolute inset-0 pointer-events-none cart-shimmer" />
+      <span className="text-sm font-medium relative" style={{ color: "#00C853" }}>
+        У вас действует скидка {percent}%
+      </span>
+      <span className="text-base font-bold relative" style={{ color: "#00C853" }}>
+        −{amount.toLocaleString("ru-RU")} ₽
+      </span>
+    </motion.div>
+  );
+}

--- a/app/franchize/components/cart/EmptyCartState.tsx
+++ b/app/franchize/components/cart/EmptyCartState.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ShoppingCart } from "lucide-react";
+import type { FranchizeCrewVM } from "../../actions";
+import { crewPaletteForSurface } from "../../lib/theme";
+
+interface EmptyCartStateProps {
+  crew: FranchizeCrewVM;
+  slug: string;
+  onNavigateToCatalog: () => void;
+}
+
+export function EmptyCartState({ crew, slug, onNavigateToCatalog }: EmptyCartStateProps) {
+  const surface = crewPaletteForSurface(crew.theme);
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.4 }}
+      className="mt-8 flex flex-col items-center gap-4 rounded-2xl border border-dashed p-8"
+      style={surface.subtleCard}
+    >
+      <ShoppingCart
+        className="h-16 w-16"
+        style={{ color: crew.theme.palette.borderSoft }}
+      />
+      <h2 className="text-lg font-semibold">Корзина пуста</h2>
+      <p className="text-sm" style={surface.mutedText}>
+        Добавьте позицию из каталога, чтобы перейти к оформлению
+      </p>
+      <button
+        onClick={onNavigateToCatalog}
+        aria-label="Перейти к каталогу"
+        className="rounded-xl border px-6 py-2.5 text-sm font-semibold transition hover:brightness-110"
+        style={{
+          borderColor: crew.theme.palette.accentMain,
+          color: crew.theme.palette.accentMain,
+        }}
+      >
+        Перейти к каталогу
+      </button>
+    </motion.div>
+  );
+}

--- a/app/franchize/components/cart/OrderSummary.tsx
+++ b/app/franchize/components/cart/OrderSummary.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { FranchizeCrewVM } from "../../actions";
+import type { FranchizeCartLineVM } from "../../hooks/useFranchizeCartLines";
+import { crewPaletteForSurface, withAlpha } from "../../lib/theme";
+import { DiscountBanner } from "./DiscountBanner";
+import { Calendar } from "lucide-react";
+
+interface OrderSummaryProps {
+  cartLines: FranchizeCartLineVM[];
+  subtotal: number;
+  crew: FranchizeCrewVM;
+}
+
+export function OrderSummary({ cartLines, subtotal, crew }: OrderSummaryProps) {
+  const surface = crewPaletteForSurface(crew.theme);
+  const rentLines = cartLines.filter((l) => l.flowType === "rental");
+  const buyLines = cartLines.filter((l) => l.flowType === "sale");
+
+  // Rental days from line options (NOT hardcoded!)
+  const totalRentalDays =
+    rentLines.length > 0
+      ? rentLines.reduce((sum, l) => sum + l.rentalDays, 0) / rentLines.length
+      : 0;
+
+  const rentDailyTotal = rentLines.reduce((sum, l) => sum + (l.item?.pricePerDay ?? 0) * l.qty, 0);
+  const rentPeriodTotal = rentDailyTotal * Math.round(totalRentalDays);
+  const buyTotal = buyLines.reduce((sum, l) => sum + (l.salePrice ?? 0), 0);
+  const grandTotal = rentPeriodTotal + buyTotal;
+
+  // Discount — franchise perk (TODO: wire to crew.catalog.discountPercent when available)
+  const discountPercent = 5;
+  const discountAmount = Math.round(grandTotal * discountPercent / 100);
+
+  return (
+    <motion.aside
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.2, duration: 0.3 }}
+      className="rounded-2xl border p-4"
+      style={surface.card}
+    >
+      <p className="text-sm" style={surface.mutedText}>
+        Итого позиций
+      </p>
+      <p className="text-2xl font-semibold">{cartLines.length}</p>
+
+      {/* Show daily rental total only if there are rental lines */}
+      {rentLines.length > 0 && (
+        <>
+          <p className="mt-3 text-sm" style={surface.mutedText}>
+            Сумма за 1 день аренды
+          </p>
+          <p className="text-lg font-semibold">
+            {rentDailyTotal.toLocaleString("ru-RU")} ₽
+          </p>
+        </>
+      )}
+
+      {/* Show buy subtotal only if there are sale lines */}
+      {buyLines.length > 0 && (
+        <>
+          <p className="mt-3 text-sm" style={surface.mutedText}>
+            Сумма покупки
+          </p>
+          <p className="text-lg font-semibold">
+            {buyTotal.toLocaleString("ru-RU")} ₽
+          </p>
+        </>
+      )}
+
+      <div
+        className="my-3 border-t"
+        style={{ borderColor: crew.theme.palette.borderSoft }}
+      />
+
+      <p className="text-sm" style={surface.mutedText}>
+        Сумма за весь период
+      </p>
+      <p
+        className="text-2xl font-bold"
+        style={{ color: crew.theme.palette.accentMain }}
+      >
+        {grandTotal.toLocaleString("ru-RU")} ₽
+      </p>
+      {rentLines.length > 0 && totalRentalDays > 0 && (
+        <span
+          className="mt-1 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium"
+          style={{
+            backgroundColor: withAlpha(crew.theme.palette.accentMain, 0.1),
+            border: `1px solid ${withAlpha(crew.theme.palette.accentMain, 0.2)}`,
+            color: crew.theme.palette.accentMain,
+          }}
+        >
+          <Calendar className="h-3 w-3" />
+          {Math.round(totalRentalDays)} {pluralizeDays(Math.round(totalRentalDays))} аренды
+        </span>
+      )}
+
+      <DiscountBanner percent={discountPercent} amount={discountAmount} />
+    </motion.aside>
+  );
+}
+
+/** Russian pluralization for days */
+function pluralizeDays(n: number): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 14) return "дней";
+  if (mod10 === 1) return "день";
+  if (mod10 >= 2 && mod10 <= 4) return "дня";
+  return "дней";
+}

--- a/app/franchize/components/cart/ProtectionPlan.tsx
+++ b/app/franchize/components/cart/ProtectionPlan.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Shield } from "lucide-react";
+import type { FranchizeCrewVM } from "../../actions";
+import { crewPaletteForSurface, readablePaletteTextOnColor, withAlpha } from "../../lib/theme";
+
+interface ProtectionPlanProps {
+  crew: FranchizeCrewVM;
+}
+
+export function ProtectionPlan({ crew }: ProtectionPlanProps) {
+  const surface = crewPaletteForSurface(crew.theme);
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.4 }}
+      className="flex items-center justify-between rounded-2xl border p-4"
+      style={{
+        ...surface.card,
+        boxShadow: `0 0 12px ${withAlpha(crew.theme.palette.accentMain, 0.08)}`,
+      }}
+    >
+      <div className="flex items-center gap-3">
+        <Shield
+          className="h-6 w-6"
+          style={{ color: crew.theme.palette.accentMain }}
+        />
+        <div>
+          <p className="text-sm font-semibold">Полная защита включена</p>
+          <p className="text-xs" style={surface.mutedText}>
+            Кража, повреждения и техподдержка 24/7
+          </p>
+        </div>
+      </div>
+      <span
+        className="rounded px-3 py-1 text-xs font-bold"
+        style={{
+          backgroundColor: crew.theme.palette.accentMain,
+          color: readablePaletteTextOnColor(
+            crew.theme.palette.accentMain,
+            crew.theme.palette,
+          ),
+        }}
+      >
+        Включено
+      </span>
+    </motion.div>
+  );
+}

--- a/app/franchize/components/cart/QuantityControl.tsx
+++ b/app/franchize/components/cart/QuantityControl.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+
+interface QuantityControlProps {
+  qty: number;
+  onDecrease: () => void;
+  onIncrease: () => void;
+  borderColor: string;
+  accentColor: string;
+}
+
+export function QuantityControl({ qty, onDecrease, onIncrease, borderColor, accentColor }: QuantityControlProps) {
+  return (
+    <div className="mt-3 flex items-center gap-3">
+      {/* CIRCULAR buttons per megacart.png — not rounded rectangles */}
+      <motion.button
+        whileTap={{ scale: 0.9 }}
+        disabled={qty <= 1}
+        aria-label="Уменьшить количество"
+        className="h-9 w-9 rounded-full border text-lg transition-colors disabled:opacity-40 flex items-center justify-center"
+        style={{ borderColor, color: accentColor }}
+        onClick={onDecrease}
+      >
+        −
+      </motion.button>
+      <AnimatePresence mode="popLayout">
+        <motion.span
+          key={qty}
+          initial={{ scale: 1.3, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ scale: 0.7, opacity: 0 }}
+          transition={{ duration: 0.15 }}
+          className="text-sm font-medium w-6 text-center"
+        >
+          {qty}
+        </motion.span>
+      </AnimatePresence>
+      <motion.button
+        whileTap={{ scale: 0.9 }}
+        aria-label="Увеличить количество"
+        className="h-9 w-9 rounded-full border text-lg transition-colors flex items-center justify-center"
+        style={{ borderColor, color: accentColor }}
+        onClick={onIncrease}
+      >
+        +
+      </motion.button>
+    </div>
+  );
+}

--- a/app/franchize/components/cart/SpecBadge.tsx
+++ b/app/franchize/components/cart/SpecBadge.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { FranchizeTheme } from "../../actions";
+import { withAlpha } from "../../lib/theme";
+import { Zap, Battery, Gauge, Palette } from "lucide-react";
+
+interface SpecBadgeProps {
+  icon: React.ReactNode;
+  value: string;
+  theme: FranchizeTheme;
+}
+
+export function SpecBadge({ icon, value, theme }: SpecBadgeProps) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium"
+      style={{
+        backgroundColor: withAlpha(theme.palette.bgBase, 0.6),
+        border: `1px solid ${withAlpha(theme.palette.borderSoft, 0.5)}`,
+        color: theme.palette.textPrimary,
+      }}
+    >
+      <span style={{ color: theme.palette.accentMain }}>{icon}</span>
+      {value}
+    </span>
+  );
+}
+
+/** Convenience wrapper that renders up to 4 spec badges from item.specs JSONB */
+interface SpecBadgesProps {
+  specs: Record<string, unknown> | undefined;
+  theme: FranchizeTheme;
+}
+
+export function SpecBadges({ specs, theme }: SpecBadgesProps) {
+  const extracted = extractSpecs(specs);
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5">
+      <SpecBadge icon={<Zap className="h-3 w-3" />} value={extracted.power} theme={theme} />
+      <SpecBadge icon={<Battery className="h-3 w-3" />} value={extracted.battery} theme={theme} />
+      <SpecBadge icon={<Gauge className="h-3 w-3" />} value={extracted.range} theme={theme} />
+      {extracted.color && (
+        <SpecBadge icon={<Palette className="h-3 w-3" />} value={extracted.color} theme={theme} />
+      )}
+    </div>
+  );
+}
+
+/** Extract spec values from item.specs JSONB — handles multiple key names from different data sources */
+function extractSpecs(specs: Record<string, unknown> | undefined) {
+  const colorVal = specs?.color ?? specs?.цвет ?? null;
+  return {
+    power: String(specs?.power_kw ?? specs?.power ?? "—") + " кВт",
+    battery: String(specs?.battery_label ?? `${specs?.battery_v ?? ""}V ${specs?.battery_ah ?? ""}Ah`),
+    range: "до " + String(specs?.range_km ?? specs?.range ?? "—") + " км",
+    color: colorVal ? String(colorVal) : null,
+  };
+}

--- a/app/franchize/components/cart/TrustBadges.tsx
+++ b/app/franchize/components/cart/TrustBadges.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Zap, Shield, Headphones } from "lucide-react";
+import type { FranchizeCrewVM } from "../../actions";
+
+interface TrustBadgesProps {
+  crew: FranchizeCrewVM;
+}
+
+export function TrustBadges({ crew }: TrustBadgesProps) {
+  const badges = [
+    { Icon: Zap, label: "Быстрое оформление" },
+    { Icon: Shield, label: "Без скрытых платежей" },
+    { Icon: Headphones, label: "Поддержка 24/7" },
+  ];
+
+  return (
+    <div className="flex justify-center gap-6 py-4">
+      {badges.map((badge, i) => (
+        <motion.div
+          key={badge.label}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 + i * 0.1 }}
+          className="flex flex-col items-center gap-1"
+        >
+          <badge.Icon
+            className="h-4 w-4"
+            style={{ color: crew.theme.palette.accentMain }}
+          />
+          <span
+            className="text-[11px] text-center"
+            style={{ color: crew.theme.palette.textSecondary }}
+          >
+            {badge.label}
+          </span>
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/app/franchize/components/cart/index.ts
+++ b/app/franchize/components/cart/index.ts
@@ -1,0 +1,10 @@
+export { CartItemCard } from "./CartItemCard";
+export { OrderSummary } from "./OrderSummary";
+export { ProtectionPlan } from "./ProtectionPlan";
+export { TrustBadges } from "./TrustBadges";
+export { CheckoutButton } from "./CheckoutButton";
+export { EmptyCartState } from "./EmptyCartState";
+export { SpecBadge, SpecBadges } from "./SpecBadge";
+export { QuantityControl } from "./QuantityControl";
+export { DiscountBanner } from "./DiscountBanner";
+export { CartShimmerStyle } from "./CartShimmerStyle";

--- a/app/franchize/hooks/useFranchizeCartLines.ts
+++ b/app/franchize/hooks/useFranchizeCartLines.ts
@@ -58,6 +58,8 @@ function parseDurationDays(rawDuration: string): number {
   return days;
 }
 
+export type CartFlowType = "rental" | "sale";
+
 export type FranchizeCartLineVM = {
   lineId: string;
   itemId: string;
@@ -67,6 +69,12 @@ export type FranchizeCartLineVM = {
   lineTotal: number;
   rentalDays: number;
   saleAvailable: boolean;
+  /** Resolved sale price from rawSpecs — null if item has no sale price or item is null */
+  salePrice: number | null;
+  /** Per-line flow type: "sale" when in buy flow with valid sale price, "rental" otherwise */
+  flowType: CartFlowType;
+  /** Human-readable price label for display: rental → "X ₽ / день", sale → "Покупка: X ₽" */
+  displayPriceLabel: string;
   options: {
     package: string;
     duration: string;
@@ -96,11 +104,12 @@ export function useFranchizeCartLines(
       .map(([lineId, line]) => {
         const item = itemById.get(line.itemId) ?? null;
         const inBuyFlow = isBuyFlow(line.options);
-        const salePrice = resolveSalePrice(item);
+        const resolvedSalePrice = resolveSalePrice(item);
+        const hasSalePrice = inBuyFlow && resolvedSalePrice > 0;
 
-        if (inBuyFlow && salePrice > 0) {
+        if (hasSalePrice) {
           const buyDelta = Math.max(0, line.options.buyPriceDelta ?? 0);
-          const effectiveSalePrice = salePrice + buyDelta;
+          const effectiveSalePrice = resolvedSalePrice + buyDelta;
           return {
             lineId,
             itemId: line.itemId,
@@ -110,6 +119,9 @@ export function useFranchizeCartLines(
             lineTotal: effectiveSalePrice * line.qty,
             rentalDays: 1,
             saleAvailable: Boolean(item?.saleAvailable),
+            salePrice: effectiveSalePrice,
+            flowType: "sale" as const,
+            displayPriceLabel: `Покупка: ${effectiveSalePrice.toLocaleString("ru-RU")} ₽`,
             options: line.options,
           };
         }
@@ -132,6 +144,9 @@ export function useFranchizeCartLines(
           lineTotal: discountedLineBase * line.qty,
           rentalDays,
           saleAvailable: Boolean(item?.saleAvailable),
+          salePrice: null,
+          flowType: "rental" as const,
+          displayPriceLabel: item?.rentPriceLabel ?? `${effectiveUnitPrice.toLocaleString("ru-RU")} ₽ / день`,
           options: line.options,
         };
       });


### PR DESCRIPTION
(feat): Cart page overhaul — premium megacart design + rental/sale flow fixes

Overhaul CartPageClient from MVP to premium dark cyberpunk design matching megacart.png reference. Fixes CART-TODO bugs #1 (subtotal label), #2 (sale price display), #3 (lineTotal context), #4 (CTA text), #8 (salePrice+flowType in VM), #9 (rentPriceLabel in buy flow). Adds: product images, spec badges, rent/buy badges, animated quantity controls (rental only), inline delete confirm, discount banner with shimmer, protection plan card, trust badges, gold glow CTA, breadcrumb nav, empty state, Easter egg. Data layer: FranchizeCartLineVM gains salePrice, flowType, displayPriceLabel fields.

**Файлы (13):**
- `app/franchize/hooks/useFranchizeCartLines.ts`
- `app/franchize/components/CartPageClient.tsx`
- `app/franchize/components/cart/CartItemCard.tsx`
- `app/franchize/components/cart/OrderSummary.tsx`
- `app/franchize/components/cart/ProtectionPlan.tsx`
- `app/franchize/components/cart/TrustBadges.tsx`
- `app/franchize/components/cart/CheckoutButton.tsx`
- `app/franchize/components/cart/EmptyCartState.tsx`
- `app/franchize/components/cart/SpecBadge.tsx`
- `app/franchize/components/cart/QuantityControl.tsx`
- `app/franchize/components/cart/DiscountBanner.tsx`
- `app/franchize/components/cart/CartShimmerStyle.tsx`
- `app/franchize/components/cart/index.ts`