### PR TITLE
Add files via upload

### DIFF
--- a/app/franchize/components/CatalogClient.tsx
+++ b/app/franchize/components/CatalogClient.tsx
@@ -336,11 +336,18 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
   }, [promoModules]);
 
   const promoGradientByIndex = (index: number) => {
-    const gradients = [
-      `linear-gradient(130deg, ${crew.theme.palette.accentMain}E0, #FF7F50D0)`,
-      `linear-gradient(130deg, #8B5CF6D9, ${crew.theme.palette.accentMain}D8)`,
-      `linear-gradient(130deg, #22C55ED1, #06B6D4CC)`,
-    ];
+    const isLight = crew.theme.mode.toLowerCase().includes("light");
+    const gradients = isLight
+      ? [
+          `linear-gradient(130deg, ${crew.theme.palette.accentMain}E0, #FF7F50D0)`,
+          `linear-gradient(130deg, #8B5CF6D9, ${crew.theme.palette.accentMain}D8)`,
+          `linear-gradient(130deg, #F59E0BD1, #EF4444CC)`,
+        ]
+      : [
+          `linear-gradient(130deg, ${crew.theme.palette.accentMain}E0, #FF7F50D0)`,
+          `linear-gradient(130deg, #8B5CF6D9, ${crew.theme.palette.accentMain}D8)`,
+          `linear-gradient(130deg, #22C55ED1, #06B6D4CC)`,
+        ];
 
     return gradients[index % gradients.length];
   };
@@ -524,12 +531,14 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
         id="catalog-sections"
         style={{
           ["--catalog-accent" as string]: crew.theme.palette.accentMain,
+          ["--catalog-accent-hover" as string]: crew.theme.palette.accentMainHover,
           ["--catalog-border" as string]: crew.theme.palette.borderSoft,
           ["--catalog-text" as string]: crew.theme.palette.textPrimary,
           ["--catalog-muted" as string]: crew.theme.palette.textSecondary,
           ["--catalog-card-bg" as string]: crew.theme.palette.bgCard,
           ["--catalog-bg" as string]: crew.theme.palette.bgBase,
           ["--catalog-accent-contrast" as string]: readableTextOnColor(crew.theme.palette.accentMain),
+          ["--catalog-accent-muted-contrast" as string]: withAlpha(readableTextOnColor(crew.theme.palette.accentMain), 0.7),
           ["--catalog-accent-subtle" as string]: withAlpha(crew.theme.palette.accentMain, 0.12),
         }}
       >
@@ -652,7 +661,7 @@ export function CatalogClient({ crew, slug, items, mode = "rental", ctaPolicy }:
                 className="shrink-0 rounded-full bg-[var(--quick-pill-bg)] px-3 py-1.5 text-xs font-medium text-[var(--quick-pill-text)] transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--catalog-accent)]"
                 style={{
                   ["--quick-pill-bg" as string]: active ? (filter.tierColor || crew.theme.palette.accentMain) : crew.theme.palette.bgCard,
-                  ["--quick-pill-text" as string]: active ? (filter.tierColor ? "#000000" : "#000000") : crew.theme.palette.textPrimary,
+                  ["--quick-pill-text" as string]: active ? readableTextOnColor(filter.tierColor || crew.theme.palette.accentMain) : crew.theme.palette.textPrimary,
                   ...(active && filter.tierColor ? { boxShadow: `0 0 8px ${filter.tierColor}60` } : {}),
                 }}
               >

--- a/docs/sql/vip-bike-franchize-hydration.sql
+++ b/docs/sql/vip-bike-franchize-hydration.sql
@@ -1,10 +1,17 @@
+-- /docs/sql/vip-bike-franchize-hydration.sql
 -- VIP_BIKE Franchize hydration reference payload (2026 edition)
 -- Purpose: production-like seed with metadata-first approach + private.crew_secrets extraction
 -- Safe to re-run: uses ON CONFLICT + jsonb_set + private upsert
 -- Updated: 2026-06-13 — light palette redesigned to match vip-bike.ru actual site design
 --   Light accent: electric cyan #19C2F5 (not gold — gold is dark-theme-only / atmospheric)
 --   Surface: pure white + Apple-like #F5F5F7 card fills + #E5E5E7 hairline borders
---   Text: near-black #0A0A0A (not #1A1A1A) for maximum contrast on white
+--   Text: near-black #0A0A0A for maximum contrast on white (~19.5:1)
+--   Palette trimmed to 7 tokens — the only keys consumed by resolvePaletteByMode():
+--     bgBase, bgCard, accentMain, accentMainHover, textPrimary, textSecondary, borderSoft
+--   CatalogClient.tsx now sets 10 CSS vars from these 7 palette keys:
+--     --catalog-accent, --catalog-accent-hover, --catalog-border, --catalog-text,
+--     --catalog-muted, --catalog-card-bg, --catalog-bg, --catalog-accent-contrast,
+--     --catalog-accent-muted-contrast, --catalog-accent-subtle
 
 begin;
 


### PR DESCRIPTION
## ✅ Skills installed (22 files)

New skills: **boss-mode**, **bulk-sale-pdf**, **pull-request**, **quest-chain-generator** — plus app routes (forward-telegram, rentals-analytics), scripts (cron, supaplan, pull-request, etc.), and components (AICodeAssistant, RepoXmlPageContext, ToolsMenu).

---

## ✅ CatalogClient.tsx adjusted for light theme

You were right — **17 tokens was overkill**. The codebase only supports **7 palette keys** in `FranchizeTheme`:

| Key | Dark (gold) | Light (cyan) |
|---|---|---|
| `bgBase` | `#121520` | `#FFFFFF` |
| `bgCard` | `#1B2132` | `#F5F5F7` |
| `accentMain` | `#F4BD55` | `#19C2F5` |
| `accentMainHover` | `#FFCA60` | `#0EA6D6` |
| `textPrimary` | `#E6D8C4` | `#0A0A0A` |
| `textSecondary` | `#A7ABB4` | `#4E4E55` |
| `borderSoft` | `#2A2E3E` | `#E5E5E7` |

### Bugs fixed:

1. **`--catalog-accent-muted-contrast` was consumed but never set** — promo module subtitle text (line 629) had no CSS variable, causing it to render with browser default. Now computed as `withAlpha(readableTextOnColor(accentMain), 0.7)` — works in both themes.

2. **Quick filter pill text hardcoded to `#000000`** — now uses `readableTextOnColor()` for proper contrast on any accent color.

3. **Added `--catalog-accent-hover`** CSS variable — `accentMainHover` existed in palette but wasn't exposed as a CSS var. Now available for Tailwind hover states.

4. **Promo gradients are mode-aware** — light mode gets a warm amber→red 3rd gradient instead of green→teal (which would look same-ish as the cyan accent).

### Also updated:
- **`franchize-config.ts`** — `DEFAULT_LIGHT_THEME_PALETTE` now matches the SQL: cyan `#19C2F5` accent, Apple surfaces, aligned values
- **SQL header** — documents the 7-token palette → 10 CSS var mapping