### PR TITLE
Fix MapRiders mobile map touch gestures

### DIFF
--- a/app/franchize/[slug]/map-riders/todo.md
+++ b/app/franchize/[slug]/map-riders/todo.md
@@ -175,3 +175,9 @@ Port AGI handoff from `./goldmine` into production `MapRiders` in controlled ite
 - Addressed P1 review: `TEMP_BYPASS_TG_AUTH_VALIDATION` no longer trusts request URL/query/origin/referer markers. Bypass activation uses only server-known deployment env (`VERCEL_ENV=preview` + `VERCEL_URL`/`VERCEL_BRANCH_URL` containing `salavey13`) or exact `TELEGRAM_AUTH_BYPASS_ALLOWED_HOSTS`.
 - Added regression tests for forged production URL `?salavey13`, exact allowlist behavior, and live-like generated Telegram WebApp initData validation.
 - VIP Bike seed SQL now includes `/franchize/{slug}/community` in header/footer navigation; `/vipbikerental` hardcoded location copy now points to `ул. Комсомольская 2`.
+
+## Investigation notes (2026-06-03 — mobile map gesture passthrough)
+- Investigated the `/franchize/vip-bike/map-riders` touch stack across `page.tsx`, `MapRidersClientRefactored`, `RacingMap`, `MapInteractionCapture`, `RiderMarkerLayer`, `RiderFAB`, `RidersDrawer`, and `StatusOverlay`.
+- Root cause found: the secondary mobile `RidersDrawer` wrapper stayed in the hit-test stack while closed; its Vaul content could create an invisible touch layer above the Leaflet map, while rider markers still worked because they live in Leaflet's interactive marker pane.
+- Fix: closed `RidersDrawer` now leaves only its small handle as `pointer-events-auto`, unmounts drawer content while closed, and the Leaflet map root now explicitly owns touch gestures with `touch-action: none` plus enabled touch zoom/drag props.
+- Verification note: local Playwright screenshot/hit-test was blocked by missing system browser library `libatk-1.0.so.0`; route/runtime checks should be repeated in preview Telegram WebApp on a real phone.

--- a/components/map-riders/RidersDrawer.tsx
+++ b/components/map-riders/RidersDrawer.tsx
@@ -112,7 +112,7 @@ export function RidersDrawer({ emptyStateCopy = DEFAULT_EMPTY_STATE_COPY }: Ride
   }, [createMeetup, dbUser?.user_id, meetupComment, meetupTitle]);
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-40 md:hidden">
+    <div className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 md:hidden">
       <Drawer.Root
         open={isOpen}
         onOpenChange={(nextOpen) => {
@@ -122,15 +122,16 @@ export function RidersDrawer({ emptyStateCopy = DEFAULT_EMPTY_STATE_COPY }: Ride
         snapPoints={drawerSnapPoints}
       >
         <Drawer.Handle
-          className="mx-auto mb-1 h-1.5 w-12 rounded-full bg-white/30"
+          className="pointer-events-auto mx-auto mb-1 h-1.5 w-12 rounded-full bg-white/30"
           onClick={() => setIsOpen((prev) => !prev)}
         />
-        <Drawer.Content
-          ref={contentRef}
-          role="dialog"
-          aria-label="Панель райдеров и meetup"
-          className="mx-auto flex h-full w-full max-w-lg flex-col rounded-t-2xl bg-black/90 backdrop-blur-xl"
-        >
+        {isOpen ? (
+          <Drawer.Content
+            ref={contentRef}
+            role="dialog"
+            aria-label="Панель райдеров и meetup"
+            className="pointer-events-auto mx-auto flex h-full w-full max-w-lg flex-col rounded-t-2xl bg-black/90 backdrop-blur-xl"
+          >
           <Tabs defaultValue="riders" className="flex h-full flex-col">
             <div className="border-b border-white/10 px-4 pt-3">
               <TabsList className="grid w-full grid-cols-3 bg-transparent">
@@ -285,7 +286,8 @@ export function RidersDrawer({ emptyStateCopy = DEFAULT_EMPTY_STATE_COPY }: Ride
               </div>
             </TabsContent>
           </Tabs>
-        </Drawer.Content>
+          </Drawer.Content>
+        ) : null}
       </Drawer.Root>
 
       {isReplayOpen ? (

--- a/components/maps/RacingMap.tsx
+++ b/components/maps/RacingMap.tsx
@@ -119,8 +119,18 @@ export function RacingMap({
   const source = TILE_LAYERS[tileLayer] || TILE_LAYERS["cartodb-dark"];
 
   return (
-    <div className={`relative z-0 ${className || ""}`}>
-      <MapContainer bounds={mapBounds} className="z-0 h-full w-full" zoomControl attributionControl preferCanvas>
+    <div className={`relative z-0 ${className || ""}`} style={{ touchAction: "none" }}>
+      <MapContainer
+        bounds={mapBounds}
+        className="z-0 h-full w-full !touch-none"
+        zoomControl
+        attributionControl
+        preferCanvas
+        dragging
+        touchZoom
+        scrollWheelZoom
+        doubleClickZoom
+      >
         <TileLayer url={source} attribution="&copy; OpenStreetMap contributors &copy; CARTO" />
 
         {points.map((poi) => {

--- a/docs/THE_FRANCHEEZEPLAN.md
+++ b/docs/THE_FRANCHEEZEPLAN.md
@@ -633,3 +633,12 @@ This root file stays intentionally compact so operators and agents can load it q
 - `risks`: Визуальный Telegram fullscreen всё ещё требует девайс-проверки, локальный браузер не воспроизводит native top buttons.
 
 - 2026-05-08 — Self-review micro-polish: side header controls restored, vertical safe offset retained, mixed-language copy tightened.
+
+### 2026-06-03 — MapRiders mobile gesture passthrough fix
+
+- `status`: ready_for_pr
+- `updated_at`: 2026-06-03T00:00:00Z
+- `owner`: codex
+- `notes`: Fixed a tricky VIP Bike MapRiders touch trap: the secondary mobile riders drawer was leaving invisible Vaul content in the pointer hit-test stack while closed, so Leaflet pan/zoom worked reliably only from marker interactions. Closed drawer content now unmounts, only the small handle remains interactive, and the Leaflet map explicitly owns touch gestures.
+- `next_step`: Preview-smoke `/franchize/vip-bike/map-riders` in Telegram WebApp on mobile: pan/zoom from blank map tiles, rider marker drag-start, drawer handle open/close, and meetup long-press.
+- `risks`: Local Playwright browser launch was blocked by missing system library `libatk-1.0.so.0`, so device QA remains the decisive proof.


### PR DESCRIPTION
### Motivation
- Users could not pan/zoom the Leaflet map unless they started the gesture over a rider marker because an invisible interactive layer (the closed Vaul drawer content) was stealing touch events. 
- The change aims to restore direct map gesture passthrough on mobile (Telegram WebApp) while keeping the drawer handle interactive and preserving meetup long-press UX.

### Description
- Make the drawer wrapper non-interactive when closed by adding `pointer-events-none` to the outer container and keeping only the handle `pointer-events-auto` so the map receives touches (`components/map-riders/RidersDrawer.tsx`).
- Unmount the Vaul `Drawer.Content` when the drawer is closed so hidden drawer internals cannot remain in the hit-test stack (`components/map-riders/RidersDrawer.tsx`).
- Explicitly give the Leaflet root ownership of touch gestures by setting `touchAction: "none"` on the map wrapper and enabling touch/drag/zoom props on `MapContainer` (`components/maps/RacingMap.tsx`).
- Record the investigation, root cause and follow-up QA steps in the MapRiders tracker and the FRANCHEEZEPLAN diary (`app/franchize/[slug]/map-riders/todo.md`, `docs/THE_FRANCHEEZEPLAN.md`).

### Testing
- Ran lint on the modified files with `npx eslint components/maps/RacingMap.tsx components/map-riders/RidersDrawer.tsx` which succeeded. 
- Ran the MapRiders smoke check `npm run qa:map-riders` which returned all endpoints and the page as `200` (smoke passed). 
- `npm run typecheck:franchize` is currently failing due to a pre-existing unrelated TypeScript error in `FranchizeProfileButton.tsx` and is therefore blocked. 
- Playwright local hit-test/screenshot probe failed to run in this environment because the runner is missing system browser libraries (`libatk-1.0.so.0`), so final device QA in a preview/Telegram WebApp on a real phone is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20b342521c832490ed990f60ade2db)