### PR TITLE
Add Telegram /start CTA to VIP Bike hero and remove unused import

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,8 +12,7 @@ import {
   User, 
   Settings,
   Zap,
-  Activity,
-  ChevronRight
+  Activity
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";

--- a/app/vipbikerental/VipBikeRentalClient.tsx
+++ b/app/vipbikerental/VipBikeRentalClient.tsx
@@ -200,6 +200,11 @@ function deriveNote(profile: VipBikeUserProfile, experience: VipBikeExperienceCo
   }
 }
 
+function getStartCommandLink(profile: VipBikeUserProfile): string | undefined {
+  if (!profile.onboardingCompleted) return "https://t.me/oneBikePlsBot?start";
+  return undefined;
+}
+
 // ═══════════════════════════════════════════════════════
 // MAIN COMPONENT — thin orchestration shell
 // ═══════════════════════════════════════════════════════
@@ -262,6 +267,7 @@ export function VipBikeRentalClient({ items, theme }: { items: CatalogItemVM[]; 
     badge: deriveBadge(profile),
     title: deriveTitle(profile),
     note: deriveNote(profile, experience),
+    startCommandHref: getStartCommandLink(profile),
     ctaHref: experience.primaryCTA.href,
     ctaLabel: experience.primaryCTA.label,
     hasSurvey: profile.onboardingCompleted,

--- a/app/vipbikerental/features/HeroSection.tsx
+++ b/app/vipbikerental/features/HeroSection.tsx
@@ -26,6 +26,7 @@ interface HeroVibeProfile {
   badge: string;
   title: string;
   note: string;
+  startCommandHref?: string;
   ctaHref: string;
   ctaLabel: string;
   hasSurvey: boolean;
@@ -66,6 +67,16 @@ export function HeroSection({
           <div className="mb-1 font-medium text-brand-yellow"><VibeContentRenderer content={vibeProfile.badge} /></div>
           <p className="font-orbitron text-lg text-white">{vibeProfile.title}</p>
           <p className="mt-1 text-white/80">{vibeProfile.note}</p>
+          {vibeProfile.startCommandHref ? (
+            <a
+              href={vibeProfile.startCommandHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-flex text-sm font-semibold text-brand-yellow underline underline-offset-4 hover:text-yellow-300"
+            >
+              /start в Telegram
+            </a>
+          ) : null}
         </div>
         <h1 className="font-orbitron text-5xl font-black uppercase leading-[0.9] tracking-tight text-white drop-shadow-[0_8px_22px_rgba(0,0,0,0.75)] sm:text-6xl md:text-7xl lg:text-8xl">
           <span className="block">Скорость. Контроль.</span>


### PR DESCRIPTION
### Motivation
- Surface a clear onboarding action for users who haven't completed onboarding by linking to the Telegram bot `/start` command in the hero area.
- Keep the hero UI modular and testable by extracting and typing the hero props for the CTA link.
- Remove a now-unused icon import to clean up imports.

### Description
- Added a helper `getStartCommandLink(profile)` to `VipBikeRentalClient.tsx` that returns the Telegram `/start` link when `profile.onboardingCompleted` is false and wired it into the `vibeProfile` memo as `startCommandHref`.
- Extended the `HeroVibeProfile` interface in `HeroSection.tsx` with `startCommandHref?: string` and render an external link to `/start в Telegram` when the prop is present.
- Extracted the hero rendering into `HeroSection.tsx` (already present) usage now accepts the new `startCommandHref` prop and conditionally shows the CTA; updated component props and JSX accordingly.
- Removed the unused `ChevronRight` import from `app/page.tsx` and applied minor trailing-newline formatting fixes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a159c5baf80832a9c08575b7bcdbb57)