### PR TITLE
Save renter secrets on contract generation and fix admin rentals fallbacks

### DIFF
--- a/app/franchize/actions-runtime.ts
+++ b/app/franchize/actions-runtime.ts
@@ -14,6 +14,7 @@ import { cloneFranchizeContentBlocks, readFranchizeContentBlocks, type Franchize
 import { resolveFranchizeTheme, resolvePaletteByMode } from "@/app/franchize/lib/theme-resolver";
 import { isTrustedTelegramBypassDeployment } from "@/lib/telegram-bypass-context";
 import { computeTelegramWebAppHash } from "@/lib/telegram-webapp-auth";
+import { CURRENT_RENTAL_TEMPLATE_VERSION } from "@/lib/rental-template-version";
 import type { FranchizeTheme } from "@/lib/franchize-config";
 import {
   DEFAULT_AD_CARDS_TEXT,
@@ -1943,6 +1944,8 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
       last_error: "",
     });
 
+    let sourceRentalId: string | null = null;
+
     if (flowType === "rental") {
       const { data: rentalRow, error: rentalLookupError } = await supabaseAdmin
         .from("rentals")
@@ -1966,6 +1969,7 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
           documentKey: variables.document_key,
         });
       } else {
+        sourceRentalId = String(rentalRow.rental_id);
         const existingMetadata =
           rentalRow.metadata && typeof rentalRow.metadata === "object" ? (rentalRow.metadata as Record<string, unknown>) : {};
         const rentalScope = `rental:${rentalRow.rental_id}`;
@@ -1996,6 +2000,32 @@ async function buildFranchizeOrderDocAndNotify(payload: FranchizeOrderNotifyPayl
           });
         }
       }
+    }
+
+    try {
+      const { saveUserRentalSecrets } = await import("@/app/lib/user-rental-secrets");
+      await saveUserRentalSecrets({
+        chat_id: payload.telegramUserId,
+        crew_slug: payload.slug,
+        doc_sha256: sha256,
+        renter_full_name: variables.renter_full_name,
+        renter_passport: variables.renter_passport,
+        renter_driver_license: variables.renter_driver_license,
+        renter_birth_date: variables.renter_birth_date,
+        renter_phone: variables.renter_phone,
+        renter_email: variables.renter_email,
+        renter_address: null,
+        source_doc_key: variables.document_key,
+        source_rental_id: sourceRentalId,
+        verification_status: "verified",
+        template_version: CURRENT_RENTAL_TEMPLATE_VERSION,
+      });
+    } catch (error) {
+      logger.error("[buildFranchizeOrderDocAndNotify] failed to save rental secrets", {
+        slug: payload.slug,
+        orderId: payload.orderId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
     }
 
     return { renderedMarkdown, docFileName };
@@ -2238,7 +2268,7 @@ export async function getFranchizeSuccessfulRentals(input: unknown): Promise<{ s
 
   const { data, error } = await supabaseAdmin
     .from("rentals")
-    .select("rental_id, user_id, vehicle_id, status, requested_start_date, requested_end_date, agreed_start_date, agreed_end_date, created_at, metadata, vehicle:cars!inner(id, make, model, crew_id)")
+    .select("rental_id, user_id, vehicle_id, status, requested_start_date, requested_end_date, agreed_start_date, agreed_end_date, created_at, metadata, vehicle:cars!inner(id, make, model, crew_id), user:users(user_id, full_name, username, metadata)")
     .eq("vehicle.crew_id", crew.id)
     .in("status", ["confirmed", "active", "completed"])
     .order("created_at", { ascending: false })
@@ -2250,27 +2280,49 @@ export async function getFranchizeSuccessfulRentals(input: unknown): Promise<{ s
     success: true,
     items: ((data ?? []) as UnknownRecord[]).map((row) => {
       const vehicle = (Array.isArray(row.vehicle) ? row.vehicle[0] : row.vehicle) as UnknownRecord | undefined;
+      const user = (Array.isArray(row.user) ? row.user[0] : row.user) as UnknownRecord | undefined;
       const metadata = (row.metadata && typeof row.metadata === "object" ? row.metadata : {}) as UnknownRecord;
+      const userMetadata = (user?.metadata && typeof user.metadata === "object" ? user.metadata : {}) as UnknownRecord;
+      const franchizeFormPrefill = (userMetadata.franchizeFormPrefill && typeof userMetadata.franchizeFormPrefill === "object"
+        ? userMetadata.franchizeFormPrefill
+        : {}) as UnknownRecord;
+      const slugPrefill = (franchizeFormPrefill[normalizeCrewSlug(slug)] && typeof franchizeFormPrefill[normalizeCrewSlug(slug)] === "object"
+        ? franchizeFormPrefill[normalizeCrewSlug(slug)]
+        : {}) as UnknownRecord;
       const verifier = (metadata.contract_verifier && typeof metadata.contract_verifier === "object" ? metadata.contract_verifier : {}) as UnknownRecord;
       const contractStatus = typeof verifier.status === "string" && verifier.status.trim() ? verifier.status.trim() : "none";
       const bikeName = `${typeof vehicle?.make === "string" ? vehicle.make : ""} ${typeof vehicle?.model === "string" ? vehicle.model : ""}`.trim();
+      const fallbackUserId = String(row.user_id ?? "").trim();
+      const renterNameCandidates = [
+        metadata.renter_full_name,
+        metadata.recipientName,
+        metadata.recipient,
+        metadata.customerName,
+        user?.full_name,
+        userMetadata.display_name,
+        slugPrefill.fullName,
+        user?.username,
+      ];
       const renterName =
-        typeof metadata.renter_full_name === "string" && metadata.renter_full_name.trim()
-          ? metadata.renter_full_name.trim()
-          : typeof metadata.recipientName === "string" && metadata.recipientName.trim()
-            ? metadata.recipientName.trim()
-            : typeof metadata.customerName === "string" && metadata.customerName.trim()
-              ? metadata.customerName.trim()
-              : String(row.user_id ?? "");
+        renterNameCandidates.find((value) => typeof value === "string" && value.trim()) as string | undefined;
+      const displayRenterName = renterName?.trim() || (fallbackUserId ? `Пользователь #${fallbackUserId}` : "");
+      const startDate = typeof row.agreed_start_date === "string" ? row.agreed_start_date
+        : typeof row.requested_start_date === "string" ? row.requested_start_date
+          : typeof metadata.rentalStartDate === "string" ? metadata.rentalStartDate
+            : null;
+      const endDate = typeof row.agreed_end_date === "string" ? row.agreed_end_date
+        : typeof row.requested_end_date === "string" ? row.requested_end_date
+          : typeof metadata.rentalEndDate === "string" ? metadata.rentalEndDate
+            : null;
 
       return {
         rentalId: String(row.rental_id ?? ""),
         status: String(row.status ?? ""),
         bikeId: String(row.vehicle_id ?? ""),
         bikeName: bikeName || String(row.vehicle_id ?? "Техника"),
-        renterName: renterName || "Арендатор не указан",
-        startDate: typeof row.agreed_start_date === "string" ? row.agreed_start_date : typeof row.requested_start_date === "string" ? row.requested_start_date : null,
-        endDate: typeof row.agreed_end_date === "string" ? row.agreed_end_date : typeof row.requested_end_date === "string" ? row.requested_end_date : null,
+        renterName: displayRenterName || "Арендатор не указан",
+        startDate,
+        endDate,
         createdAt: String(row.created_at ?? ""),
         contractStatus,
       };

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -48,6 +48,15 @@ This root file stays intentionally compact so operators and agents can load it q
 
 ## 2) Mini execution diary
 
+### 2026-05-31 — VIP Bike 1-click next rent Task D/M
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-05-31T00:00:00Z
+- `owner`: codex
+- `notes`: Wired rental contract generation paths to persist verified renter identity snapshots into `private.user_rental_secrets` using the shared rental template version, and fixed successful-rent admin fallbacks for renter display names plus webhook metadata dates.
+- `next_step`: Continue with QR/deep-link auto-fill tasks after this save path lands.
+- `risks`: Skill-script identity save uses a direct private-schema fallback when Node cannot load the Next.js TypeScript server module at runtime.
+
 ### 2026-05-29 — VIPBikeRental Bike Showcase full-bleed restore
 
 - `status`: ready_for_pr

--- a/docs/TODO-1-click-next-rent.md
+++ b/docs/TODO-1-click-next-rent.md
@@ -116,17 +116,18 @@
 > **Complexity**: M
 > **Depends on**: Task C ✅
 
-- [ ] **Skill script** (`make-rental-contract-skill.mjs`):
-  - [ ] After successful DOCX generation + SHA256, insert row into `private.user_rental_secrets`
-  - [ ] Extract renter fields from the same data used to fill template variables
-  - [ ] Set `verification_status = 'verified'` (doc was just generated and sent)
-  - [ ] Set `template_version` from current template version constant
+- [x] **Skill script** (`make-rental-contract-skill.mjs`):
+  - [x] After successful DOCX generation + SHA256, insert row into `private.user_rental_secrets`
+  - [x] Extract renter fields from the same data used to fill template variables
+  - [x] Set `verification_status = 'verified'` (doc was just generated and sent)
+  - [x] Set `template_version` from current template version constant
 
-- [ ] **Web-app pipeline** (`buildFranchizeOrderDocAndNotify`):
-  - [ ] Same insert logic after successful doc generation
-  - [ ] Read renter data from `userSensitive` + payload fields
+- [x] **Web-app pipeline** (`buildFranchizeOrderDocAndNotify`):
+  - [x] Same insert logic after successful doc generation
+  - [x] Read renter data from `userSensitive` + payload fields
 
-- [ ] **Future preparation**: design insert to work for batch imports (digitize old docs workflow)
+- [x] **Future preparation**: design insert to work for batch imports (digitize old docs workflow)
+- [x] **Shared template version**: `CURRENT_RENTAL_TEMPLATE_VERSION` constant defined for contract save paths
 
 ---
 
@@ -250,11 +251,11 @@
 > **Complexity**: S
 > **Depends on**: nothing (bug fixes in existing code)
 
-- [ ] **Bug 1 — renter name fallback**: `metadata.renter_full_name` is null for web-app rentals → add fallback to `metadata.recipientName` + join `users` table for actual name
+- [x] **Bug 1 — renter name fallback**: `metadata.renter_full_name` is null for web-app rentals → add fallback to `metadata.recipientName` + join `users` table for actual name
   - Current code: `metadata.renter_full_name` → `metadata.recipientName` → `metadata.customerName` → `row.user_id`
   - Fix: also try `users.display_name` or `users.metadata.franchizeFormPrefill[slug].fullName` via user_id join
 
-- [ ] **Bug 2 — missing date fallback**: `agreed_start_date` / `requested_start_date` are null for payment-webhook rentals → add fallback to `metadata.rentalStartDate` / `metadata.rentalEndDate`
+- [x] **Bug 2 — missing date fallback**: `agreed_start_date` / `requested_start_date` are null for payment-webhook rentals → add fallback to `metadata.rentalStartDate` / `metadata.rentalEndDate`
   - Current code: `agreed_start_date` → `requested_start_date` → null
   - Fix: `agreed_start_date` → `requested_start_date` → `metadata.rentalStartDate` → null
 

--- a/lib/rental-template-version.ts
+++ b/lib/rental-template-version.ts
@@ -1,0 +1,1 @@
+export const CURRENT_RENTAL_TEMPLATE_VERSION = 1;

--- a/scripts/make-rental-contract-skill.mjs
+++ b/scripts/make-rental-contract-skill.mjs
@@ -11,6 +11,19 @@ function arg(name, fallback = '') { const i = process.argv.indexOf(`--${name}`);
 const RENTAL_DOC_TEMPLATE_MODE = String(process.env.RENTAL_DOC_TEMPLATE_MODE || 'md').trim().toLowerCase();
 const RENTAL_DOC_BASELINE_TEMPLATE_PATH = 'docs/RENTAL_DEAL_TEMPLATE.md';
 const RENTAL_DOC_HTML_TEMPLATE_PATH = 'docs/RENTAL_DEAL_TEMPLATE.html';
+const RENTAL_TEMPLATE_VERSION_PATH = 'lib/rental-template-version.ts';
+
+function readCurrentRentalTemplateVersion() {
+  try {
+    const source = readFileSync(RENTAL_TEMPLATE_VERSION_PATH, 'utf8');
+    const match = source.match(/CURRENT_RENTAL_TEMPLATE_VERSION\s*=\s*(\d+)/);
+    return match ? Number(match[1]) : 1;
+  } catch {
+    return 1;
+  }
+}
+
+const CURRENT_RENTAL_TEMPLATE_VERSION = readCurrentRentalTemplateVersion();
 
 function renderTemplateWithVars(template, vars) {
   return template.replace(/{{\s*([a-zA-Z0-9_]+)\s*}}/g, (_,k)=> String(vars[k] ?? ''));
@@ -103,7 +116,7 @@ const supabaseRestSelect = (from, to) => {
     throw new Error('Supabase env is missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
   }
 
-  const url = `${baseUrl}/rest/v1/cars?select=id,make,model,specs,type&type=in.(bike,ebike)&offset=${from}&limit=${to - from + 1}`;
+  const url = `${baseUrl}/rest/v1/cars?select=id,make,model,specs,type,crew_id&type=in.(bike,ebike)&offset=${from}&limit=${to - from + 1}`;
   const curl = spawnSync('curl', ['-sS', url, '-H', `apikey: ${serviceKey}`, '-H', `Authorization: Bearer ${serviceKey}`], {
     encoding: 'utf8',
   });
@@ -145,7 +158,7 @@ const fetchAllBikeCandidates = async () => {
     try {
       const response = await supabase
         .from('cars')
-        .select('id,make,model,specs,type')
+        .select('id,make,model,specs,type,crew_id')
         .in('type', ['bike', 'ebike'])
         .range(from, to);
       data = response.data;
@@ -178,6 +191,18 @@ const ranked = bikes.map(b => ({ bike: b, score: scoreBike(bikeId, b) })).sort((
 const top = ranked[0];
 if (!top || top.score <= 0) failStage('bike_resolve', 'bike_not_found', { bikeQuery: bikeId });
 const bike = top.bike;
+let resolvedCrewSlug = arg('crewSlug', '');
+if (!resolvedCrewSlug && bike.crew_id) {
+  const { data: crewSlugRow, error: crewSlugError } = await supabase
+    .from('crews')
+    .select('slug')
+    .eq('id', bike.crew_id)
+    .maybeSingle();
+  if (crewSlugError) {
+    console.warn(`[make-rental-contract-skill] failed to resolve crew slug: ${crewSlugError.message}`);
+  }
+  resolvedCrewSlug = String(crewSlugRow?.slug || '').trim();
+}
 
 const mdTemplate = readFileSync(RENTAL_DOC_BASELINE_TEMPLATE_PATH, 'utf8');
 const now = new Date();
@@ -290,6 +315,7 @@ const vars = {
   renter_birth_date: renterBirthDate,
   renter_phone: passportJson.phone || '',
   renter_email: passportJson.email || '',
+  renter_address: passportJson.address || passportJson.registration || '',
   renter_driver_license: `${renterLicenseSeries} ${renterLicenseNumber}`.trim(),
   renter_passport: `${renterPassportSeries} ${renterPassportNumber}`.trim(),
   bike_make_model: `${bike.make||''} ${bike.model||''}`.trim(),
@@ -458,6 +484,43 @@ if (saveMetadata) {
   }
   result.metadataVerified = true;
   result.metadataTable = metadataTable;
+}
+
+const rentalSecretsPayload = {
+  chat_id: telegramChatId,
+  crew_slug: resolvedCrewSlug,
+  doc_sha256: originalSha256,
+  renter_full_name: vars.renter_full_name,
+  renter_passport: vars.renter_passport,
+  renter_driver_license: vars.renter_driver_license,
+  renter_birth_date: vars.renter_birth_date,
+  renter_phone: vars.renter_phone,
+  renter_email: vars.renter_email,
+  renter_address: vars.renter_address || null,
+  source_doc_key: vars.document_key,
+  source_rental_id: null,
+  verification_status: 'verified',
+  template_version: CURRENT_RENTAL_TEMPLATE_VERSION,
+};
+
+try {
+  const { saveUserRentalSecrets } = await import('../app/lib/user-rental-secrets.ts');
+  const saved = await saveUserRentalSecrets(rentalSecretsPayload);
+  if (!saved) throw new Error('saveUserRentalSecrets returned null');
+  result.rentalSecretsSaved = true;
+} catch (err) {
+  try {
+    const { error: fallbackError } = await supabase
+      .schema('private')
+      .from('user_rental_secrets')
+      .insert({ ...rentalSecretsPayload, updated_at: new Date().toISOString() });
+    if (fallbackError) throw fallbackError;
+    result.rentalSecretsSaved = true;
+    result.rentalSecretsSaveFallback = true;
+  } catch (fallbackErr) {
+    console.error('[make-rental-contract-skill] failed to save rental secrets:', fallbackErr?.message || fallbackErr, 'primary:', err?.message || err);
+    result.rentalSecretsSaved = false;
+  }
 }
 
 console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
### Motivation

- Persist verified renter identity snapshots when contracts are generated to enable QR/deep-link autofill and downstream VIP workflows.
- Use a shared template version token so saved identities can be tied to a contract template and enable re-sign/version detection.
- Fix admin-facing display issues so renter names and rental dates render sensibly for both web-app and payment-webhook-created rentals.

### Description

- Add `lib/rental-template-version.ts` with `CURRENT_RENTAL_TEMPLATE_VERSION = 1` as the shared template version constant.
- In `app/franchize/actions-runtime.ts` compute `sourceRentalId` when possible and, after successful DOCX generation + verifier metadata update, call `saveUserRentalSecrets` (dynamic import) to persist renter data with `verification_status='verified'` and `template_version`, while logging errors non-blockingly.
- Update `scripts/make-rental-contract-skill.mjs` to read the template version, include `crew_id` in car lookups and resolve `crew_slug`, add `renter_address` into template vars, and persist secrets via `saveUserRentalSecrets` with a fallback direct insert to the `private` schema; all saves are non-blocking and report fallback state in the script result.
- Fix `getFranchizeSuccessfulRentals` by selecting `user:users(...)` in the query, improving renter name fallback chain (include `user.full_name`, `user.metadata.franchizeFormPrefill[slug].fullName`, `user.metadata.display_name`, username and a prefixed fallback) and adding tertiary fallbacks for `startDate`/`endDate` from `metadata.rentalStartDate`/`metadata.rentalEndDate`.
- Update tracking docs: checked off Task D/M items in `docs/TODO-1-click-next-rent.md` and appended a diary entry in `docs/THE_FRANCHEEZEPLAN.md` describing the change.

### Testing

- Ran `npm run lint -- --file app/franchize/actions-runtime.ts` and it completed with no ESLint warnings (passed). 
- Ran `node --check scripts/make-rental-contract-skill.mjs` for basic syntax validation of the skill script and it returned OK (passed).
- Ran `npm run typecheck:franchize` which failed due to an existing unrelated TypeScript error in `app/franchize/components/FranchizeProfileButton.tsx` (pre-existing, not caused by these changes).
- Ran a full `npx tsc --noEmit --project tsconfig.json` which surfaced many pre-existing repository type errors unrelated to this PR (typecheck blocked by repo-wide issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c89fd08c0832592fff8425dc7942b)