### PR TITLE
Adjust pointer-events and z-index for franchise map bottom nav and rider drawer

### DIFF
--- a/components/layout/FranchizeMapBottomNav.tsx
+++ b/components/layout/FranchizeMapBottomNav.tsx
@@ -25,13 +25,13 @@ export default function FranchizeMapBottomNav({ pathname }: FranchizeMapBottomNa
 
   return (
     <nav
-      className="fixed inset-x-0 bottom-0 z-30 border-t px-4 pb-[max(env(safe-area-inset-bottom),0.7rem)] pt-2 backdrop-blur-xl md:hidden"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-30 border-t px-4 pb-[max(env(safe-area-inset-bottom),0.7rem)] pt-2 backdrop-blur-xl md:hidden"
       style={{
         borderColor: "color-mix(in srgb, var(--fr-map-nav-accent, #facc15) 28%, transparent)",
         backgroundColor: "color-mix(in srgb, var(--fr-map-nav-bg, #030712) 82%, black)",
       }}
     >
-      <div className="mx-auto grid w-full max-w-3xl grid-cols-4 gap-2">
+      <div className="pointer-events-auto mx-auto grid w-full max-w-3xl grid-cols-4 gap-2">
         {items.map((item) => {
           const Icon = item.icon;
           const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);

--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -449,10 +449,10 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
         modal={false}
       >
         <Drawer.Portal>
-          <Drawer.Content className="fixed inset-x-0 bottom-0 z-40 pointer-events-none">
-            <div className="pointer-events-auto rounded-t-[1.4rem] border border-white/15 bg-[var(--mr-card)]/96 p-3 shadow-[0_-20px_60px_rgba(0,0,0,0.45)] backdrop-blur-2xl"><Drawer.Handle className="mx-auto mb-2 h-1.5 w-14 rounded-full bg-white/35" />
+          <Drawer.Content className="fixed inset-x-0 bottom-0 z-20 pointer-events-none">
+            <div className={`rounded-t-[1.4rem] border border-white/15 bg-[var(--mr-card)]/96 p-3 shadow-[0_-20px_60px_rgba(0,0,0,0.45)] backdrop-blur-2xl ${activeSnap <= 0.2 ? "pointer-events-none" : "pointer-events-auto"}`}><Drawer.Handle className="pointer-events-auto mx-auto mb-2 h-1.5 w-14 rounded-full bg-white/35" />
             {/* Snap control buttons */}
-            <div className="mb-3 flex items-center justify-between gap-2">
+            <div className="pointer-events-auto mb-3 flex items-center justify-between gap-2">
               <h3 className="font-orbitron text-sm text-white/90">Панель райдера</h3>
               <div className="pointer-events-auto flex gap-1.5">
                 {SNAP_POINTS.map((snap) => (
@@ -469,7 +469,7 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
                 ))}
               </div>
             </div>
-            <div className="mx-auto max-h-[82dvh] w-full max-w-6xl overflow-y-auto pb-20">
+            <div className={`mx-auto max-h-[82dvh] w-full max-w-6xl overflow-y-auto pb-[calc(6rem+env(safe-area-inset-bottom))] ${activeSnap <= 0.2 ? "pointer-events-none opacity-70" : "pointer-events-auto opacity-100"}`}>
               <div className="grid gap-3 lg:grid-cols-[1.35fr,1fr]">
         {/* Stats card */}
         <div className="rounded-2xl border p-4 backdrop-blur-xl" style={{ ...surface.subtleCard, borderColor: "var(--mr-border)" }}>


### PR DESCRIPTION
### Motivation
- Ensure the bottom franchise map navigation is visually present but only interactive where intended so it does not block map gestures or drawer interactions. 
- Make the rider bottom sheet (vaul) respect snap state for interactivity and stacking order so collapsed states don't intercept clicks and the nav and handle behave consistently.

### Description
- Add `pointer-events-none` to the root `<nav>` in `FranchizeMapBottomNav.tsx` and `pointer-events-auto` to its inner container so the nav is visually fixed but only its interactive children receive events.
- Lower the drawer content z-index from `z-40` to `z-20` in `MapRidersClientRefactored.tsx` and introduce conditional `pointer-events-*` and `opacity` classes on the drawer panel based on `activeSnap` so the sheet becomes non-interactive and visually de-emphasized when collapsed (`activeSnap <= 0.2`).
- Ensure the drawer handle and snap control buttons remain interactive by explicitly applying `pointer-events-auto` to them.

### Testing
- Ran the application build and local dev verification (`next build` / dev server smoke) to confirm no runtime build errors and that navigation and drawer behavior update as expected; build succeeded.
- Executed the repository test suite (`pnpm test`) and lint checks; the automated tests and linting completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a159c8212c8832a838d3fef811ec6bf)