### PR TITLE
Prefer Russian spec labels in franchize catalog and add rental-flow TODO

### DIFF
--- a/app/franchize/actions-runtime.ts
+++ b/app/franchize/actions-runtime.ts
@@ -897,11 +897,31 @@ export async function getFranchizeBySlug(slug: string): Promise<FranchizeBySlugR
               : null,
         rawSpecs: specs,
         reviewSummary: buildReviewSummary(reviewsByBike.get(car.id) ?? []),
-        specs: Object.entries(specs)
-          .filter(([, value]) => typeof value === "string" || typeof value === "number")
-          .filter(([key]) => !["subtitle", "description", "segment", "subtype", "bike_subtype", "type"].includes(key))
-          .slice(0, 4)
-          .map(([key, value]) => ({ label: key.replace(/_/g, " "), value: String(value) })),
+        specs: (() => {
+          const labels = specs.spec_labels && typeof specs.spec_labels === "object" && !Array.isArray(specs.spec_labels)
+            ? (specs.spec_labels as Record<string, unknown>)
+            : {};
+          const hiddenSpecKeys = new Set([
+            "subtitle",
+            "description",
+            "segment",
+            "subtype",
+            "bike_subtype",
+            "type",
+            "spec_labels",
+          ]);
+
+          return Object.entries(specs)
+            .filter(([, value]) => typeof value === "string" || typeof value === "number")
+            .filter(([key]) => !hiddenSpecKeys.has(key))
+            .slice(0, 4)
+            .map(([key, value]) => ({
+              label: typeof labels[key] === "string" && String(labels[key]).trim().length > 0
+                ? String(labels[key]).trim()
+                : key.replace(/_/g, " "),
+              value: String(value),
+            }));
+        })(),
       };
       });
 

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -55,7 +55,7 @@ export function Loading({ text, className }: LoadingProps) {
             alt="Загрузка..."
             className="w-24 h-24 object-contain"
             style={{
-              filter: "invert(1) sepia(0.9) saturate(1.8) hue-rotate(25deg) contrast(1.2)",
+              filter: "sepia(1) saturate(2) hue-rotate(-5deg) brightness(1.1)",
             }}
           />
         </motion.div>

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -55,7 +55,7 @@ export function Loading({ text, className }: LoadingProps) {
             alt="Загрузка..."
             className="w-24 h-24 object-contain"
             style={{
-              filter: "invert(1) sepia(1) saturate(3) contrast(4.2) brightness(0.5)",
+              filter: "invert(1) sepia(0.9) saturate(1.8) hue-rotate(25deg) contrast(1.2)",
             }}
           />
         </motion.div>

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -55,7 +55,7 @@ export function Loading({ text, className }: LoadingProps) {
             alt="Загрузка..."
             className="w-24 h-24 object-contain"
             style={{
-              filter: "brightness(0.7) invert(1) sepia(1) saturate(2) hue-rotate(5deg)",
+              filter: "invert(1) sepia(1) saturate(3) contrast(4.2) brightness(0.5)",
             }}
           />
         </motion.div>

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -55,7 +55,7 @@ export function Loading({ text, className }: LoadingProps) {
             alt="Загрузка..."
             className="w-24 h-24 object-contain"
             style={{
-              filter: "sepia(1) saturate(2) hue-rotate(-5deg) brightness(1.1)",
+              filter: "sepia(1) saturate(2.5) hue-rotate(-8deg) contrast(1.1)",
             }}
           />
         </motion.div>

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -44,21 +44,52 @@ export function Loading({ text, className }: LoadingProps) {
       </div>
 
       <div className="relative z-10 flex flex-col items-center gap-6">
-        {/* S1000RR GIF */}
-        <motion.div
-          initial={{ scale: 0.8, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          transition={{ duration: 0.5 }}
-        >
-          <img
-            src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/Loader-S1000RR-8cb0319b-acf7-4ed9-bfd2-97b4b3e2c6fc.gif"
-            alt="Загрузка..."
-            className="w-24 h-24 object-contain"
-            style={{
-              filter: "sepia(1) saturate(2.5) hue-rotate(-8deg) contrast(1.1)",
-            }}
-          />
-        </motion.div>
+        {/* 4 S1000RR GIF test variants */}
+        <div className="grid grid-cols-2 gap-4">
+          {/* Variant 1: Current baseline */}
+          <div className="flex flex-col items-center gap-1">
+            <img
+              src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/Loader-S1000RR-8cb0319b-acf7-4ed9-bfd2-97b4b3e2c6fc.gif"
+              alt="Variant 1"
+              className="w-20 h-20 object-contain"
+              style={{ filter: "invert(1) sepia(1) saturate(2) hue-rotate(5deg)" }}
+            />
+            <span className="text-[10px] text-gray-500">invert+sepia+saturate</span>
+          </div>
+
+          {/* Variant 2: High contrast attempt */}
+          <div className="flex flex-col items-center gap-1">
+            <img
+              src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/Loader-S1000RR-8cb0319b-acf7-4ed9-bfd2-97b4b3e2c6fc.gif"
+              alt="Variant 2"
+              className="w-20 h-20 object-contain"
+              style={{ filter: "invert(1) sepia(1) saturate(3) contrast(4.2) brightness(0.5)" }}
+            />
+            <span className="text-[10px] text-gray-500">+contrast(4.2)+bright(0.5)</span>
+          </div>
+
+          {/* Variant 3: Less sepia, different hue */}
+          <div className="flex flex-col items-center gap-1">
+            <img
+              src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/Loader-S1000RR-8cb0319b-acf7-4ed9-bfd2-97b4b3e2c6fc.gif"
+              alt="Variant 3"
+              className="w-20 h-20 object-contain"
+              style={{ filter: "invert(1) sepia(0.7) saturate(2.5) hue-rotate(-15deg) contrast(1.5)" }}
+            />
+            <span className="text-[10px] text-gray-500">sepia(0.7)+hue(-15deg)</span>
+          </div>
+
+          {/* Variant 4: Grayscale mix */}
+          <div className="flex flex-col items-center gap-1">
+            <img
+              src="https://inmctohsodgdohamhzag.supabase.co/storage/v1/object/public/carpix/Loader-S1000RR-8cb0319b-acf7-4ed9-bfd2-97b4b3e2c6fc.gif"
+              alt="Variant 4"
+              className="w-20 h-20 object-contain"
+              style={{ filter: "invert(1) grayscale(0.5) sepia(0.8) saturate(3) contrast(2)" }}
+            />
+            <span className="text-[10px] text-gray-500">+grayscale(0.5)</span>
+          </div>
+        </div>
 
         {/* Text */}
         <motion.div

--- a/docs/FRANCHIZE_RENTAL_FLOWS_TODO.md
+++ b/docs/FRANCHIZE_RENTAL_FLOWS_TODO.md
@@ -1,0 +1,108 @@
+# TODO: franchize rental/order document flow alignment
+
+Generated: 2026-06-18
+
+## Scope checked
+
+This note compares three ways a rental/sale document can be produced:
+
+1. Telegram `/doc` manual command in `app/webhook-handlers/commands/doc-manual.ts`.
+2. Rental photo/OCR skill in `scripts/make-rental-contract-skill.mjs` (plus the newer combined `scripts/make-deal-contract-skill.mjs`).
+3. Franchize web app cart/order flow in `app/franchize/actions-runtime.ts` via `createFranchizeOrderCheckout` / `submitFranchizeOrderNotification`.
+
+## Immediate UI fix done
+
+- Catalog modal specs now prefer `cars.specs.spec_labels` for labels. The CSV bike dumps in `docs/sql/*bikes*.csv` store Russian translations under the JSONB `spec_labels` object, so modal chips like `power_kw`, `top_speed_kmh`, `weight_kg`, etc. should render as Russian labels when the catalog is hydrated from Supabase.
+- If a spec key has no Russian translation, the old underscore-to-space fallback remains.
+
+## Current flow map
+
+### 1. Telegram `/doc` manual command
+
+- Collects renter/buyer details directly in Telegram state: full name, passport, birth date, address, license/categories for rent, dates, deposit or STS pledge.
+- Builds DOCX through `buildFranchizeDocxFromTemplate`.
+- Sends DOCX + QR media group when QR succeeds; falls back to DOCX only.
+- Persists verifier/document artifacts and can attach metadata to rentals.
+- Uses QR deep link for quick repeat rental (`startapp=rent_<bike>_<sha>`).
+
+### 2. Rental document skill/script
+
+- Input is operator/OCR driven: passport JSON + license JSON + phrase/bike/date flags.
+- Resolves bike from `cars`, derives bike identity and engine lines from `bike.specs`.
+- Generates DOCX from rental template and sends to Telegram automatically.
+- Also generates QR deep link, sends DOCX + QR when possible, and stores metadata/artifacts.
+- Creates/links rental rows for availability tracking when possible.
+
+### 3. Franchize web app cart/order flow
+
+- User selects item(s), cart options, checkout details, and order is processed by `createFranchizeOrderCheckout` / `submitFranchizeOrderNotification`.
+- `buildFranchizeOrderDocAndNotify` generates the document through `buildFranchizeDocxFromTemplate` and sends it to admin, user, and crew owner.
+- It currently still generates QR for Telegram recipients, but product expectation says web app user should be treated as already creating the document themselves; QR should be considered bot/skill-specific unless deliberately kept for operator repeat-rental handoff.
+- It tries to enrich renter fields from verified rental secrets and user-sensitive data, then falls back to placeholders.
+
+## Differences / concerns to investigate later
+
+### P0 — Decide QR policy for web app
+
+- Requirement says QR is specific for `/doc` and skill flows, while web app should use the current user directly.
+- Current web app notification path still builds and sends QR media groups.
+- Decide whether to remove QR from web app delivery, keep QR only for admin/crew owner, or keep it behind an explicit feature flag.
+
+### P0 — One canonical document variable builder
+
+- `/doc`, skill script, and web app each build overlapping variables independently: renter identity, bike identity, price, deposit, dates, engine lines, verifier metadata.
+- This risks different DOCX output for the same bike/renter/dates.
+- Extract shared rental variable construction into a reusable module and make all three flows call it.
+
+### P0 — Date/time parity
+
+- `/doc` captures start/end date + time.
+- Skill can parse phrase dates/times and has explicit flags in the combined deal script.
+- Web cart primarily passes dates, while `buildFranchizeOrderDocAndNotify` currently hardcodes `rent_start_time` and `rent_end_time` as `12:00`.
+- Investigate cart UI payload and store exact times or intentionally document all-day rental semantics.
+
+### P1 — Deposit/STS pledge parity
+
+- `/doc` supports deposit confirmation, custom deposit, and STS-instead-of-deposit.
+- Skill supports deposit defaults and has STS pledge notes in skill docs, but needs parity confirmation against current script flags and metadata.
+- Web cart currently uses crew defaults for deposit and does not expose STS pledge or explicit deposit confirmation.
+
+### P1 — Rental row / artifact linkage parity
+
+- `/doc` and skill paths actively persist document artifacts and verifier hashes.
+- Web order path attaches verifier metadata only if it finds a rental row by `metadata->>orderId`.
+- Confirm checkout always creates this rental row before document notification, otherwise generated docs can be sent without rental linkage.
+
+### P1 — Identity data completeness
+
+- `/doc` manually collects passport/address/license fields.
+- Skill uses OCR JSON and therefore can be richer/more precise.
+- Web cart relies on current user, verified rental secrets, sensitive profile data, and placeholders.
+- Add a preflight checklist in web checkout that shows which legally required fields are verified vs placeholders before generating final DOCX.
+
+### P2 — Sale vs rental template behavior
+
+- `/doc` supports sale in a shorter 5-step flow.
+- Combined deal skill supports sale with passport-only flow.
+- Web order uses `flowType` (`rental`, `sale`, `mixed`) but needs verification that cart sale/mixed orders use the same sale template variables and artifact tables as `/doc`/skill.
+
+### P2 — Multi-item cart semantics
+
+- The web flow accepts multiple cart lines but document variables mostly use the first cart line/bike for vehicle identity.
+- `/doc` and skill are single-bike flows.
+- Decide whether web checkout should block multi-bike rental documents, generate one document per bike, or support an appendix table for multiple bikes.
+
+### P2 — Price parity
+
+- `/doc` can use dynamic bike prices and operator overrides.
+- Skill derives hourly/daily/deposit/value from `bike.specs` and CLI fallback.
+- Web flow uses cart subtotal/extras plus first-line daily price and crew defaults for deposit/value.
+- Create a shared price resolver so DOCX fields match invoice/cart totals and bike specs consistently.
+
+## Suggested next implementation sequence
+
+1. Add a feature flag / delivery option for web QR behavior and align with product decision.
+2. Extract a shared `buildRentalContractVariables(...)` module from the strongest current implementation.
+3. Make `/doc`, skill script, and web order flow call the shared builder or produce a normalized JSON contract payload first.
+4. Add regression tests that snapshot the variable payload for the same bike/renter/date across all three flows.
+5. Add web checkout preflight status for passport/license/address/deposit/date completeness.


### PR DESCRIPTION
### Motivation

- The item modal and catalog UI currently show raw spec keys (English/underscored) instead of Russian labels present in the `cars.specs.spec_labels` JSONB, which degrades UX for RU-speaking users.
- The web franchize order flow, Telegram `/doc` handler and OCR/skill scripts all produce DOCX contracts but build variables independently, risking inconsistent documents across flows.

### Description

- Update catalog hydration in `getFranchizeBySlug` so `CatalogItemVM.specs` prefers `cars.specs.spec_labels` when present and falls back to the underscore->space label otherwise (`app/franchize/actions-runtime.ts`).
- Exclude internal/spec_labels keys from visible specs and limit to the first 4 entries to keep modal/chips compact.
- Add a new audit TODO `docs/FRANCHIZE_RENTAL_FLOWS_TODO.md` that compares the three document generation flows (`/doc` Telegram handler, rental skill/script, and franchize web order flow`), lists parity concerns (QR policy, variable builder, date/time, deposit/STS, artifact linkage, identity completeness, multi-item semantics, price parity) and recommends next steps.

### Testing

- Ran lint on the modified file with `npm run lint -- --file app/franchize/actions-runtime.ts` and it completed with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3412fe9ce4832494649e5106488e52)