### PR TITLE
feat: add RENTAL_DOC_TEMPLATE_MODE with HTML render adapter and md fallback

### DIFF
--- a/scripts/make-rental-contract-skill.mjs
+++ b/scripts/make-rental-contract-skill.mjs
@@ -6,6 +6,37 @@ import { Document, Packer, Paragraph, TextRun } from 'docx';
 
 function arg(name, fallback = '') { const i = process.argv.indexOf(`--${name}`); return i>=0 ? (process.argv[i+1]||'') : fallback; }
 
+const RENTAL_DOC_TEMPLATE_MODE = String(process.env.RENTAL_DOC_TEMPLATE_MODE || 'md').trim().toLowerCase();
+const RENTAL_DOC_BASELINE_TEMPLATE_PATH = 'docs/RENTAL_DEAL_TEMPLATE.md';
+const RENTAL_DOC_HTML_TEMPLATE_PATH = 'docs/RENTAL_DEAL_TEMPLATE.html';
+
+function renderTemplateWithVars(template, vars) {
+  return template.replace(/{{\s*([a-zA-Z0-9_]+)\s*}}/g, (_,k)=> String(vars[k] ?? ''));
+}
+
+function renderHtmlTemplateAdapter(htmlTemplate, vars) {
+  const renderedHtml = renderTemplateWithVars(htmlTemplate, vars);
+  const text = renderedHtml
+    .replace(/<\s*br\s*\/?>/gi, '\n')
+    .replace(/<\s*\/p\s*>/gi, '\n\n')
+    .replace(/<\s*\/tr\s*>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&quot;/g, '"')
+    .replace(/&laquo;/g, '«')
+    .replace(/&raquo;/g, '»')
+    .replace(/&ndash;/g, '–')
+    .replace(/&mdash;/g, '—')
+    .replace(/&amp;/g, '&')
+    .trim();
+
+  if (!text) {
+    throw new Error('HTML adapter produced empty output');
+  }
+
+  return text;
+}
+
 function formatRuDate(d) {
   return `${String(d.getDate()).padStart(2,'0')}.${String(d.getMonth()+1).padStart(2,'0')}.${d.getFullYear()}`;
 }
@@ -143,7 +174,8 @@ const top = ranked[0];
 if (!top || top.score <= 0) throw new Error(`No matching bike for input: ${bikeId}`);
 const bike = top.bike;
 
-const template = readFileSync('docs/RENTAL_DEAL_TEMPLATE_DEMO.md','utf8');
+const mdTemplate = readFileSync(RENTAL_DOC_BASELINE_TEMPLATE_PATH, 'utf8');
+const htmlTemplate = readFileSync(RENTAL_DOC_HTML_TEMPLATE_PATH, 'utf8');
 const now = new Date();
 const phraseSchedule = extractScheduleFromPhrase(phrase);
 
@@ -173,7 +205,18 @@ const vars = {
   included_mileage:'200', overage_rate:'35', included_km_per_day:'200', extra_km_fee_rub:'35', late_return_penalty_rub:'10000', late_return_penalty_max_days:'90', bike_value_rub:'850000', bike_value_words:'Восемьсот пятьдесят тысяч',
   return_address:'г. Нижний Новгород, пл. Комсомольская 2', issuer_name:'Воробьев Р.В.', issuer_signatory:'Менеджер Мотосалона', issuer_representative:'ИП Воробьев Р.В.', signature_timestamp: now.toLocaleString('ru-RU'), signature_fingerprint:'offline-skill', renter_signature:'согласие через Telegram', bike_mileage: String(bike.specs?.mileage||''), equipment:'ключ(и) 1 шт.; шлем 1', damage_notes_at_delivery:'от даты начала аренды', damage_notes_at_return:'от даты возврата тс', battery_level_start:'100 %', battery_level_end:'____ %', media_links:'телефон', renter_passport_issue_date: passportJson.issueDate || '', renter_registration: passportJson.registration || '', damage_price_list:'мотоцикл в сборе / царапина на пластике / прочее по расчету', document_key:`rental-${bike.id}-${Date.now()}`
 };
-let rendered = template.replace(/{{\s*([a-zA-Z0-9_]+)\s*}}/g, (_,k)=> String(vars[k] ?? ''));
+let rendered;
+if (RENTAL_DOC_TEMPLATE_MODE === 'html') {
+  try {
+    rendered = renderHtmlTemplateAdapter(htmlTemplate, vars);
+  } catch (error) {
+    console.warn(`[rental-doc] html render failed, fallback to md: ${String(error?.message || error)}`);
+    rendered = renderTemplateWithVars(mdTemplate, vars);
+  }
+} else {
+  rendered = renderTemplateWithVars(mdTemplate, vars);
+}
+
 const doc = new Document({sections:[{children: rendered.split('\n').map(line=>new Paragraph({children:[new TextRun(line)]}))}]});
 const buf = await Packer.toBuffer(doc);
 

--- a/scripts/rental-doc-template-smoke.mjs
+++ b/scripts/rental-doc-template-smoke.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const TEMPLATE_MD = 'docs/RENTAL_DEAL_TEMPLATE.md';
+const TEMPLATE_HTML = 'docs/RENTAL_DEAL_TEMPLATE.html';
+const REQUIRED_VARS = [
+  'contract_number','day','month_num','year','renter_full_name','bike_vin','bike_make','bike_model',
+  'bike_category','bike_color','bike_year','bike_engine_cc','bike_power_hp','rent_start_date',
+  'rent_start_time','rent_end_date','rent_end_time','return_address','daily_price_rub','subtotal_rub','deposit_rub',
+];
+
+function extractVars(template) {
+  const vars = new Set();
+  for (const match of template.matchAll(/{{\s*([a-zA-Z0-9_]+)\s*}}/g)) {
+    vars.add(match[1]);
+  }
+  return vars;
+}
+
+function verifyMode(name, vars) {
+  const missing = REQUIRED_VARS.filter((item) => !vars.has(item));
+  if (missing.length) {
+    throw new Error(`${name}: missing required variables: ${missing.join(', ')}`);
+  }
+}
+
+const mdVars = extractVars(readFileSync(TEMPLATE_MD, 'utf8'));
+const htmlVars = extractVars(readFileSync(TEMPLATE_HTML, 'utf8'));
+
+verifyMode('md', mdVars);
+verifyMode('html', htmlVars);
+
+const onlyMd = [...mdVars].filter((item) => !htmlVars.has(item));
+const onlyHtml = [...htmlVars].filter((item) => !mdVars.has(item));
+if (onlyMd.length || onlyHtml.length) {
+  throw new Error(`template variable mismatch (only md: ${onlyMd.join(', ') || '-'}; only html: ${onlyHtml.join(', ') || '-'})`);
+}
+
+console.log('OK: md/html templates contain identical variable keys and all required vars.');


### PR DESCRIPTION
### Motivation
- Introduce a selectable template rendering mode so rental document generation can use an HTML template alternative to the existing Markdown pipeline. 
- Keep the existing Markdown template as the stable baseline and ensure parity/robustness between md and html templates.

### Description
- Added `RENTAL_DOC_TEMPLATE_MODE` config (default `md`) and constants `RENTAL_DOC_BASELINE_TEMPLATE_PATH` and `RENTAL_DOC_HTML_TEMPLATE_PATH` to `scripts/make-rental-contract-skill.mjs`.
- Implemented `renderTemplateWithVars` and `renderHtmlTemplateAdapter` helpers and routing logic so `md` uses the existing variable-substitution pipeline and `html` uses the HTML→text adapter for doc generation.
- If HTML rendering fails the code falls back to the Markdown pipeline and emits a warning via `console.warn` with the failure reason.
- Added a smoke-check script `scripts/rental-doc-template-smoke.mjs` that verifies required variable keys are present and that `docs/RENTAL_DEAL_TEMPLATE.md` and `docs/RENTAL_DEAL_TEMPLATE.html` expose identical `{{variable}}` placeholders.

### Testing
- Ran the smoke check `node scripts/rental-doc-template-smoke.mjs` which completed successfully with message: `OK: md/html templates contain identical variable keys and all required vars.`
- Confirmed the updated generator reads `docs/RENTAL_DEAL_TEMPLATE.md` as baseline and consumes `docs/RENTAL_DEAL_TEMPLATE.html` when `RENTAL_DOC_TEMPLATE_MODE=html` (fallback path exercised by adapter error handling during local validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1627149a288325948c86e525b17db6)