### PR TITLE
Add Russian explainer page for rental-doc-by-photo workflow

### DIFF
--- a/app/rental-doc-workflow/page.tsx
+++ b/app/rental-doc-workflow/page.tsx
@@ -1,0 +1,239 @@
+import Link from "next/link";
+import {
+  ArrowRight,
+  Bike,
+  Bot,
+  CalendarClock,
+  CheckCircle2,
+  Clock3,
+  FileCheck2,
+  Image as ImageIcon,
+  LockKeyhole,
+  MessageCircle,
+  QrCode,
+  ShieldCheck,
+  Sparkles,
+  UserCheck,
+} from "lucide-react";
+
+const doneItems = [
+  "Договор собирается автоматически из сообщения оператора, фото паспорта и фото водительского удостоверения.",
+  "Мотоцикл ищется в базе по названию, ID или похожей фразе: например, «кавасаки» → нужный Kawasaki.",
+  "В договор подставляются данные байка, клиента, даты, цена, адрес и служебные поля передачи мотоцикла.",
+  "Готовый DOCX отправляется в Telegram без повторной отправки дублем.",
+  "К договору добавлен QR-код: клиент сканирует его и попадает в Telegram Mini App для следующей быстрой аренды.",
+  "Секретные данные арендатора вынесены в приватные таблицы, чтобы паспортные данные не светились в публичной части приложения.",
+  "Для байков уже есть уровни доступа: базовый, средний и pro — они нужны для будущего VIP-повтора без лишних проверок.",
+];
+
+const operatorSteps = [
+  {
+    title: "1. Отправьте команду",
+    text: "В Telegram/Slack пишем обычным языком: «создай документ на Kawasaki с 30.05 20:00 до 23:00, сумма 6000 ₽». Главное — назвать байк и период аренды.",
+    icon: MessageCircle,
+  },
+  {
+    title: "2. Приложите две фотографии",
+    text: "Нужны фото паспорта и водительского удостоверения. Если фото нечитаемое или не хватает даты аренды, система попросит уточнение, а не будет выдумывать данные.",
+    icon: ImageIcon,
+  },
+  {
+    title: "3. AI достаёт данные клиента",
+    text: "Из фото берутся ФИО, дата рождения, паспорт, адрес регистрации и номер водительского удостоверения. В публичные отчёты полные персональные данные не попадают.",
+    icon: UserCheck,
+  },
+  {
+    title: "4. Байк подтягивается из базы",
+    text: "Оператору не нужно вручную переписывать VIN, модель, госномер и характеристики. Система сама находит карточку мотоцикла и подставляет поля в договор.",
+    icon: Bike,
+  },
+  {
+    title: "5. Получите DOCX + QR",
+    text: "На выходе в Telegram приходит договор аренды и QR-код. DOCX можно печатать и подписывать, QR открывает путь к следующей аренде этого клиента.",
+    icon: FileCheck2,
+  },
+];
+
+const futureItems = [
+  {
+    status: "В работе",
+    title: "QR как вход в быструю повторную аренду",
+    text: "Скан QR должен открывать Mini App сразу с выбранным байком и проверенным документом, чтобы клиенту не приходилось снова фотографировать паспорт.",
+  },
+  {
+    status: "Запланировано",
+    title: "Команда /doc прямо в Telegram",
+    text: "Бот проведёт оператора по шагам: паспорт → права → подтверждение данных → выбор байка → срок → готовый договор.",
+  },
+  {
+    status: "Запланировано",
+    title: "OCR и ручная проверка",
+    text: "Фото документов будут распознаваться через OCR, а админ сможет быстро подтвердить или поправить результат перед сохранением.",
+  },
+  {
+    status: "Запланировано",
+    title: "VIP Club и уровни доступа",
+    text: "После первой проверенной аренды клиент получает уровень доступа. Чем выше уровень, тем больше мотоциклов доступно для повторной аренды без лишней бюрократии.",
+  },
+  {
+    status: "Исследование",
+    title: "NFC-активация",
+    text: "Дальняя идея: связать аренду, телефон и доступ к мотоциклу так, чтобы подтверждённая аренда превращалась в безопасный цифровой ключ.",
+  },
+];
+
+const simpleInputs = [
+  "фраза «создай документ» или «сделай договор»;",
+  "название байка или понятный намёк: Kawasaki, Ducati, Falcon и т.п.;",
+  "дата и время аренды: например, «с 20:00 до 23:00 30 мая»;",
+  "цена или условия, если они отличаются от стандартных;",
+  "фото паспорта;",
+  "фото водительского удостоверения, если оно нужно для выбранного байка.",
+];
+
+export default function RentalDocWorkflowPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-white">
+      <section className="relative overflow-hidden border-b border-white/10">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(34,211,238,0.24),_transparent_34%),radial-gradient(circle_at_top_right,_rgba(245,158,11,0.22),_transparent_32%)]" />
+        <div className="relative mx-auto max-w-6xl px-5 py-16 sm:px-8 lg:py-24">
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-300/10 px-4 py-2 text-sm font-semibold text-cyan-100">
+            <Sparkles className="h-4 w-4" />
+            Документы аренды по фото — понятная версия
+          </div>
+
+          <div className="grid gap-10 lg:grid-cols-[1.08fr_0.92fr] lg:items-center">
+            <div>
+              <h1 className="max-w-4xl text-4xl font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
+                Один текст, две фотки — и договор аренды готов
+              </h1>
+              <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
+                Эта страница объясняет человеческим языком, как работает новый поток VIP Bike Rental: оператор отправляет короткое сообщение, прикладывает фото документов, а система сама находит мотоцикл в базе, собирает DOCX и добавляет QR-код для следующей аренды.
+              </p>
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href="/vipbikerental"
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl bg-amber-400 px-6 py-3 font-bold text-slate-950 shadow-lg shadow-amber-500/20 transition hover:bg-amber-300"
+                >
+                  Открыть VIP Bike
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link
+                  href="/doc-verifier"
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/15 bg-white/5 px-6 py-3 font-bold text-white transition hover:bg-white/10"
+                >
+                  Проверка документа
+                  <ShieldCheck className="h-4 w-4" />
+                </Link>
+              </div>
+            </div>
+
+            <div className="rounded-[2rem] border border-white/10 bg-white/10 p-6 shadow-2xl shadow-cyan-950/40 backdrop-blur">
+              <div className="mb-5 flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-[0.24em] text-cyan-200">Что отправить</p>
+                  <h2 className="mt-2 text-2xl font-black">Минимальный вход</h2>
+                </div>
+                <Bot className="h-10 w-10 text-amber-300" />
+              </div>
+              <ul className="space-y-3">
+                {simpleInputs.map((item) => (
+                  <li key={item} className="flex gap-3 rounded-2xl bg-slate-950/60 p-4 text-slate-200">
+                    <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-emerald-300" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-5 py-14 sm:px-8">
+        <div className="mb-8 flex items-end justify-between gap-4">
+          <div>
+            <p className="text-sm font-bold uppercase tracking-[0.24em] text-amber-300">Рабочий сценарий</p>
+            <h2 className="mt-3 text-3xl font-black sm:text-4xl">Как это проходит на практике</h2>
+          </div>
+          <CalendarClock className="hidden h-12 w-12 text-slate-500 sm:block" />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
+          {operatorSteps.map((step) => (
+            <article key={step.title} className="rounded-3xl border border-white/10 bg-slate-900/80 p-5">
+              <step.icon className="mb-5 h-8 w-8 text-cyan-300" />
+              <h3 className="text-lg font-black text-white">{step.title}</h3>
+              <p className="mt-3 text-sm leading-6 text-slate-300">{step.text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-white/10 bg-slate-900/50">
+        <div className="mx-auto grid max-w-6xl gap-8 px-5 py-14 sm:px-8 lg:grid-cols-[0.9fr_1.1fr]">
+          <div>
+            <p className="text-sm font-bold uppercase tracking-[0.24em] text-emerald-300">Уже сделано</p>
+            <h2 className="mt-3 text-3xl font-black sm:text-4xl">Зелёные галочки из ToDo — простыми словами</h2>
+            <p className="mt-4 text-slate-300">
+              Техническая ToDo уже содержит много закрытых пунктов. Ниже — не программистская расшифровка, что это означает для оператора и клиента.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            {doneItems.map((item) => (
+              <div key={item} className="flex gap-3 rounded-2xl border border-emerald-300/15 bg-emerald-300/5 p-4">
+                <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-emerald-300" />
+                <p className="text-slate-200">{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-5 py-14 sm:px-8">
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="rounded-3xl border border-cyan-300/20 bg-cyan-300/10 p-6">
+            <QrCode className="h-10 w-10 text-cyan-200" />
+            <h3 className="mt-5 text-2xl font-black">QR уже в логике</h3>
+            <p className="mt-3 leading-7 text-cyan-50/85">
+              QR нужен не «для красоты»: он связывает конкретный договор, конкретный байк и будущую быструю аренду через Telegram Mini App.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-amber-300/20 bg-amber-300/10 p-6">
+            <LockKeyhole className="h-10 w-10 text-amber-200" />
+            <h3 className="mt-5 text-2xl font-black">Данные защищены</h3>
+            <p className="mt-3 leading-7 text-amber-50/85">
+              Паспортные данные и права должны храниться только в приватной зоне. В интерфейсах и отчётах показываем минимум, нужный для работы.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-violet-300/20 bg-violet-300/10 p-6">
+            <Clock3 className="h-10 w-10 text-violet-200" />
+            <h3 className="mt-5 text-2xl font-black">Повторная аренда быстрее</h3>
+            <p className="mt-3 leading-7 text-violet-50/85">
+              После первой проверенной аренды клиент сможет идти по короткому пути: выбрать доступный байк, подтвердить условия и получить договор.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-5 pb-20 sm:px-8">
+        <div className="mb-8">
+          <p className="text-sm font-bold uppercase tracking-[0.24em] text-slate-400">Планы дальше</p>
+          <h2 className="mt-3 text-3xl font-black sm:text-4xl">Что ещё запланировано</h2>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {futureItems.map((item) => (
+            <article key={item.title} className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
+              <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs font-bold uppercase tracking-widest text-slate-300">
+                {item.status}
+              </span>
+              <h3 className="mt-4 text-xl font-black text-white">{item.title}</h3>
+              <p className="mt-3 leading-7 text-slate-300">{item.text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/rental-doc-workflow/page.tsx
+++ b/app/rental-doc-workflow/page.tsx
@@ -39,7 +39,7 @@ const operatorSteps = [
   },
   {
     title: "3. AI достаёт данные клиента",
-    text: "Из фото берутся ФИО, дата рождения, паспорт, адрес регистрации и номер водительского удостоверения. В публичные отчёты полные персональные данные не попадают.",
+    text: "Целевой путь — ZAI VLM: модель смотрит на фото как человек, возвращает строгий JSON с ФИО, датой рождения, паспортом, адресом и правами. Tesseract оставляем только как запасной эксперимент.",
     icon: UserCheck,
   },
   {
@@ -67,8 +67,8 @@ const futureItems = [
   },
   {
     status: "Запланировано",
-    title: "OCR и ручная проверка",
-    text: "Фото документов будут распознаваться через OCR, а админ сможет быстро подтвердить или поправить результат перед сохранением.",
+    title: "ZAI VLM вместо Tesseract",
+    text: "Планируем основной разбор фото через ZAI VLM: лучше для реальных снимков паспорта/прав, а админ подтверждает или правит результат перед сохранением.",
   },
   {
     status: "Запланировано",
@@ -91,6 +91,21 @@ const simpleInputs = [
   "фото водительского удостоверения, если оно нужно для выбранного байка.",
 ];
 
+const vlmPlanItems = [
+  {
+    title: "Почему не Tesseract как основной путь",
+    text: "Локальный OCR полезен как проба, но на реальных фото с бликами, углами и русскими полями он даёт хрупкий результат. Для договора важнее точность и понятные ошибки.",
+  },
+  {
+    title: "Как будет работать ZAI VLM",
+    text: "Сервер отправляет фото паспорта или прав в ZAI VLM и просит вернуть только JSON: ФИО, дата рождения, серия/номер, регистрация, категории ВУ и предупреждения.",
+  },
+  {
+    title: "Безопасность и контроль",
+    text: "Ответ модели валидируется, персональные данные маскируются в логах, а сомнительные поля отправляются на ручную проверку администратора.",
+  },
+];
+
 export default function RentalDocWorkflowPage() {
   return (
     <main className="min-h-screen bg-slate-950 text-white">
@@ -108,7 +123,7 @@ export default function RentalDocWorkflowPage() {
                 Один текст, две фотки — и договор аренды готов
               </h1>
               <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
-                Эта страница объясняет человеческим языком, как работает новый поток VIP Bike Rental: оператор отправляет короткое сообщение, прикладывает фото документов, а система сама находит мотоцикл в базе, собирает DOCX и добавляет QR-код для следующей аренды.
+                Эта страница объясняет человеческим языком, как работает новый поток VIP Bike Rental: оператор отправляет короткое сообщение, прикладывает фото документов, ZAI VLM достаёт данные из снимков, а система сама находит мотоцикл в базе, собирает DOCX и добавляет QR-код для следующей аренды.
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                 <Link
@@ -166,6 +181,28 @@ export default function RentalDocWorkflowPage() {
               <p className="mt-3 text-sm leading-6 text-slate-300">{step.text}</p>
             </article>
           ))}
+        </div>
+      </section>
+
+      <section className="border-y border-white/10 bg-slate-900/40">
+        <div className="mx-auto max-w-6xl px-5 py-14 sm:px-8">
+          <div className="mb-8 max-w-3xl">
+            <p className="text-sm font-bold uppercase tracking-[0.24em] text-cyan-300">Новая версия скилла</p>
+            <h2 className="mt-3 text-3xl font-black sm:text-4xl">Фото разбирает ZAI VLM, а не просто OCR</h2>
+            <p className="mt-4 text-slate-300">
+              В ToDo теперь фиксируем VLM-first план: Tesseract был быстрым тестом, но целевой сценарий — vision-модель, строгий JSON и ручная проверка спорных полей.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            {vlmPlanItems.map((item) => (
+              <article key={item.title} className="rounded-3xl border border-cyan-300/15 bg-cyan-300/[0.06] p-6">
+                <Sparkles className="mb-5 h-8 w-8 text-cyan-200" />
+                <h3 className="text-xl font-black text-white">{item.title}</h3>
+                <p className="mt-3 leading-7 text-slate-300">{item.text}</p>
+              </article>
+            ))}
+          </div>
         </div>
       </section>
 

--- a/docs/TODO-1-click-next-rent.md
+++ b/docs/TODO-1-click-next-rent.md
@@ -423,22 +423,27 @@ The gold seed already has `license_class` on every bike. Here's the mapping:
 
 ---
 
-## 🔬 Phase 4: OCR Pipeline — `/doc` Command & Web-App OCR
+## 🔬 Phase 4: VLM Photo Extraction Pipeline — `/doc` Command & Web-App Intake
 
-> **Goal**: Users send passport/license photos to bot → OCR extracts data → contract generated. No more manual JSON files. OCR result also extracts license category, feeding directly into VIP tier system.
+> **Goal**: Users send passport/license photos to bot → ZAI VLM extracts structured data → contract generated. No more manual JSON files. VLM result also extracts license category, feeding directly into VIP tier system.
 
-### 4.0 OCR Architecture Decision
+### 4.0 VLM/OCR Architecture Decision
 
-- [ ] **Evaluated OCR approaches**:
-  - [ ] **Option A: VLM-based** — send photo to GLM-4V / GPT-4V → structured JSON extraction
-    - Cons: API latency, cost per call, not always deterministic
-  - [x] **Option B: Tesseract.js** — open-source OCR in Node.js
+> **Updated direction (June 2026): ZAI VLM-first.** Tesseract.js was tried as a cheap/local prototype, but for Russian passport + водительское удостоверение photos the target implementation should use a vision-language model: send the image to ZAI VLM, receive strict JSON, validate it, then allow admin correction. Tesseract can remain only as a fallback/cost experiment, not the main path.
+
+- [ ] **Evaluated OCR/VLM approaches**:
+  - [x] **Option A: ZAI VLM-based** — send photo to ZAI/GLM vision model → structured JSON extraction
+    - Pros: better with real-world photos, rotated documents, shadows, Russian fields, mixed passport/license layouts
+    - Cons: requires API access, latency/cost, must validate JSON strictly
+    - Decision: **primary roadmap path** once ZAI VLM access is available
+  - [x] **Option B: Tesseract.js prototype** — open-source OCR in Node.js
     - Pros: free, local, no API dependency
-    - Cons: lower accuracy on Russian passports, needs trained models
-  - [ ] **Option C: Hybrid** — Tesseract for text extraction + VLM for structured parsing
-    - Pros: Tesseract handles layout, VLM handles semantics
-    - Cons: two-pass complexity
-- [x] **Implemented**: **Option B** (Tesseract.js) — implemented in `app/api/ocr/route.ts` + `app/lib/ocr-constants.ts`
+    - Cons: lower accuracy on Russian documents, trained-data/runtime friction, brittle parsing
+    - Decision: keep as fallback/research only; do not design the production skill around Tesseract
+  - [ ] **Option C: Hybrid fallback** — ZAI VLM primary, Tesseract/manual entry fallback when API is unavailable
+    - Pros: resilient delivery; operator can still generate contract during provider outage
+    - Cons: more branches to test; fallback output must be clearly marked as lower confidence
+- [ ] **Target implementation**: replace the Tesseract-first `/api/ocr` contract with a **VLM-first extraction service** while preserving the same downstream JSON shape used by `make-rental-contract-skill.mjs`.
 
 ### 4.1 Telegram Bot `/doc` Command
 
@@ -484,75 +489,108 @@ The gold seed already has `license_class` on every bike. Here's the mapping:
   - [ ] Store state in `users.metadata.doc_flow_state` (temporary, cleared after completion)
   - [ ] Timeout: 5 minutes of inactivity → reset state
 
-- [ ] **Photo handling**:
+- [ ] **Photo handling — VLM-first**:
   - [ ] Receive photo via Telegram `message.photo` (largest size)
-  - [ ] Download to temp storage or pass URL to VLM
-  - [ ] VLM extracts structured data → `passportJson` / `licenseJson` format
-  - [ ] Validate extracted fields (non-empty name, valid series/number format)
+  - [ ] Download Telegram file to a short-lived server buffer or signed temporary URL
+  - [ ] Send image + document type (`passport` / `license`) to ZAI VLM extraction service
+  - [ ] VLM returns strict JSON in `passportJson` / `licenseJson` format
+  - [ ] Validate required fields (non-empty name, birth date, passport series/number, license categories when provided)
+  - [ ] If confidence/validation fails, ask user for a clearer photo or route to manual admin correction
 
-### 4.2 OCR Service (Next.js API Route)
+### 4.2 VLM Extraction Service (Next.js API Route)
 
-- [ ] **Create `/api/ocr` endpoint** — reusable by both bot and web app:
+- [ ] **Create/replace `/api/ocr` as a VLM-first endpoint** — reusable by both bot and web app:
   ```typescript
   // POST /api/ocr
-  // Body: { image: base64, type: "passport" | "license" }
-  // Response: { passportJson } or { licenseJson }
+  // Body: { image: base64 | imageUrl, type: "passport" | "license", provider?: "zai-vlm" }
+  // Response: { success: true, provider: "zai-vlm", passportJson } or { licenseJson }
   ```
 
-- [ ] **VLM integration**:
-  - [ ] Use `z-ai-web-dev-sdk` VLM capabilities (already available in project)
-  - [ ] System prompt for passport extraction:
-    ```
-    Extract passport data from this Russian passport photo. Return JSON:
-    { "fullName": "...", "birthDate": "DD.MM.YYYY", "series": "1234",
-      "number": "567890", "issueDate": "DD.MM.YYYY", "registration": "..." }
-    ```
-  - [ ] System prompt for license extraction:
-    ```
-    Extract driver's license data from this Russian ВУ photo. Return JSON:
-    { "series": "99 76", "number": "543210", "categories": ["A", "B", "M"],
-      "issueDate": "DD.MM.YYYY", "expiryDate": "DD.MM.YYYY" }
-    ```
+- [ ] **Provider wrapper**:
+  - [ ] Add a server-only `extractRentalDocumentWithZaiVlm()` helper (no client imports)
+  - [ ] Read provider credentials only from server env (for example `ZAI_API_KEY` / SDK-specific config)
+  - [ ] Keep request payloads short-lived; never persist raw images in public storage unless explicitly needed for admin review
+  - [ ] Return normalized JSON plus `confidence`, `warnings[]`, and masked debug metadata
 
-- [ ] **License category extraction** — CRITICAL for VIP tier system:
-  - [ ] Parse `categories` array from OCR result
+- [ ] **ZAI VLM passport prompt**:
+  ```text
+  You are extracting fields from a Russian passport photo for a legal motorcycle rental agreement.
+  Return JSON only. Do not invent missing fields.
+  Required shape:
+  {
+    "fullName": "...",
+    "birthDate": "DD.MM.YYYY",
+    "series": "1234",
+    "number": "567890",
+    "issueDate": "DD.MM.YYYY",
+    "divisionCode": "XXX-XXX",
+    "registration": "...",
+    "confidence": 0.0,
+    "warnings": []
+  }
+  ```
+
+- [ ] **ZAI VLM driver-license prompt**:
+  ```text
+  You are extracting fields from a Russian driver license photo for a motorcycle rental access check.
+  Return JSON only. Do not invent missing fields.
+  Required shape:
+  {
+    "series": "99 76",
+    "number": "543210",
+    "categories": ["A", "B", "M"],
+    "issueDate": "DD.MM.YYYY",
+    "expiryDate": "DD.MM.YYYY",
+    "confidence": 0.0,
+    "warnings": []
+  }
+  ```
+
+- [ ] **Strict JSON safety**:
+  - [ ] Parse model output with safe JSON extraction; reject markdown/text wrappers
+  - [ ] Validate with Zod or existing OCR validators before passing data to the contract script
+  - [ ] Never let malformed model JSON crash the bot/web route; return exact field-level errors
+  - [ ] Mask PII in logs (`1234 ******`, `Иванов И***`) and keep full values only in server-only flow
+
+- [ ] **License category extraction — CRITICAL for VIP tier system**:
+  - [ ] Parse `categories` array from VLM result
   - [ ] Map to access tier: A → Pro, A1/B/M → Mid, none → Entry
-  - [ ] Store in `user_rental_secrets` or `user_secrets.sensitive_metadata.license_categories`
+  - [ ] Store in `user_rental_secrets` or `user_secrets.sensitive_metadata.license_categories` after user/admin verification
 
-- [ ] **Web-app OCR integration**:
+- [ ] **Web-app VLM integration**:
   - [ ] Camera capture in checkout flow: "Сфотографируйте паспорт"
-  - [ ] Upload to `/api/ocr` → extract data → pre-fill form
-  - [ ] Fallback: manual entry if OCR fails or user prefers typing
+  - [ ] Upload to `/api/ocr` → ZAI VLM extracts data → pre-fill form
+  - [ ] Fallback: manual entry if VLM fails or user prefers typing
   - [ ] Progressive disclosure: passport first, then license (license = tier upgrade)
 
-### 4.3 OCR Result → VIP Tier Auto-Upgrade
+### 4.3 VLM Result → VIP Tier Auto-Upgrade
 
-- [ ] **On successful OCR + verification**:
-  - [ ] Extract license categories from OCR
+- [ ] **On successful VLM extraction + verification**:
+  - [ ] Extract license categories from VLM result
   - [ ] Derive access tier: `A → "pro"`, `A1/B/M → "mid"`, `no license → "entry"`
   - [ ] Store tier in `user_rental_secrets.sensitive_metadata.access_tier`
   - [ ] Or compute dynamically from stored license categories at rental time
 
-- [ ] **No OCR result → Entry tier only**:
+- [ ] **No verified license result → Entry tier only**:
   - [ ] User who didn't provide license can only rent Entry bikes
   - [ ] This is the "cold start" path — safe default, no license check needed
   - [ ] Upgrade available at any time: "Улучшите доступ — предоставьте ВУ"
 
-### 4.4 OCR Quality & Fallbacks
+### 4.4 VLM Quality, Validation & Fallbacks
 
-- [ ] **Validation**: check OCR output for common errors
+- [ ] **Validation**: check VLM output for common errors
   - [ ] Russian passport: series is 4 digits, number is 6 digits
   - [ ] License: series is 2+2 digits, number is 6 digits
   - [ ] Birth date format: DD.MM.YYYY
   - [ ] Category format: A, A1, B, B1, M, etc.
 
-- [ ] **Human verification**: admin can review + correct OCR results
+- [ ] **Human verification**: admin can review + correct VLM results
   - [ ] Admin dashboard: "Проверка документов" section
-  - [ ] Show OCR result + original photo side-by-side
+  - [ ] Show VLM result + original photo side-by-side
   - [ ] Confirm or edit before saving to secrets
 
-- [ ] **OCR caching**: don't re-OCR same photo if user resends
-  - [ ] Hash photo bytes → cache OCR result
+- [ ] **Extraction caching**: don't re-run VLM on the same photo if user resends
+  - [ ] Hash photo bytes → cache validated VLM result
   - [ ] Useful for retry scenarios
 
 ---
@@ -571,11 +609,11 @@ Phase 2+3+4 MEGA RUN (Run 4 — execute until context limit):
   8. Task G (profile page enhancement)
   9. Phase 3.2 (VIP status from license + ФЗ-152)
   10. Phase 3.3 (VIP rental flow + bike filtering)
-  11. Phase 4.0 (OCR architecture decision)
+  11. Phase 4.0 (VLM/OCR architecture decision)
   12. Phase 4.1 (Telegram /doc command)
-  13. Phase 4.2 (OCR API endpoint + VLM)
-  14. Phase 4.3 (OCR → tier auto-upgrade)
-  15. Phase 4.4 (OCR quality + admin verification)
+  13. Phase 4.2 (VLM-first extraction endpoint)
+  14. Phase 4.3 (VLM → tier auto-upgrade)
+  15. Phase 4.4 (VLM quality + admin verification)
   16. Phase 3.4 (NFC research)
 
   Parallel-safe: 5↔6, 11↔any, 16↔any


### PR DESCRIPTION
### Motivation
- Provide a plain-language, operator-facing explanation of the new “generate rental contract from two photos” flow so non‑developers can understand how to use it. 
- Surface what’s already done (DOCX pipeline, QR deep-link, private storage, access tiers) and the short roadmap (OCR, `/doc` flow, VIP club, NFC research). 

### Description
- Added a new Next.js page `app/rental-doc-workflow/page.tsx` that presents a visual, Russian-language explainer for the workflow (operator steps, minimal inputs, green check items, and planned items). 
- The page summarizes the end-to-end happy path: send a short command + two photos → AI/OCR extracts data → bike is resolved in DB → DOCX generated → Telegram delivery with QR. 
- Included clear CTAs linking to existing areas (`/vipbikerental`, `/doc-verifier`) and a human-friendly list of what’s done vs planned. 
- No backend or DB schema changes were made in this PR; this is a documentation/UX surface only.

### Testing
- Ran `npm run lint -- --file app/rental-doc-workflow/page.tsx` with no ESLint errors (success). 
- `npm run build` failed in this environment due to an existing unresolved dependency: `app/api/ocr/route.ts` cannot resolve `tesseract.js` (issue pre-existed and is unrelated to the new page). 
- Development server started (`next dev`) successfully and a Playwright screenshot was produced locally after installing Playwright browsers; visual snapshot saved to `artifacts/rental-doc-workflow-chromium.png` (artifact not committed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20461468408333a8d034b9bed2b76f)