### PR TITLE
fixed specs extraction in cart

### DIFF
--- a/app/franchize/components/cart/CartItemCard.tsx
+++ b/app/franchize/components/cart/CartItemCard.tsx
@@ -151,7 +151,7 @@ export function CartItemCard({ line, crew, onDecreaseQty, onIncreaseQty, onDelet
           </span>
 
           {/* Spec badges row */}
-          {line.item && <SpecBadges specs={line.item.rawSpecs} theme={crew.theme} />}
+          {line.item && <SpecBadges specs={line.item.rawSpecs ?? {}} theme={crew.theme} />}
 
           {/* Price section — Buy price is THE BIGGEST text on the card + gold glow */}
           <div className="mt-2">

--- a/app/franchize/components/cart/CartItemCard.tsx
+++ b/app/franchize/components/cart/CartItemCard.tsx
@@ -1,3 +1,4 @@
+// app/franchize/components/cart/CartItemCard.tsx
 "use client";
 
 import { useState } from "react";
@@ -150,7 +151,7 @@ export function CartItemCard({ line, crew, onDecreaseQty, onIncreaseQty, onDelet
           </span>
 
           {/* Spec badges row */}
-          {line.item && <SpecBadges specs={line.item.specs as Record<string, unknown>} theme={crew.theme} />}
+          {line.item && <SpecBadges specs={line.item.rawSpecs} theme={crew.theme} />}
 
           {/* Price section — Buy price is THE BIGGEST text on the card + gold glow */}
           <div className="mt-2">

--- a/app/franchize/components/cart/SpecBadge.tsx
+++ b/app/franchize/components/cart/SpecBadge.tsx
@@ -1,3 +1,4 @@
+// app/franchize/components/cart/SpecBadge.tsx
 "use client";
 
 import type { FranchizeTheme } from "../../actions";
@@ -51,7 +52,7 @@ function extractSpecs(specs: Record<string, unknown> | undefined) {
   const colorVal = specs?.color ?? specs?.цвет ?? null;
   return {
     power: String(specs?.power_kw ?? specs?.power ?? "—") + " кВт",
-    battery: String(specs?.battery_label ?? `${specs?.battery_v ?? ""}V ${specs?.battery_ah ?? ""}Ah`),
+    battery: String(specs?.battery_label ?? specs?.battery ?? `${specs?.battery_v ?? ""}V ${specs?.battery_ah ?? ""}Ah`),
     range: "до " + String(specs?.range_km ?? specs?.range ?? "—") + " км",
     color: colorVal ? String(colorVal) : null,
   };


### PR DESCRIPTION
Screenshot confirms the bug: badges show `— кВт`, `V Ah`, `до — км` — all empty. Let me trace the data flow to find why specs aren't reaching `extractSpecs`. Found the root cause! Two bugs:

1. **`CartItemCard.tsx`** passes `line.item.specs` (a transformed **array**) instead of `line.item.rawSpecs` (the raw JSONB record). The `as Record<string, unknown>` cast silences TypeScript but at runtime it's an array → `specs?.power_kw` is always `undefined`.

2. **`extractSpecs`** doesn't handle the `battery` key that actually exists in the data.

Let me fix all three issues:
Now let me apply both fixes — the CartItemCard bug and the SpecBadge `battery` key: Now fix `extractSpecs` to handle the `battery` key: Now fix the Sequence Zero rent price label from "per hour" to "per day": Now let me check if there's also a `CartItemCard.tsx` in the other directory that needs the same fix: Let me also check if there's a SpecBadge.tsx in the project code that needs the battery fix too: All fixes applied. Here's the summary:

---

### 3 Fixes Applied

| # | What | File(s) | Change |
|---|------|---------|--------|
| 🔴 1 | **Cart spec badges empty** | `CartItemCard.tsx` (×2 copies) | `line.item.specs as Record<string, unknown>` → `line.item.rawSpecs` | | 🟡 2 | **Battery spec not extracted** | `SpecBadge.tsx` (×2 copies + upload) | Added `specs?.battery ??` fallback before the `V/Ah` template | | 🟡 3 | **Sequence Zero price label** | CSV data | `15 000 ₽/час` → `15 000 ₽/день` |

### Root Cause

The `CatalogItemVM` type has **two** specs fields:
- `specs: Array<{ label: string; value: string }>` — a transformed display array (for spec tables)
- `rawSpecs?: Record<string, unknown>` — the original JSONB record (for badge extraction)

`CartItemCard` was passing `specs` (the array) to `SpecBadges`, which expects a `Record<string, unknown>`. The `as` cast silenced TypeScript but at runtime `specs?.power_kw` on an array is always `undefined` → all badges showed `—`. Fixed by using `rawSpecs` instead (which already has the correct type, no cast needed).
