### PR TITLE
feat: enforce bridge callback contract and validation

### DIFF
--- a/app/api/codex-bridge/callback/route.ts
+++ b/app/api/codex-bridge/callback/route.ts
@@ -5,11 +5,11 @@ import { sendComplexMessage } from "@/app/webhook-handlers/actions/sendComplexMe
 import { notifyAdmin } from "@/app/actions";
 
 type CallbackBody = {
-  branch?: string;
-  taskPath?: string;
-  prUrl?: string;
-  summary?: string;
-  status?: "done" | "failed" | "in_progress" | string;
+  branch: string;
+  taskPath: string;
+  prUrl: string;
+  summary: string;
+  status: "done" | "failed" | "in_progress" | "completed" | string;
   telegramChatId?: string | number;
   telegramUserId?: string | number;
   slackChannelId?: string;
@@ -128,26 +128,65 @@ async function sendTelegramPhotoWithCaption(chatId: string | number, text: strin
   return { target: String(chatId), ok: true, mode: "photo", sentImages };
 }
 
+function validateReplyTargets(body: CallbackBody) {
+  const errors: string[] = [];
+  if (body.telegramChatId !== undefined && !/^-?\d+$/.test(String(body.telegramChatId))) {
+    errors.push('telegramChatId must be numeric');
+  }
+  if (body.slackChannelId !== undefined && !/^[A-Z0-9]{8,15}$/.test(String(body.slackChannelId))) {
+    errors.push('slackChannelId has invalid format');
+  }
+  if (body.slackThreadTs !== undefined && !/^\d{10}\.\d{6}$/.test(String(body.slackThreadTs))) {
+    errors.push('slackThreadTs has invalid format');
+  }
+  return errors;
+}
+
+function validateRequired(body: Partial<CallbackBody>) {
+  const errors: string[] = [];
+  if (!body.status) errors.push('status is required');
+  if (!body.summary) errors.push('summary is required');
+  if (!body.branch) errors.push('branch is required');
+  if (!body.taskPath || !String(body.taskPath).startsWith('/')) errors.push('taskPath is required and must start with /');
+  if (!body.prUrl) {
+    errors.push('prUrl is required');
+  } else {
+    try {
+      const parsed = new URL(String(body.prUrl));
+      if (!['http:', 'https:'].includes(parsed.protocol)) errors.push('prUrl must be http(s)');
+    } catch {
+      errors.push('prUrl must be a valid URL');
+    }
+  }
+  return errors;
+}
+
 export async function POST(req: NextRequest) {
   try {
     if (!verifySecret(req)) {
       return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = (await req.json()) as CallbackBody;
-    const previewUrl = buildPreviewUrl(body.branch, body.taskPath);
-    const productionTaskUrl = buildProductionTaskUrl(body.taskPath);
-    const homeworkDeepLink = buildTelegramHomeworkDeepLink(body.taskPath);
-    const imageUrls = extractImageUrls(body);
+    const body = (await req.json()) as Partial<CallbackBody>;
+    const requiredErrors = validateRequired(body);
+    const targetErrors = validateReplyTargets(body as CallbackBody);
+    if (requiredErrors.length > 0 || targetErrors.length > 0) {
+      return NextResponse.json({ ok: false, error: "Validation error", details: [...requiredErrors, ...targetErrors] }, { status: 400 });
+    }
+    const payload = body as CallbackBody;
+    const previewUrl = buildPreviewUrl(payload.branch, payload.taskPath);
+    const productionTaskUrl = buildProductionTaskUrl(payload.taskPath);
+    const homeworkDeepLink = buildTelegramHomeworkDeepLink(payload.taskPath);
+    const imageUrls = extractImageUrls(payload);
 
     const lines = [
-      `Codex update: ${body.status || "done"}`,
-      body.summary ? `Summary: ${body.summary}` : null,
-      body.branch ? `Branch: ${body.branch}` : null,
+      `Codex update: ${payload.status || "done"}`,
+      payload.summary ? `Summary: ${payload.summary}` : null,
+      payload.branch ? `Branch: ${payload.branch}` : null,
       productionTaskUrl ? `Result: ${productionTaskUrl}` : null,
       previewUrl ? `Preview: ${previewUrl}` : null,
       homeworkDeepLink ? `Open in bot app: ${homeworkDeepLink}` : null,
-      body.prUrl ? `PR: ${body.prUrl}` : null,
+      payload.prUrl ? `PR: ${payload.prUrl}` : null,
     ].filter(Boolean) as string[];
 
     const message = lines.join("\n");
@@ -161,7 +200,7 @@ export async function POST(req: NextRequest) {
     };
 
     const uniqueTelegramTargets = Array.from(
-      new Set([body.telegramChatId, body.telegramUserId].filter(Boolean).map((value) => String(value))),
+      new Set([payload.telegramChatId, payload.telegramUserId].filter(Boolean).map((value) => String(value))),
     );
 
     for (const target of uniqueTelegramTargets) {
@@ -180,7 +219,7 @@ export async function POST(req: NextRequest) {
     }
 
     const slackConfig = getSlackBridgeConfig();
-    const canSendToSlack = Boolean(body.slackChannelId || body.slackThreadTs || slackConfig.incomingWebhookUrl || slackConfig.defaultChannel);
+    const canSendToSlack = Boolean(payload.slackChannelId || payload.slackThreadTs || slackConfig.incomingWebhookUrl || slackConfig.defaultChannel);
 
     if (canSendToSlack) {
       const slackText = imageUrls.length > 0
@@ -206,13 +245,13 @@ export async function POST(req: NextRequest) {
 
       const slackResult = await postSlackMessage({
         text: slackText,
-        channel: body.slackChannelId,
-        threadTs: body.slackThreadTs,
+        channel: payload.slackChannelId,
+        threadTs: payload.slackThreadTs,
         blocks: slackBlocks,
       });
 
       imageDelivery.slack = {
-        target: body.slackChannelId || slackConfig.defaultChannel || "incoming_webhook",
+        target: payload.slackChannelId || slackConfig.defaultChannel || "incoming_webhook",
         ok: slackResult.ok,
         mode: imageUrls.length > 0 ? "photo" : "text",
         sentImages: imageUrls.length > 0 ? imageUrls.length : 0,
@@ -226,12 +265,12 @@ export async function POST(req: NextRequest) {
     if (!wasAlreadyDeliveredToAdmin) {
       await notifyAdmin([
         "🤖 Codex bridge callback received",
-        `Status: ${body.status || "done"}`,
-        body.summary ? `Summary: ${body.summary}` : null,
-        body.branch ? `Branch: ${body.branch}` : null,
-        body.prUrl ? `PR: ${body.prUrl}` : null,
-        body.telegramChatId ? `Chat: ${body.telegramChatId}` : null,
-        body.telegramUserId ? `User: ${body.telegramUserId}` : null,
+        `Status: ${payload.status || "done"}`,
+        payload.summary ? `Summary: ${payload.summary}` : null,
+        payload.branch ? `Branch: ${payload.branch}` : null,
+        payload.prUrl ? `PR: ${payload.prUrl}` : null,
+        payload.telegramChatId ? `Chat: ${payload.telegramChatId}` : null,
+        payload.telegramUserId ? `User: ${payload.telegramUserId}` : null,
         previewUrl ? `Preview: ${previewUrl}` : null,
         imageUrls.length > 0 ? `Images: ${imageUrls.length}` : null,
       ].filter(Boolean).join("\n"));

--- a/docs/AUTOMATION_EXPANSION_PLAN.md
+++ b/docs/AUTOMATION_EXPANSION_PLAN.md
@@ -113,3 +113,12 @@ Recommended resolver order:
 - Keep all privileged operations server-side only.
 - Redact secrets and sensitive identifiers in outbound notifications.
 - Make each automation idempotent and retry-safe with explicit correlation IDs.
+
+
+## Bridge callback completion contract
+
+For bridge task completion, use one unified callback payload format:
+- Required fields: `status`, `summary`, `branch`, `taskPath`, `prUrl`
+- Optional reply targets: `telegramChatId`, `slackChannelId`, `slackThreadTs`
+- Preview URL must be derived only from the actual branch (`/` replaced with `-`).
+- If auto-send fails, return a ready-to-run fallback cURL with all resolved fields and explicit failure reason.

--- a/scripts/codex-notify.mjs
+++ b/scripts/codex-notify.mjs
@@ -108,6 +108,104 @@ function getBranchFallback() {
   }
 }
 
+
+function isValidStatus(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidSummary(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidBranch(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidTaskPath(value) {
+  return typeof value === 'string' && value.trim().startsWith('/');
+}
+
+function isValidPrUrl(value) {
+  if (typeof value !== 'string' || value.trim().length === 0) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isValidTelegramId(value) {
+  if (value === undefined || value === null || value === '') return true;
+  return /^-?\d+$/.test(String(value).trim());
+}
+
+function isValidSlackChannelId(value) {
+  if (value === undefined || value === null || value === '') return true;
+  return /^[A-Z0-9]{8,15}$/.test(String(value).trim());
+}
+
+function isValidSlackThreadTs(value) {
+  if (value === undefined || value === null || value === '') return true;
+  return /^\d{10}\.\d{6}$/.test(String(value).trim());
+}
+
+function normalizeBranchSlug(branch) {
+  return String(branch || '').trim().replace(/\//g, '-').replace(/[^a-zA-Z0-9._-]/g, '-');
+}
+
+function buildPreviewUrl(branch, taskPath = '/') {
+  if (!isValidBranch(branch)) return undefined;
+  const slug = normalizeBranchSlug(branch);
+  const projectName = process.env.VERCEL_PROJECT_NAME || 'v0-car-test';
+  const suffix = process.env.VERCEL_PREVIEW_DOMAIN_SUFFIX || '-salavey13s-projects.vercel.app';
+  const normalizedSuffix = suffix.startsWith('.') || suffix.startsWith('-') ? suffix : `.${suffix}`;
+  const normalizedPath = isValidTaskPath(taskPath) ? taskPath : '/';
+  return `https://${projectName}-git-${slug}${normalizedSuffix}${normalizedPath}`;
+}
+
+function buildFallbackCurl(endpoint, secret, payload, reason) {
+  const safePayload = { ...payload, fallbackReason: reason, previewUrl: buildPreviewUrl(payload.branch, payload.taskPath) };
+  const secretValue = secret || '$CODEX_BRIDGE_CALLBACK_SECRET';
+  return [
+    `curl -X POST "${endpoint}" \\`,
+    '  -H "Content-Type: application/json" \\',
+    `  -H "x-codex-bridge-secret: ${secretValue}" \\`,
+    `  -d '${JSON.stringify(safePayload, null, 2)}'`,
+  ].join('\n');
+}
+
+function validateCallbackPayload(payload) {
+  const errors = [];
+  if (!isValidStatus(payload.status)) errors.push('status is required');
+  if (!isValidSummary(payload.summary)) errors.push('summary is required');
+  if (!isValidBranch(payload.branch)) errors.push('branch is required');
+  if (!isValidTaskPath(payload.taskPath)) errors.push('taskPath must start with /');
+  if (!isValidPrUrl(payload.prUrl)) errors.push('prUrl must be a valid http(s) url');
+  if (!isValidTelegramId(payload.telegramChatId)) errors.push('telegramChatId must be numeric');
+  if (!isValidSlackChannelId(payload.slackChannelId)) errors.push('slackChannelId has invalid format');
+  if (!isValidSlackThreadTs(payload.slackThreadTs)) errors.push('slackThreadTs must match 1234567890.123456');
+  return errors;
+}
+
+function prepareCallbackPayload() {
+  const payload = {
+    status: getArg('status', 'completed'),
+    summary: getArg('summary', 'Codex task update'),
+    branch: getArg('branch', process.env.PR_HEAD_REF || getBranchFallback()),
+    taskPath: getArg('taskPath', '/'),
+    prUrl: getArg('prUrl'),
+    telegramChatId: getArg('telegramChatId', process.env.TELEGRAM_CHAT_ID || process.env.ADMIN_CHAT_ID),
+    telegramUserId: getArg('telegramUserId', process.env.TELEGRAM_USER_ID),
+    slackChannelId: getArg('slackChannelId', process.env.SLACK_CODEX_CHANNEL_ID),
+    slackThreadTs: getArg('slackThreadTs', process.env.SLACK_THREAD_TS),
+    imageUrl: getArg('imageUrl') || (getArg('imagePath') ? uploadImageToSupabaseStorage(getArg('imagePath')) : undefined),
+  };
+  const errors = validateCallbackPayload(payload);
+  if (errors.length > 0) throw new Error(`Invalid callback payload: ${errors.join('; ')}`);
+  return payload;
+}
+
 async function postJson(url, body, headers = {}) {
   try {
     const res = await fetch(url, {
@@ -139,24 +237,19 @@ async function runCallbackMode() {
   const secret = process.env.CODEX_BRIDGE_CALLBACK_SECRET || getArg('secret');
   if (!secret) throw new Error('Missing CODEX_BRIDGE_CALLBACK_SECRET (or --secret)');
 
-  const branch = getArg('branch', process.env.PR_HEAD_REF || getBranchFallback());
-  const payload = {
-    status: getArg('status', 'completed'),
-    summary: getArg('summary', 'Codex task update'),
-    branch,
-    taskPath: getArg('taskPath', '/'),
-    prUrl: getArg('prUrl'),
-    telegramChatId: getArg('telegramChatId', process.env.TELEGRAM_CHAT_ID || process.env.ADMIN_CHAT_ID),
-    telegramUserId: getArg('telegramUserId', process.env.TELEGRAM_USER_ID),
-    slackChannelId: getArg('slackChannelId', process.env.SLACK_CODEX_CHANNEL_ID),
-    slackThreadTs: getArg('slackThreadTs', process.env.SLACK_THREAD_TS),
-    imageUrl: getArg('imageUrl') || (getArg('imagePath') ? uploadImageToSupabaseStorage(getArg('imagePath')) : undefined),
-  };
-
-  const response = await postJson(endpoint, payload, {
-    'x-codex-bridge-secret': secret,
-  });
-  console.log(response);
+  const payload = prepareCallbackPayload();
+  try {
+    const response = await postJson(endpoint, payload, {
+      'x-codex-bridge-secret': secret,
+    });
+    console.log(response);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.error(`callback send failed: ${reason}`);
+    console.error('Fallback cURL:');
+    console.error(buildFallbackCurl(endpoint, secret, payload, reason));
+    throw error;
+  }
 }
 
 async function runCallbackAutoMode() {
@@ -168,23 +261,18 @@ async function runCallbackAutoMode() {
     return;
   }
 
-  const payload = {
-    status: getArg('status', 'completed'),
-    summary: getArg('summary', 'Codex task update'),
-    branch: getArg('branch', process.env.PR_HEAD_REF || getBranchFallback()),
-    taskPath: getArg('taskPath', '/'),
-    prUrl: getArg('prUrl'),
-    telegramChatId: getArg('telegramChatId', process.env.TELEGRAM_CHAT_ID || process.env.ADMIN_CHAT_ID),
-    telegramUserId: getArg('telegramUserId', process.env.TELEGRAM_USER_ID),
-    slackChannelId: getArg('slackChannelId', process.env.SLACK_CODEX_CHANNEL_ID),
-    slackThreadTs: getArg('slackThreadTs', process.env.SLACK_THREAD_TS),
-    imageUrl: getArg('imageUrl') || (getArg('imagePath') ? uploadImageToSupabaseStorage(getArg('imagePath')) : undefined),
-  };
-
-  const response = await postJson(endpoint, payload, {
-    'x-codex-bridge-secret': secret,
-  });
-  console.log(response);
+  const payload = prepareCallbackPayload();
+  try {
+    const response = await postJson(endpoint, payload, {
+      'x-codex-bridge-secret': secret,
+    });
+    console.log(response);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.error(`callback-auto send failed: ${reason}`);
+    console.error('Fallback cURL:');
+    console.error(buildFallbackCurl(endpoint, secret, payload, reason));
+  }
 }
 
 async function runTelegramMode() {


### PR DESCRIPTION
### Motivation
- Make the Codex bridge callback flow deterministic by enforcing a single required payload contract and validating optional reply targets before delivery.
- Ensure preview links are derived from the real branch name and provide a clear, copy-paste fallback when auto-send fails so operators can recover quickly.

### Description
- Added strict client-side payload preparation and validation helpers to `scripts/codex-notify.mjs`, including checks for required fields `status`, `summary`, `branch`, `taskPath`, `prUrl`, optional reply-target format validators, branch-slug preview builder (`/` -> `-`), and a `buildFallbackCurl` generator used when auto-send fails.
- Updated `app/api/codex-bridge/callback/route.ts` to require the callback fields at the API level, validate reply-target formats, return `400` with `details` on validation errors, and use the validated payload to generate preview/production URLs and drive Telegram/Slack delivery.
- Added a concise `Bridge callback completion contract` section to `docs/AUTOMATION_EXPANSION_PLAN.md` documenting required fields, optional reply targets, preview derivation rules, and the fallback-cURL requirement.
- Files changed: `scripts/codex-notify.mjs`, `app/api/codex-bridge/callback/route.ts`, `docs/AUTOMATION_EXPANSION_PLAN.md`.

### Testing
- Ran a static Node syntax check `node --check scripts/codex-notify.mjs`, which completed successfully.
- Attempted `npm run -s lint app/api/codex-bridge/callback/route.ts`, which failed because Next.js lint invocation in this environment could not locate the `app/pages` dir (lint context issue), not because of the callback route changes.
- Ran full `npm run -s lint`, which failed due to existing unrelated ESLint errors in `app/franchize/[slug]/components/VipBikeRentalClient-integration.tsx`; the callback-specific changes did not introduce those errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16273644d083259551bbfcac2a9fa4)