### PR TITLE
Fix rental document pipeline regressions and stabilize callbacks

### DIFF
--- a/app/api/codex-bridge/callback/route.ts
+++ b/app/api/codex-bridge/callback/route.ts
@@ -7,7 +7,7 @@ import { notifyAdmin } from "@/app/actions";
 type CallbackBody = {
   branch: string;
   taskPath: string;
-  prUrl: string;
+  prUrl?: string;
   summary: string;
   status: "done" | "failed" | "in_progress" | "completed" | string;
   telegramChatId?: string | number;
@@ -148,9 +148,10 @@ function validateRequired(body: Partial<CallbackBody>) {
   if (!body.summary) errors.push('summary is required');
   if (!body.branch) errors.push('branch is required');
   if (!body.taskPath || !String(body.taskPath).startsWith('/')) errors.push('taskPath is required and must start with /');
-  if (!body.prUrl) {
-    errors.push('prUrl is required');
-  } else {
+  const requiresPrUrl = ["done", "completed"].includes(String(body.status || "").toLowerCase());
+  if (requiresPrUrl && !body.prUrl) {
+    errors.push('prUrl is required when status is done/completed');
+  } else if (body.prUrl) {
     try {
       const parsed = new URL(String(body.prUrl));
       if (!['http:', 'https:'].includes(parsed.protocol)) errors.push('prUrl must be http(s)');

--- a/app/franchize/actions-runtime.ts
+++ b/app/franchize/actions-runtime.ts
@@ -1627,8 +1627,8 @@ type FranchizeOrderNotifyPayload = z.infer<typeof franchizeOrderInvoiceSchema> &
 };
 
 type FranchizeOrderDocContactField = "renterBirthDate" | "renterPhone" | "renterEmail";
-type FranchizeOrderDocRequiredField = "renterBirthDate" | "renterPhone";
-const FRANCHIZE_DOC_REQUIRED_FIELDS: FranchizeOrderDocRequiredField[] = ["renterBirthDate", "renterPhone"];
+type FranchizeOrderDocRequiredField = "renterPhone";
+const FRANCHIZE_DOC_REQUIRED_FIELDS: FranchizeOrderDocRequiredField[] = ["renterPhone"];
 
 type FranchizeOrderDocVariables = {
   renterBirthDate: string;
@@ -1685,28 +1685,31 @@ function resolveFranchizeDocField(
 
 /**
  * Payload contract for order-doc generation:
- * Required: renterBirthDate, renterPhone. Optional: renterEmail.
+ * Required: renterPhone. Optional: renterBirthDate, renterEmail.
  * Priority source is strict: payload -> userSensitive -> fallback.
  * Valid example: { renterBirthDate: "15.03.1992", renterPhone: "+79001234567", renterEmail: "rider@crew.ru" }
- * Invalid example: { renterBirthDate: "", renterPhone: "12345" } // missing birth date + invalid RU phone.
+ * Invalid example: { renterBirthDate: "", renterPhone: "12345" } // invalid RU phone.
  */
 function resolveAndValidateFranchizeDocVariables(
   payload: FranchizeOrderNotifyPayload,
   userSensitive: UnknownRecord,
 ): FranchizeOrderDocVariables {
   const birthDate = formatDateDdMmYyyy(resolveFranchizeDocField("renterBirthDate", payload, userSensitive, ""));
+  const normalizedBirthDate = birthDate || "указывается при выдаче";
   const phone = formatPhoneRu(resolveFranchizeDocField("renterPhone", payload, userSensitive, payload.phone || ""));
   const email = resolveFranchizeDocField("renterEmail", payload, userSensitive, "указывается при выдаче");
+  if (!birthDate) {
+    logger.warn("[franchize-doc] renterBirthDate missing in payload/userSensitive; using fallback placeholder");
+  }
 
   const requiredValues: Record<FranchizeOrderDocRequiredField, string> = {
-    renterBirthDate: birthDate,
     renterPhone: phone,
   };
   const missing = FRANCHIZE_DOC_REQUIRED_FIELDS.filter((field) => !requiredValues[field]);
   if (missing.length > 0) throw new FranchizeOrderDocValidationError(missing);
 
   return {
-    renterBirthDate: birthDate,
+    renterBirthDate: normalizedBirthDate,
     renterPhone: phone,
     renterEmail: email,
   };
@@ -1885,6 +1888,7 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
       fileName: docFileName,
       template,
       variables,
+      flowType,
     });
 
     const adminChatId = process.env.ADMIN_CHAT_ID;

--- a/app/franchize/lib/docx-capability.ts
+++ b/app/franchize/lib/docx-capability.ts
@@ -16,6 +16,7 @@ export interface BuildFranchizeDocxInput {
   fileName: string;
   template: string;
   variables: TemplateVariables;
+  flowType?: "rental" | "sale" | "mixed";
 }
 
 export interface BuildFranchizeDocxOutput {
@@ -26,21 +27,23 @@ export interface BuildFranchizeDocxOutput {
 }
 
 export async function buildFranchizeDocxFromTemplate(input: BuildFranchizeDocxInput): Promise<BuildFranchizeDocxOutput> {
-  const checklist = runLegalTemplateChecklist(input.template);
-  if (!checklist.ok) {
-    logger.error("[franchize-docx] template integrity check failed", {
-      integrationScope: input.integrationScope,
-      missingCritical: checklist.criticalIssues.map((issue) => issue.marker),
-      warnings: checklist.warnings.map((issue) => issue.marker),
-    });
-    throw new TemplateIntegrityError(checklist);
-  }
+  if ((input.flowType ?? "rental") === "rental") {
+    const checklist = runLegalTemplateChecklist(input.template);
+    if (!checklist.ok) {
+      logger.error("[franchize-docx] template integrity check failed", {
+        integrationScope: input.integrationScope,
+        missingCritical: checklist.criticalIssues.map((issue) => issue.marker),
+        warnings: checklist.warnings.map((issue) => issue.marker),
+      });
+      throw new TemplateIntegrityError(checklist);
+    }
 
-  if (checklist.warnings.length > 0) {
-    logger.warn("[franchize-docx] template integrity warnings", {
-      integrationScope: input.integrationScope,
-      warnings: checklist.warnings.map((issue) => issue.marker),
-    });
+    if (checklist.warnings.length > 0) {
+      logger.warn("[franchize-docx] template integrity warnings", {
+        integrationScope: input.integrationScope,
+        warnings: checklist.warnings.map((issue) => issue.marker),
+      });
+    }
   }
 
   const renderedMarkdown = applyTemplateVariables(input.template, input.variables);

--- a/app/franchize/lib/legalChecklist.ts
+++ b/app/franchize/lib/legalChecklist.ts
@@ -48,8 +48,19 @@ function warningReason(marker: string): string {
 
 export function runLegalTemplateChecklist(template: string): LegalChecklistResult {
   const source = String(template ?? "");
+  const markerToRegex = (marker: string): RegExp => {
+    if (marker.startsWith("§")) {
+      const num = marker.slice(1).replace(".", "\\.");
+      return new RegExp(`§?\\s*${num}\\.?`, "i");
+    }
+    if (marker.startsWith("Приложение")) {
+      const num = marker.match(/\d+/)?.[0] ?? "";
+      return new RegExp(`Приложение\\s*№\\s*${num}`, "i");
+    }
+    return new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+  };
   const issues: LegalChecklistIssue[] = LEGAL_TEMPLATE_REQUIRED_MARKERS
-    .filter((marker) => !source.includes(marker))
+    .filter((marker) => !markerToRegex(marker).test(source))
     .map((marker) => {
       if (isWarningMarker(marker)) {
         return { marker, severity: "warning" as const, reason: warningReason(marker) };

--- a/scripts/codex-notify.mjs
+++ b/scripts/codex-notify.mjs
@@ -166,11 +166,11 @@ function buildPreviewUrl(branch, taskPath = '/') {
 
 function buildFallbackCurl(endpoint, secret, payload, reason) {
   const safePayload = { ...payload, fallbackReason: reason, previewUrl: buildPreviewUrl(payload.branch, payload.taskPath) };
-  const secretValue = secret || '$CODEX_BRIDGE_CALLBACK_SECRET';
   return [
+    '# Replace $CODEX_BRIDGE_CALLBACK_SECRET with actual value before running',
     `curl -X POST "${endpoint}" \\`,
     '  -H "Content-Type: application/json" \\',
-    `  -H "x-codex-bridge-secret: ${secretValue}" \\`,
+    '  -H "x-codex-bridge-secret: $CODEX_BRIDGE_CALLBACK_SECRET" \\',
     `  -d '${JSON.stringify(safePayload, null, 2)}'`,
   ].join('\n');
 }
@@ -181,7 +181,10 @@ function validateCallbackPayload(payload) {
   if (!isValidSummary(payload.summary)) errors.push('summary is required');
   if (!isValidBranch(payload.branch)) errors.push('branch is required');
   if (!isValidTaskPath(payload.taskPath)) errors.push('taskPath must start with /');
-  if (!isValidPrUrl(payload.prUrl)) errors.push('prUrl must be a valid http(s) url');
+  const requiresPrUrl = ['done', 'completed'].includes(String(payload.status || '').toLowerCase());
+  if (requiresPrUrl && !isValidPrUrl(payload.prUrl)) {
+    errors.push('prUrl must be a valid http(s) url when status is done/completed');
+  }
   if (!isValidTelegramId(payload.telegramChatId)) errors.push('telegramChatId must be numeric');
   if (!isValidSlackChannelId(payload.slackChannelId)) errors.push('slackChannelId has invalid format');
   if (!isValidSlackThreadTs(payload.slackThreadTs)) errors.push('slackThreadTs must match 1234567890.123456');

--- a/scripts/make-rental-contract-skill.mjs
+++ b/scripts/make-rental-contract-skill.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { createClient } from '@supabase/supabase-js';
 import { Document, Packer, Paragraph, TextRun } from 'docx';
 
@@ -20,6 +21,7 @@ function renderHtmlTemplateAdapter(htmlTemplate, vars) {
     .replace(/<\s*br\s*\/?>/gi, '\n')
     .replace(/<\s*\/p\s*>/gi, '\n\n')
     .replace(/<\s*\/tr\s*>/gi, '\n')
+    .replace(/<\s*\/t[dh]\s*>/gi, '\t')
     .replace(/<[^>]+>/g, '')
     .replace(/&nbsp;/g, ' ')
     .replace(/&quot;/g, '"')
@@ -181,7 +183,6 @@ if (!top || top.score <= 0) failStage('bike_resolve', 'bike_not_found', { bikeQu
 const bike = top.bike;
 
 const mdTemplate = readFileSync(RENTAL_DOC_BASELINE_TEMPLATE_PATH, 'utf8');
-const htmlTemplate = readFileSync(RENTAL_DOC_HTML_TEMPLATE_PATH, 'utf8');
 const now = new Date();
 const phraseSchedule = extractScheduleFromPhrase(phrase);
 const startDate = arg('startDate', phraseSchedule.startDate || '');
@@ -229,6 +230,7 @@ const vars = {
 let rendered;
 if (RENTAL_DOC_TEMPLATE_MODE === 'html') {
   try {
+    const htmlTemplate = readFileSync(RENTAL_DOC_HTML_TEMPLATE_PATH, 'utf8');
     rendered = renderHtmlTemplateAdapter(htmlTemplate, vars);
   } catch (error) {
     console.warn(`[rental-doc] html render failed, fallback to md: ${String(error?.message || error)}`);
@@ -240,6 +242,7 @@ if (RENTAL_DOC_TEMPLATE_MODE === 'html') {
 
 const doc = new Document({sections:[{children: rendered.split('\n').map(line=>new Paragraph({children:[new TextRun(line)]}))}]});
 const buf = await Packer.toBuffer(doc);
+const originalSha256 = createHash('sha256').update(buf).digest('hex');
 
 const token = process.env.TELEGRAM_BOT_TOKEN;
 const telegramUrl = `https://api.telegram.org/bot${token}/sendDocument`;
@@ -260,7 +263,7 @@ try {
 if (!json.ok) failStage('telegram_delivery', 'telegram_send_failed', { telegram: json });
 
 const result = {ok:true, requestedBikeId: bikeId, resolvedBikeId: bike.id, chatId: telegramChatId, messageId: json.result?.message_id, contractKey: vars.document_key};
-const saveMetadata = arg('saveMetadata', '1') !== '0';
+const saveMetadata = arg('saveMetadata', '0') !== '0';
 const metadataTable = arg('metadataTable', 'rental_contract_artifacts');
 if (saveMetadata) {
   const payload = {
@@ -272,6 +275,7 @@ if (saveMetadata) {
     renter_full_name: renterFullName,
     rent_start_date: startDate,
     rent_end_date: endDate,
+    original_sha256: originalSha256,
   };
   const writeRes = await supabase.from(metadataTable).insert(payload).select('contract_key').limit(1);
   if (writeRes.error) failStage('metadata_write', 'metadata_write_failed', { table: metadataTable, error: writeRes.error.message });

--- a/supabase/migrations/20260527090000_rental_contract_artifacts.sql
+++ b/supabase/migrations/20260527090000_rental_contract_artifacts.sql
@@ -1,0 +1,20 @@
+create table if not exists public.rental_contract_artifacts (
+  id uuid primary key default gen_random_uuid(),
+  contract_key text not null unique,
+  requested_bike_id text,
+  resolved_bike_id text,
+  telegram_chat_id text,
+  telegram_message_id bigint,
+  renter_full_name text,
+  rent_start_date date,
+  rent_end_date date,
+  doc_verifier_id uuid references public.doc_verifier_records(id),
+  original_sha256 text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_rental_contract_artifacts_key
+  on public.rental_contract_artifacts(contract_key);
+
+create index if not exists idx_rental_contract_artifacts_sha256
+  on public.rental_contract_artifacts(original_sha256);


### PR DESCRIPTION
### Motivation
- Close regressions and gaps listed in `docs/RENTAL_PIPELINE_FIX_ALL.md` so rental DOCX generation and the super-skill work reliably across web-app and offline skill flows. 
- Restore backward compatibility for the web checkout path by avoiding hard-fail conditions introduced by recent PRs. 
- Harden callback/notifier behavior and add metadata persistence scaffolding for read-after-write verification and anti-forgery integration.

### Description
- Make `renterBirthDate` optional in the web-app flow with a fallback placeholder (`"указывается при выдаче"`) and warning log, and keep `renterPhone` required, while returning normalized variables to template rendering (`app/franchize/actions-runtime.ts`).
- Gate the legal-template checklist to run only for `flowType === 'rental'`, add `flowType` to `buildFranchizeDocxFromTemplate` inputs, and improve marker detection by replacing strict `includes()` with tolerant regex matching for section/appending formats (`app/franchize/lib/docx-capability.ts`, `app/franchize/lib/legalChecklist.ts`, `app/franchize/actions-runtime.ts`).
- Make `prUrl` conditionally required only for `done/completed` statuses in the bridge API and notifier, and prevent leaking the real callback secret in fallback cURL output by using the `$CODEX_BRIDGE_CALLBACK_SECRET` placeholder (`app/api/codex-bridge/callback/route.ts`, `scripts/codex-notify.mjs`).
- Fix super-skill script regressions: read the HTML template only when `RENTAL_DOC_TEMPLATE_MODE === 'html'`, preserve table cell boundaries in the HTML adapter (`</td>`/`</th>` → `\t`), default `--saveMetadata` to disabled, and compute/store DOCX SHA256 in the metadata payload; also add a migration for `rental_contract_artifacts` to support metadata and verifier links (`scripts/make-rental-contract-skill.mjs`, `supabase/migrations/20260527090000_rental_contract_artifacts.sql`).

### Testing
- Ran `node --check scripts/make-rental-contract-skill.mjs` and it succeeded without syntax errors. 
- Ran `node --check scripts/codex-notify.mjs` and it succeeded without syntax errors. 
- Attempted repository linting (`npm run lint`) and targeted lint checks but the full lint run failed due to unrelated pre-existing Next.js / JSX issues (missing app/pages root and undefined JSX symbols in an integration component), so no repo-wide lint green was produced. 
- Committed the changes and added the migration file; note that end-to-end `doc_verifier_records` registration from the super-skill (upload to doc-verifier storage + upsert) is intentionally left as the next integration step and is documented in the PR notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a173e6600048325b3408c5bbf5de48f)