### PR TITLE
fix(map-riders): prevent hidden background content stealing gestures & unblock sharing for authenticated users

### DIFF
--- a/app/api/map-riders/_lib/crew-access.ts
+++ b/app/api/map-riders/_lib/crew-access.ts
@@ -19,17 +19,8 @@ export async function assertCrewMembership(userId: string, crewSlug: string) {
     return true;
   }
 
-  const { data: member, error } = await supabaseAdmin
-    .from("crew_members")
-    .select("id")
-    .eq("user_id", userId)
-    .eq("crew_id", crew.id)
-    .eq("membership_status", "active")
-    .maybeSingle();
-
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  return Boolean(member);
+  // MapRiders sharing is available to any authenticated rider.
+  // Crew membership still influences visibility mode (crew/public),
+  // but is no longer a hard gate for starting a session.
+  return true;
 }

--- a/components/map-riders/MapRidersClientRefactored.tsx
+++ b/components/map-riders/MapRidersClientRefactored.tsx
@@ -357,7 +357,7 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
 
   return (
     <div
-      className="relative min-h-[100dvh] w-full pb-24 pt-16 md:pt-20"
+      className="fixed inset-0 isolate h-[100dvh] w-full overflow-hidden"
       style={{
         ["--mr-accent" as string]: crew.theme.palette.accentMain,
         ["--mr-accent-hover" as string]: crew.theme.palette.accentMainHover,
@@ -367,8 +367,6 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
         ["--mr-muted" as string]: crew.theme.palette.textSecondary,
       }}
     >
-      <BeginnerRiderOnboardingQuiz crew={crew} />
-
       {/* ── MAP (fullscreen background) ── */}
       <section className="fixed inset-0 overflow-hidden [touch-action:pan-x_pan-y_pinch-zoom]" style={{ borderColor: `${crew.theme.palette.borderSoft}aa` }}>
         <div className="absolute inset-0 z-0">
@@ -491,7 +489,9 @@ function MapRidersInner({ crew }: { crew: FranchizeCrewVM }) {
               </div>
             </div>
             <div className={`mx-auto max-h-[82dvh] w-full max-w-6xl overflow-y-auto pb-[calc(8.5rem+env(safe-area-inset-bottom))] [touch-action:pan-y] ${activeSnap <= 0.2 ? "pointer-events-none opacity-70" : "pointer-events-auto opacity-100"}`}>
-              <div className="grid gap-3 lg:grid-cols-[1.35fr,1fr]">
+              <BeginnerRiderOnboardingQuiz crew={crew} />
+              <div className="mt-3 grid gap-3 lg:grid-cols-[1.35fr,1fr]">
+
         {/* Stats card */}
         <div className="rounded-2xl border p-4 backdrop-blur-xl" style={{ ...surface.subtleCard, borderColor: "var(--mr-border)" }}>
           <Badge className="mb-3 w-fit border" style={{ borderColor: `${crew.theme.palette.accentMain}55`, backgroundColor: `${crew.theme.palette.accentMain}18`, color: crew.theme.palette.accentMain }}>


### PR DESCRIPTION
### Motivation
- Prevent an invisible page layer under the map from intercepting touch gestures in Telegram WebApp and causing swipe-down app collapse.
- Stop the large onboarding block from rendering underneath the fullscreen map where it can affect pointer/touch behavior.
- Allow authenticated riders to start/share sessions without being blocked by strict crew membership checks that surfaced `Join crew to start sharing`.

### Description
- Changed MapRiders root container to a fixed full-viewport layout with `overflow-hidden` to eliminate background scrollable content (`components/map-riders/MapRidersClientRefactored.tsx`).
- Moved `BeginnerRiderOnboardingQuiz` out of the top-level flow into the bottom-sheet drawer content so it no longer exists as an invisible DOM block beneath the map (`components/map-riders/MapRidersClientRefactored.tsx`).
- Relaxed the server-side crew membership gate in `app/api/map-riders/_lib/crew-access.ts` so any authenticated rider can share; removed the crew_members lookup that caused the hard-block and `Join crew to start sharing` error.

### Testing
- Ran lint with `npm run -s lint -- --file components/map-riders/MapRidersClientRefactored.tsx --file app/api/map-riders/_lib/crew-access.ts` and it completed with no ESLint warnings or errors.
- No additional automated unit/integration tests were executed for this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ed320cb4832aa4deb6cdfd54dae7)