### PR TITLE
feat: add legal template checklist integrity validation

### DIFF
--- a/app/franchize/lib/docx-capability.ts
+++ b/app/franchize/lib/docx-capability.ts
@@ -5,6 +5,7 @@ import { registerVerifierOriginalForBuffer } from "@/app/doc-verifier/actions";
 import { generateDocxBytes } from "@/app/markdown-doc/actions";
 import { applyTemplateVariables } from "@/lib/markdownTemplate";
 import { logger } from "@/lib/logger";
+import { runLegalTemplateChecklist, TemplateIntegrityError } from "@/app/franchize/lib/legalChecklist";
 
 type TemplateVariables = Record<string, string | number>;
 
@@ -25,6 +26,23 @@ export interface BuildFranchizeDocxOutput {
 }
 
 export async function buildFranchizeDocxFromTemplate(input: BuildFranchizeDocxInput): Promise<BuildFranchizeDocxOutput> {
+  const checklist = runLegalTemplateChecklist(input.template);
+  if (!checklist.ok) {
+    logger.error("[franchize-docx] template integrity check failed", {
+      integrationScope: input.integrationScope,
+      missingCritical: checklist.criticalIssues.map((issue) => issue.marker),
+      warnings: checklist.warnings.map((issue) => issue.marker),
+    });
+    throw new TemplateIntegrityError(checklist);
+  }
+
+  if (checklist.warnings.length > 0) {
+    logger.warn("[franchize-docx] template integrity warnings", {
+      integrationScope: input.integrationScope,
+      warnings: checklist.warnings.map((issue) => issue.marker),
+    });
+  }
+
   const renderedMarkdown = applyTemplateVariables(input.template, input.variables);
   const bytes = await generateDocxBytes(renderedMarkdown);
   const sha256 = createHash("sha256").update(bytes).digest("hex");

--- a/app/franchize/lib/legalChecklist.ts
+++ b/app/franchize/lib/legalChecklist.ts
@@ -1,0 +1,89 @@
+export const LEGAL_TEMPLATE_REQUIRED_MARKERS = [
+  "§3.3",
+  "§4.3",
+  "§5.1",
+  "§6.1",
+  "§7.1",
+  "§8.1",
+  "§9.1",
+  "§10.1",
+  "§11.1",
+  "§12.1",
+  "Приложение №1",
+  "Приложение №2",
+  "Приложение №3",
+  "Приложение №4",
+] as const;
+
+export type LegalChecklistSeverity = "critical" | "warning";
+
+export interface LegalChecklistIssue {
+  marker: string;
+  severity: LegalChecklistSeverity;
+  reason: string;
+}
+
+export interface LegalChecklistResult {
+  ok: boolean;
+  issues: LegalChecklistIssue[];
+  criticalIssues: LegalChecklistIssue[];
+  warnings: LegalChecklistIssue[];
+}
+
+const WARNING_PATTERN_GROUPS: { markers: readonly string[]; reason: string }[] = [
+  {
+    markers: ["Приложение №3", "Приложение №4"],
+    reason: "Приложения с чеклистами/актами желательно держать в шаблоне для полноты юридического пакета.",
+  },
+];
+
+function isWarningMarker(marker: string): boolean {
+  return WARNING_PATTERN_GROUPS.some((group) => group.markers.includes(marker));
+}
+
+function warningReason(marker: string): string {
+  const group = WARNING_PATTERN_GROUPS.find((entry) => entry.markers.includes(marker));
+  return group?.reason ?? "Маркер отсутствует, рекомендуется добавить в шаблон.";
+}
+
+export function runLegalTemplateChecklist(template: string): LegalChecklistResult {
+  const source = String(template ?? "");
+  const issues: LegalChecklistIssue[] = LEGAL_TEMPLATE_REQUIRED_MARKERS
+    .filter((marker) => !source.includes(marker))
+    .map((marker) => {
+      if (isWarningMarker(marker)) {
+        return { marker, severity: "warning" as const, reason: warningReason(marker) };
+      }
+      return {
+        marker,
+        severity: "critical" as const,
+        reason: "Ключевой юридический блок отсутствует в шаблоне договора.",
+      };
+    });
+
+  const criticalIssues = issues.filter((issue) => issue.severity === "critical");
+  const warnings = issues.filter((issue) => issue.severity === "warning");
+
+  return {
+    ok: criticalIssues.length === 0,
+    issues,
+    criticalIssues,
+    warnings,
+  };
+}
+
+export class TemplateIntegrityError extends Error {
+  code = "template_integrity_failed" as const;
+  diagnostics: LegalChecklistResult;
+
+  constructor(diagnostics: LegalChecklistResult) {
+    const critical = diagnostics.criticalIssues.map((item) => item.marker).join(", ");
+    const warning = diagnostics.warnings.map((item) => item.marker).join(", ");
+    super(
+      `template_integrity_failed: missing critical markers [${critical || "none"}]` +
+      `${warning ? `; warnings [${warning}]` : ""}`,
+    );
+    this.name = "TemplateIntegrityError";
+    this.diagnostics = diagnostics;
+  }
+}

--- a/tests/franchize/legal-checklist.spec.ts
+++ b/tests/franchize/legal-checklist.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LEGAL_TEMPLATE_REQUIRED_MARKERS,
+  TemplateIntegrityError,
+  runLegalTemplateChecklist,
+} from "@/app/franchize/lib/legalChecklist";
+
+describe("runLegalTemplateChecklist", () => {
+  it("passes when all required markers exist", () => {
+    const fullTemplate = LEGAL_TEMPLATE_REQUIRED_MARKERS.join("\n");
+    const result = runLegalTemplateChecklist(fullTemplate);
+
+    expect(result.ok).toBe(true);
+    expect(result.criticalIssues).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("returns template_integrity_failed diagnostics for missing critical markers", () => {
+    const template = "§3.3\n§4.3\nПриложение №1\nПриложение №2\nПриложение №3\nПриложение №4";
+    const result = runLegalTemplateChecklist(template);
+
+    expect(result.ok).toBe(false);
+    expect(result.criticalIssues.map((issue) => issue.marker)).toEqual([
+      "§5.1",
+      "§6.1",
+      "§7.1",
+      "§8.1",
+      "§9.1",
+      "§10.1",
+      "§11.1",
+      "§12.1",
+    ]);
+
+    const err = new TemplateIntegrityError(result);
+    expect(err.code).toBe("template_integrity_failed");
+    expect(err.message).toContain("missing critical markers");
+    expect(err.diagnostics.criticalIssues).toHaveLength(8);
+  });
+
+  it("keeps non-blocking markers as warnings", () => {
+    const template = LEGAL_TEMPLATE_REQUIRED_MARKERS.filter((marker) => marker !== "Приложение №3" && marker !== "Приложение №4").join("\n");
+    const result = runLegalTemplateChecklist(template);
+
+    expect(result.ok).toBe(true);
+    expect(result.criticalIssues).toHaveLength(0);
+    expect(result.warnings.map((issue) => issue.marker)).toEqual(["Приложение №3", "Приложение №4"]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure generated franchize documents include mandatory legal sections and appendices so operators do not send incomplete contracts.
- Provide an early, lightweight, local check to fail fast before DOCX rendering or external uploads when critical markers are missing.

### Description
- Added `app/franchize/lib/legalChecklist.ts` which defines `LEGAL_TEMPLATE_REQUIRED_MARKERS`, `runLegalTemplateChecklist`, typed diagnostics and `TemplateIntegrityError` (with `code = "template_integrity_failed"`).
- Integrated the checklist into `buildFranchizeDocxFromTemplate` so `runLegalTemplateChecklist(input.template)` runs before rendering and throws `TemplateIntegrityError` on critical missing markers; warnings are logged but do not block generation.
- Classified some markers (e.g. `Приложение №3`, `Приложение №4`) as non-blocking warnings with explanatory reasons in diagnostics.
- Added unit tests `tests/franchize/legal-checklist.spec.ts` that exercise success, critical-missing, and warning-only cases without calling external services.

### Testing
- Ran `npx vitest run tests/franchize/legal-checklist.spec.ts` and all tests passed (3 tests in 1 file).
- The checklist logic was exercised by unit tests only and requires no external network or service mocks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1627180f248325a5d85d292960a31f)