### PR TITLE
fix(franchize): treat same-site footer/header links as internal SPA links

### DIFF
--- a/app/franchize/components/CrewFooter.tsx
+++ b/app/franchize/components/CrewFooter.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { ChevronRight, MapPin, Phone, Send } from "lucide-react";
 import type { FranchizeCrewVM } from "../actions";
-import { isExternalHref } from "../lib/navigation";
+import { toInternalHref } from "../lib/navigation";
 import { readablePaletteTextOnColor, withAlpha } from "../lib/theme";
 
 interface CrewFooterProps {
@@ -61,13 +61,13 @@ export function CrewFooter({ crew }: CrewFooterProps) {
           </h3>
           <ul className="mt-3 space-y-1 text-sm">
             {crew.header.menuLinks.map((link) => {
-              const isExternal = isExternalHref(link.href);
+              const internalHref = toInternalHref(link.href);
               return (
                 <li
                   key={`${link.href}-${link.label}`}
                   className="border-b border-[var(--footer-border)]"
                 >
-                  {isExternal ? (
+                  {internalHref === null ? (
                     <a
                       href={link.href}
                       className="flex items-center gap-2 py-2 transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
@@ -80,7 +80,7 @@ export function CrewFooter({ crew }: CrewFooterProps) {
                     </a>
                   ) : (
                     <Link
-                      href={link.href}
+                      href={internalHref}
                       className="flex items-center gap-2 py-2 hover:opacity-90 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
                     >
                       <ChevronRight className="h-4 w-4" />

--- a/app/franchize/lib/navigation.ts
+++ b/app/franchize/lib/navigation.ts
@@ -1,3 +1,55 @@
+const APP_HOSTS = new Set(["v0-car-test.vercel.app"]);
+
+function currentAppHost() {
+  if (typeof window !== "undefined") {
+    return window.location.host;
+  }
+
+  return undefined;
+}
+
+function configuredAppHost() {
+  const configuredUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (!configuredUrl) return undefined;
+
+  try {
+    return new URL(configuredUrl).host;
+  } catch {
+    return undefined;
+  }
+}
+
+function knownAppHosts() {
+  return new Set([currentAppHost(), configuredAppHost(), ...APP_HOSTS].filter(Boolean) as string[]);
+}
+
 export const toCategoryId = (category: string) => `category-${category.trim().toLowerCase().replace(/\s+/g, "-")}`;
 
-export const isExternalHref = (href: string) => /^https?:\/\//.test(href);
+export function toInternalHref(href: string) {
+  const value = href.trim();
+
+  if (!value || value.startsWith("#")) {
+    return value;
+  }
+
+  if (value.startsWith("/") && !value.startsWith("//")) {
+    return value;
+  }
+
+  if (!/^https?:\/\//i.test(value)) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    if (knownAppHosts().has(url.host)) {
+      return `${url.pathname}${url.search}${url.hash}`;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export const isExternalHref = (href: string) => toInternalHref(href) === null;

--- a/app/franchize/modals/HeaderMenu.tsx
+++ b/app/franchize/modals/HeaderMenu.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { FranchizeCrewVM } from "../actions";
+import { toInternalHref } from "../lib/navigation";
 import { crewPaletteForSurface } from "../lib/theme";
 
 interface HeaderMenuProps {
@@ -115,11 +116,36 @@ export function HeaderMenu({ crew, activePath, open, onOpenChange }: HeaderMenuP
 
         <div className="space-y-2">
           {crew.header.menuLinks.map((link) => {
-            const isActive = activePath === link.href;
+            const internalHref = toInternalHref(link.href);
+            const normalizedHref = internalHref ?? link.href;
+            const isActive = activePath === normalizedHref;
+            const linkClassName = `w-full text-left block rounded-xl border px-4 py-3 text-sm no-underline transition cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--header-menu-accent)] ${
+              isActive
+                ? "border-[var(--header-menu-accent)] text-[var(--header-menu-accent)]"
+                : "border-[var(--header-menu-border)] text-[var(--header-menu-text)]"
+            }`;
+
+            if (internalHref === null) {
+              return (
+                <a
+                  key={`${link.href}-${link.label}`}
+                  href={link.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() => onOpenChange(false)}
+                  className={linkClassName}
+                  style={{ textDecoration: "none" }}
+                  aria-label={`${link.label} (откроется в новой вкладке)`}
+                >
+                  {link.label}
+                </a>
+              );
+            }
+
             return (
               <Link
                 key={`${link.href}-${link.label}`}
-                href={link.href}
+                href={internalHref}
                 onClick={(e) => {
                   // ── FIX v6: Always close menu + let Link navigate ──
                   // v5 tried: "don't close menu for regular links, let pathname
@@ -137,19 +163,15 @@ export function HeaderMenu({ crew, activePath, open, onOpenChange }: HeaderMenuP
                   // batch, so they don't conflict.
                   //
                   // For hash links, prevent default and scroll manually.
-                  if (link.href.startsWith("#")) {
+                  if (internalHref.startsWith("#")) {
                     e.preventDefault();
-                    const target = document.querySelector(link.href);
+                    const target = document.querySelector(internalHref);
                     target?.scrollIntoView({ behavior: "smooth", block: "start" });
                   }
                   onOpenChange(false);
                 }}
                 aria-current={isActive ? "page" : undefined}
-                className={`w-full text-left block rounded-xl border px-4 py-3 text-sm no-underline transition cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--header-menu-accent)] ${
-                  isActive
-                    ? "border-[var(--header-menu-accent)] text-[var(--header-menu-accent)]"
-                    : "border-[var(--header-menu-border)] text-[var(--header-menu-text)]"
-                }`}
+                className={linkClassName}
                 style={{ textDecoration: "none" }}
               >
                 {link.label}


### PR DESCRIPTION
### Motivation

- Prevent franchise footer/menu links from opening a new window or performing a hard reload when they point to the same app, and make mobile/header menu behavior consistent with the footer.

### Description

- Add `toInternalHref` URL normalization to `app/franchize/lib/navigation.ts` that recognizes relative, hash, and same-site absolute URLs (including `NEXT_PUBLIC_SITE_URL` and current host) and returns an internal path when appropriate.
- Update `app/franchize/components/CrewFooter.tsx` to use `toInternalHref` so same-site links render as Next.js `<Link>` SPA navigation while true external links remain `<a target="_blank">`.
- Update `app/franchize/modals/HeaderMenu.tsx` to apply the same normalization and behavior in the mobile/header menu, including correct active-path matching and smooth scroll for hash links.
- Small UX safety: external links preserve `target="_blank" rel="noreferrer"` and internal links use normalized paths for SPA navigation.

### Testing

- Ran `npx eslint --max-warnings=0 app/franchize/lib/navigation.ts app/franchize/components/CrewFooter.tsx app/franchize/modals/HeaderMenu.tsx`, which succeeded.
- Ran `npm run lint:target`, which failed due to pre-existing unrelated lint errors in `app/franchize/[slug]/components/VipBikeRentalClient-integration.tsx` (undefined JSX identifiers), so full-target lint could not be completed here.
- Ran `npm run typecheck:franchize`, which failed due to an unrelated existing TypeScript error in `app/franchize/components/FranchizeProfileButton.tsx` (missing `override` modifier), so typecheck of the whole franchize slice could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19872901088322ad7696d65bfe249d)