### PR TITLE
Fix franchize buy Telegram share

### DIFF
--- a/app/franchize/components/SaleBikeLandingClient.tsx
+++ b/app/franchize/components/SaleBikeLandingClient.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ArrowLeft,
   Battery,
@@ -528,26 +528,68 @@ export function SaleBikeLandingClient({
   };
 
 
-  const handleShareBuyLink = () => {
-    const shareText = `Карточка ${item.title}: ${buyWebAppHref}`;
+  const handleShareBuyLink = useCallback(async () => {
+    const shareTitle = `Карточка ${item.title}`;
+    const shareText = `${shareTitle}: ${buyWebAppHref}`;
+    const shareUrl = `https://t.me/share/url?url=${encodeURIComponent(buyWebAppHref)}&text=${encodeURIComponent(shareTitle)}`;
 
-    if (tg?.switchInlineQuery) {
-      tg.switchInlineQuery(shareText, ["users", "groups", "channels"]);
-      return;
+    tg?.HapticFeedback?.impactOccurred?.("light");
+
+    const openTelegramShare = () => {
+      if (tg?.openTelegramLink) {
+        tg.openTelegramLink(shareUrl);
+        return true;
+      }
+
+      if (tg?.openLink) {
+        tg.openLink(shareUrl);
+        return true;
+      }
+
+      if (typeof window !== "undefined") {
+        window.open(shareUrl, "_blank", "noopener,noreferrer");
+        return true;
+      }
+
+      return false;
+    };
+
+    try {
+      // Native `switchInlineQuery` silently depends on bot inline-mode support,
+      // so prefer Telegram's share URL first: it opens the chat picker for any bot.
+      if (openTelegramShare()) {
+        setCartMessage("Открыли Telegram-отправку карточки. Выберите чат для ссылки.");
+        return;
+      }
+    } catch (error) {
+      console.warn("buy/share telegram link failed", error);
     }
 
-    const shareUrl = `https://t.me/share/url?url=${encodeURIComponent(buyWebAppHref)}&text=${encodeURIComponent(`Карточка ${item.title}`)}`;
-    if (tg?.openTelegramLink) {
-      tg.openTelegramLink(shareUrl);
-      return;
-    }
-    if (tg?.openLink) {
-      tg.openLink(shareUrl);
-      return;
+    try {
+      if (typeof navigator !== "undefined" && navigator.share) {
+        await navigator.share({ title: shareTitle, text: shareText, url: buyWebAppHref });
+        setCartMessage("Ссылка на карточку отправлена через системное меню.");
+        return;
+      }
+    } catch (error) {
+      console.warn("buy/share native menu failed", error);
     }
 
-    window.open(shareUrl, "_blank", "noopener,noreferrer");
-  };
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(shareText);
+        setCartMessage("Ссылка скопирована. Вставьте её в нужный Telegram-чат.");
+        tg?.showPopup?.({
+          title: "Ссылка скопирована",
+          message: "Вставьте её в нужный Telegram-чат.",
+          buttons: [{ type: "ok" }],
+        });
+      }
+    } catch (error) {
+      console.warn("buy/share clipboard fallback failed", error);
+      setCartMessage("Не удалось открыть отправку. Скопируйте ссылку из адресной строки.");
+    }
+  }, [buyWebAppHref, item.title, tg]);
 
   const handlePrintBuySheet = async () => {
     setPrintState("loading");

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -49,6 +49,16 @@ This root file stays intentionally compact so operators and agents can load it q
 ## 2) Mini execution diary
 
 
+
+### 2026-05-29 — Telegram buy share button repair
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-29T00:00:00Z
+- `owner`: codex
+- `notes`: Executed explicit operator scope: repaired the `/franchize/{slug}/market/{bike_id}/buy` share CTA by routing the button through Telegram's `t.me/share/url` chat picker first instead of inline-query mode, and added native share plus clipboard/popup fallbacks so the button gives visible recovery feedback when a Telegram client blocks opening.
+- `next_step`: Smoke `/franchize/vip-bike/market/<bike_id>/buy` inside Telegram WebApp and confirm the button opens chat selection with the `buy_<bikeId>` WebApp link.
+- `risks`: Final confirmation still depends on a live Telegram client because local browser smoke cannot emulate Telegram's native share bridge.
+
 ### 2026-05-14 — Telegram buy print/share capability polish
 
 - `status`: ready_for_pr


### PR DESCRIPTION
### Motivation
- The franchize buy-page "Поделиться" CTA could become non-functional when the bot lacks inline-mode or when Telegram client blocks inline-query flows, resulting in a dead/quiet button for users.
- Improve resilience and user feedback by preferring a universal Telegram chat-picker URL and adding progressive fallbacks for non-Telegram environments.

### Description
- Updated `app/franchize/components/SaleBikeLandingClient.tsx` to use `useCallback` and a new `handleShareBuyLink` that opens `https://t.me/share/url?url=...` first, instead of relying on `switchInlineQuery` (which can silently fail). 
- Added fallback flows: `tg.openTelegramLink` / `tg.openLink`, `window.open`, native Web Share (`navigator.share`), clipboard copy via `navigator.clipboard.writeText`, Telegram `showPopup` feedback, and light haptic call where available.
- Minor import update to include `useCallback` and replaced the old handler wiring so the existing button stays in place but now routes through the resilient handler.
- Recorded the change in `docs/THE_FRANCHEEZEPLAN.md` under the mini execution diary for traceability.

### Testing
- Ran lint on the modified file with `npx eslint --max-warnings=0 app/franchize/components/SaleBikeLandingClient.tsx` which succeeded.
- Ran the franchize typecheck via `npm run typecheck:franchize` which failed due to a pre-existing type error in `app/franchize/components/FranchizeProfileButton.tsx` unrelated to these edits, so typecheck could not fully complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197c8cc2e08322a114b05efb512ce9)