### PR TITLE
fix(franchize): rentals-analytics stuck loading, dead date buttons, mi

### DIFF
--- a/app/franchize/[slug]/commercial-offers-analytics/CommercialOffersAnalyticsClient.tsx
+++ b/app/franchize/[slug]/commercial-offers-analytics/CommercialOffersAnalyticsClient.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { format } from "date-fns";
+import { ru } from "date-fns/locale";
+import {
+  Calendar,
+  ChevronLeft,
+  ChevronRight,
+  RefreshCw,
+  FileText,
+  Phone,
+  Mail,
+  QrCode,
+  User,
+  Building2,
+  BarChart3,
+  Tag,
+} from "lucide-react";
+
+import { useAppContext } from "@/contexts/AppContext";
+import {
+  getCommercialProposalsDashboard,
+  validateAnalyticsPassword,
+  type CommercialProposalItem,
+  type CommercialProposalsResult,
+} from "@/app/franchize/server-actions/rentals-dashboard";
+import { useFranchizeTheme } from "@/app/franchize/hooks/useFranchizeTheme";
+import { withAlpha } from "@/app/franchize/lib/theme";
+
+const formatRubles = (amount: number | null | undefined): string => {
+  if (amount == null || !Number.isFinite(amount)) return "—";
+  return new Intl.NumberFormat("ru-RU", {
+    style: "currency",
+    currency: "RUB",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+};
+
+const formatRussianDate = (dateStr: string | null): string => {
+  if (!dateStr) return "—";
+  try {
+    return format(new Date(dateStr), "dd MMM yyyy, HH:mm", { locale: ru });
+  } catch {
+    return "—";
+  }
+};
+
+const formatRussianDateOnly = (dateStr: string | null): string => {
+  if (!dateStr) return "—";
+  try {
+    return format(new Date(dateStr), "dd MMM yyyy", { locale: ru });
+  } catch {
+    return "—";
+  }
+};
+
+const OFFER_TYPE_LABELS: Record<string, string> = {
+  rent: "Аренда",
+  sale: "Продажа",
+  service: "Сервис",
+  lease: "Лизинг",
+  unknown: "Другое",
+};
+
+interface CommercialOffersAnalyticsClientProps {
+  initialSlug: string;
+  initialDate: string;
+  crew: { id: string; name: string; theme: any };
+}
+
+export function CommercialOffersAnalyticsClient({ initialSlug, initialDate, crew }: CommercialOffersAnalyticsClientProps) {
+  const { dbUser, isLoading: authLoading } = useAppContext();
+  const theme = useFranchizeTheme(crew.theme);
+
+  const [selectedDate, setSelectedDate] = useState(initialDate);
+  const [proposals, setProposals] = useState<CommercialProposalItem[]>([]);
+  const [summary, setSummary] = useState<CommercialProposalsResult["summary"] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Password auth (optional — mirrors rentals-analytics flow)
+  const [showPasswordEntry, setShowPasswordEntry] = useState(false);
+  const [passwordInput, setPasswordInput] = useState("");
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [isPasswordValidating, setIsPasswordValidating] = useState(false);
+  const [passwordAuthOwnerId, setPasswordAuthOwnerId] = useState<string | null>(null);
+
+  const getActorUserId = useCallback((): string | null => dbUser?.user_id || passwordAuthOwnerId, [dbUser?.user_id, passwordAuthOwnerId]);
+
+  const navigateDate = (delta: number) => {
+    const d = new Date(selectedDate);
+    d.setDate(d.getDate() + delta);
+    setSelectedDate(d.toISOString().split("T")[0]);
+  };
+
+  const loadProposals = useCallback(async (date: string, showRefresh = false) => {
+    const actorUserId = getActorUserId();
+    if (!actorUserId) {
+      // Never get stuck in the initial loading state.
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+
+    if (showRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    try {
+      const result = await getCommercialProposalsDashboard({
+        slug: initialSlug?.trim() || "vip-bike",
+        actorUserId,
+        date,
+        isPasswordAuth: !!passwordAuthOwnerId,
+      });
+
+      if (!result.success) {
+        if (result.error?.includes("прав") || result.error?.includes("доступ")) {
+          setShowPasswordEntry(true);
+          toast.error("Требуется пароль");
+          return;
+        }
+        toast.error(result.error || "Не удалось загрузить КП");
+        return;
+      }
+
+      setProposals(result.data?.items || []);
+      setSummary(result.data?.summary || null);
+    } catch (error) {
+      console.error("[CommercialOffersAnalytics] Load error:", error);
+      toast.error("Ошибка загрузки");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [getActorUserId, initialSlug, passwordAuthOwnerId]);
+
+  useEffect(() => {
+    if (getActorUserId()) {
+      void loadProposals(selectedDate);
+    }
+  }, [getActorUserId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (getActorUserId() && !authLoading) {
+      void loadProposals(selectedDate, true);
+    }
+  }, [selectedDate]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handlePasswordSubmit = async () => {
+    if (!passwordInput.trim()) return;
+    setIsPasswordValidating(true);
+    setPasswordError(null);
+    try {
+      const result = await validateAnalyticsPassword({ password: passwordInput });
+      if (!result.success) {
+        setPasswordError(result.error || "Неверный пароль");
+        return;
+      }
+      if (result.data?.slug && result.data.slug !== initialSlug?.trim()) {
+        setPasswordError(`Пароль для другого экипажа: ${result.data.slug}`);
+        return;
+      }
+      setPasswordAuthOwnerId(result.data?.ownerId || null);
+      setShowPasswordEntry(false);
+      setPasswordInput("");
+      toast.success("Доступ разрешён");
+    } catch {
+      setPasswordError("Ошибка проверки пароля");
+    } finally {
+      setIsPasswordValidating(false);
+    }
+  };
+
+  // Theme tokens
+  const bgBase = "var(--franchize-bg-base)";
+  const bgCard = "var(--franchize-bg-card)";
+  const accentMain = "var(--franchize-accent-main)";
+  const textPrimary = "var(--franchize-text-primary)";
+  const textSecondary = "var(--franchize-text-secondary)";
+  const borderSoft = "var(--franchize-border-soft)";
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ backgroundColor: bgBase }}>
+        <div className="w-12 h-12 rounded-full border-4 animate-spin" style={{ borderColor: withAlpha(accentMain, 0.2), borderTopColor: accentMain }} />
+      </div>
+    );
+  }
+
+  if (showPasswordEntry) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4" style={{ backgroundColor: bgBase }}>
+        <div className="w-full max-w-sm p-6 rounded-2xl border" style={{ backgroundColor: bgCard, borderColor: borderSoft }}>
+          <h2 className="text-lg font-bold mb-2" style={{ color: textPrimary }}>Доступ по паролю</h2>
+          <p className="text-sm mb-4" style={{ color: textSecondary }}>Введите пароль аналитики для доступа к КП.</p>
+          <input
+            type="password"
+            value={passwordInput}
+            onChange={(e) => setPasswordInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") void handlePasswordSubmit(); }}
+            className="w-full px-3 py-2 rounded-lg mb-3 outline-none"
+            style={{ backgroundColor: bgBase, border: `1px solid ${borderSoft}`, color: textPrimary }}
+            autoFocus
+          />
+          {passwordError && <p className="text-sm mb-3" style={{ color: "#f87171" }}>{passwordError}</p>}
+          <button
+            onClick={() => void handlePasswordSubmit()}
+            disabled={isPasswordValidating}
+            className="w-full py-2 rounded-lg font-bold disabled:opacity-50"
+            style={{ backgroundColor: accentMain, color: "#ffffff" }}
+          >
+            {isPasswordValidating ? "Проверка..." : "Войти"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const totalCount = summary?.totalCount ?? proposals.length;
+  const withQr = summary?.withQr ?? proposals.filter((p) => p.qr_included).length;
+  const totalRevenue = proposals.reduce((sum, p) => sum + (p.total_price || 0), 0);
+  const byType = summary?.byType || {};
+  const basePath = `/franchize/${initialSlug}`;
+
+  return (
+    <div className="space-y-4">
+      {/* Cross-analytics navigation */}
+      <div
+        className="flex items-center gap-1.5 flex-wrap p-2 rounded-xl border"
+        style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+      >
+        <BarChart3 className="w-3.5 h-3.5 ml-1.5 flex-shrink-0" style={{ color: textSecondary }} />
+        <span className="text-[10px] uppercase font-bold tracking-wide mr-1" style={{ color: textSecondary }}>Аналитика:</span>
+        <a
+          href={`${basePath}/rentals-analytics`}
+          className="flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-bold transition-all"
+          style={{ color: textSecondary, border: `1px solid ${borderSoft}` }}
+        >
+          <Calendar className="w-3 h-3" /> Аренды
+        </a>
+        <a
+          href={`${basePath}/sales-analytics`}
+          className="flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-bold transition-all"
+          style={{ color: textSecondary, border: `1px solid ${borderSoft}` }}
+        >
+          <Tag className="w-3 h-3" /> Продажи
+        </a>
+        <span
+          className="flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-bold"
+          style={{ backgroundColor: withAlpha(accentMain, 0.2), color: accentMain, border: `1px solid ${withAlpha(accentMain, 0.4)}` }}
+        >
+          <FileText className="w-3 h-3" /> КП
+        </span>
+      </div>
+
+      {/* Toolbar */}
+      <div
+        className="flex items-center justify-between gap-2 flex-wrap p-3 rounded-xl border"
+        style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+      >
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => navigateDate(-1)}
+            className="p-2 rounded-lg border"
+            style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+            aria-label="Предыдущий день"
+          >
+            <ChevronLeft className="w-4 h-4" style={{ color: textSecondary }} />
+          </button>
+          <div
+            className="flex items-center gap-2 px-3 py-1.5 rounded-lg border"
+            style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+          >
+            <Calendar className="w-4 h-4" style={{ color: accentMain }} />
+            <span className="text-sm font-medium" style={{ color: textPrimary }}>
+              {formatRussianDateOnly(selectedDate)}
+            </span>
+          </div>
+          <button
+            onClick={() => navigateDate(1)}
+            className="p-2 rounded-lg border"
+            style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+            aria-label="Следующий день"
+          >
+            <ChevronRight className="w-4 h-4" style={{ color: textSecondary }} />
+          </button>
+          <button
+            onClick={() => { const d = new Date().toISOString().split("T")[0]; setSelectedDate(d); }}
+            className="px-3 py-1.5 rounded-lg border text-xs font-bold"
+            style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft, color: textSecondary }}
+          >
+            Сегодня
+          </button>
+        </div>
+        <button
+          onClick={() => void loadProposals(selectedDate, true)}
+          disabled={refreshing}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-bold disabled:opacity-50"
+          style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft, color: textSecondary }}
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${refreshing ? "animate-spin" : ""}`} />
+          Обновить
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard label="Всего КП" value={String(totalCount)} icon={<FileText className="w-4 h-4" />} accentMain={accentMain} bgCard={bgCard} borderSoft={borderSoft} textPrimary={textPrimary} textSecondary={textSecondary} />
+        <StatCard label="Сумма" value={formatRubles(totalRevenue)} icon={<FileText className="w-4 h-4" />} accentMain={accentMain} bgCard={bgCard} borderSoft={borderSoft} textPrimary={textPrimary} textSecondary={textSecondary} />
+        <StatCard label="С QR-кодом" value={String(withQr)} icon={<QrCode className="w-4 h-4" />} accentMain={accentMain} bgCard={bgCard} borderSoft={borderSoft} textPrimary={textPrimary} textSecondary={textSecondary} />
+        <StatCard label="Типов" value={String(Object.keys(byType).length)} icon={<Building2 className="w-4 h-4" />} accentMain={accentMain} bgCard={bgCard} borderSoft={borderSoft} textPrimary={textPrimary} textSecondary={textSecondary} />
+      </div>
+
+      {/* List */}
+      <div className="rounded-xl border overflow-hidden" style={{ backgroundColor: withAlpha(bgCard, 0.4), borderColor: borderSoft }}>
+        <div
+          className="px-4 py-3 border-b"
+          style={{ borderColor: borderSoft, background: `linear-gradient(to right, ${withAlpha(accentMain, 0.05)}, transparent)` }}
+        >
+          <h3 className="text-sm font-black tracking-tight" style={{ color: textPrimary }}>КОММЕРЧЕСКИЕ ПРЕДЛОЖЕНИЯ</h3>
+        </div>
+
+        {loading ? (
+          <div className="p-4 space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-20 rounded-lg animate-pulse" style={{ backgroundColor: withAlpha(bgCard, 0.5) }} />
+            ))}
+          </div>
+        ) : proposals.length === 0 ? (
+          <div className="p-8 text-center">
+            <p className="text-sm" style={{ color: textSecondary }}>За этот день КП отсутствуют.</p>
+          </div>
+        ) : (
+          <div className="divide-y" style={{ borderColor: borderSoft }}>
+            {proposals.map((p) => (
+              <div key={p.id} className="p-4 flex flex-col md:flex-row md:items-center gap-3">
+                <div className="flex-1 space-y-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <User className="w-3.5 h-3.5 flex-shrink-0" style={{ color: textSecondary }} />
+                    <span className="text-sm font-semibold" style={{ color: textPrimary }}>{p.client_name}</span>
+                    {p.client_inn && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ backgroundColor: withAlpha(borderSoft, 0.4), color: textSecondary }}>
+                        ИНН {p.client_inn}
+                      </span>
+                    )}
+                    <span
+                      className="text-[10px] px-1.5 py-0.5 rounded font-bold uppercase"
+                      style={{ backgroundColor: withAlpha(accentMain, 0.15), color: accentMain }}
+                    >
+                      {OFFER_TYPE_LABELS[p.offer_type] || p.offer_type}
+                    </span>
+                    {p.qr_included && (
+                      <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded" style={{ backgroundColor: withAlpha("#10b981", 0.15), color: "#10b981" }}>
+                        <QrCode className="w-3 h-3" /> QR
+                      </span>
+                    )}
+                  </div>
+                  {p.client_phone && (
+                    <div className="flex items-center gap-2">
+                      <Phone className="w-3.5 h-3.5 flex-shrink-0" style={{ color: textSecondary }} />
+                      <a href={`tel:${p.client_phone}`} className="text-xs hover:underline" style={{ color: accentMain }}>{p.client_phone}</a>
+                    </div>
+                  )}
+                  {p.client_email && (
+                    <div className="flex items-center gap-2">
+                      <Mail className="w-3.5 h-3.5 flex-shrink-0" style={{ color: textSecondary }} />
+                      <a href={`mailto:${p.client_email}`} className="text-xs hover:underline" style={{ color: accentMain }}>{p.client_email}</a>
+                    </div>
+                  )}
+                  {p.offer_summary && (
+                    <p className="text-xs mt-1 line-clamp-2" style={{ color: textSecondary }}>{p.offer_summary}</p>
+                  )}
+                </div>
+                <div className="flex flex-col md:items-end gap-1">
+                  <div className="text-lg font-black" style={{ color: accentMain }}>{formatRubles(p.total_price)}</div>
+                  <div className="text-[10px] uppercase tracking-wide" style={{ color: textSecondary }}>
+                    Срок действия: {p.validity_days} дн.
+                  </div>
+                  <div className="text-[10px]" style={{ color: textSecondary }}>{formatRussianDate(p.created_at)}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Small stat card ────────────────────────────────────────────────────────────
+function StatCard({
+  label,
+  value,
+  icon,
+  accentMain,
+  bgCard,
+  borderSoft,
+  textPrimary,
+  textSecondary,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  accentMain: string;
+  bgCard: string;
+  borderSoft: string;
+  textPrimary: string;
+  textSecondary: string;
+}) {
+  return (
+    <div className="p-3 rounded-xl border" style={{ backgroundColor: withAlpha(bgCard, 0.4), borderColor: borderSoft }}>
+      <div className="flex items-center gap-1.5 mb-1">
+        <div style={{ color: accentMain }}>{icon}</div>
+        <span className="text-[10px] md:text-xs uppercase tracking-wide font-bold" style={{ color: textSecondary }}>{label}</span>
+      </div>
+      <div className="text-lg md:text-xl font-black" style={{ color: textPrimary }}>{value}</div>
+    </div>
+  );
+}

--- a/app/franchize/[slug]/commercial-offers-analytics/page.tsx
+++ b/app/franchize/[slug]/commercial-offers-analytics/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+
+import { CrewHeader } from "@/app/franchize/components/CrewHeader";
+import { FranchizePageShell } from "@/app/franchize/components/FranchizePageShell";
+import { getFranchizeBySlug } from "@/app/franchize/actions";
+import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { buildFranchizeSectionMetadata } from "../metadata";
+import { CommercialOffersAnalyticsClient } from "./CommercialOffersAnalyticsClient";
+
+interface FranchizeCommercialOffersAnalyticsPageProps {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ date?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Аналитика коммерческих предложений",
+    sectionDescription:
+      "Ежедневная статистика КП: клиенты, типы оферт, суммы и сроки действия.",
+    pathSuffix: "/commercial-offers-analytics",
+  });
+}
+
+export default async function FranchizeCommercialOffersAnalyticsPage({
+  params,
+  searchParams,
+}: FranchizeCommercialOffersAnalyticsPageProps) {
+  const { slug } = await params;
+  const { date: dateParam } = await searchParams;
+  const { crew } = await getFranchizeBySlug(slug);
+  const resolvedSlug = crew.slug || slug;
+  const activePath = `/franchize/${resolvedSlug}/commercial-offers-analytics`;
+  const surface = crewPaletteForSurface(crew.theme);
+
+  // Default to today if no date provided
+  const today = new Date().toISOString().split("T")[0];
+  const selectedDate = dateParam || today;
+
+  return (
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader
+        crew={crew}
+        activePath={activePath}
+        groupLinks={[]}
+        showRail={false}
+      />
+      <FranchizePageShell theme={crew.theme} contentClassName="space-y-4" width="full">
+        <CommercialOffersAnalyticsClient
+          initialSlug={resolvedSlug}
+          initialDate={selectedDate}
+          crew={crew}
+        />
+      </FranchizePageShell>
+    </main>
+  );
+}

--- a/app/franchize/[slug]/rentals-analytics/RentalsAnalyticsClient.tsx
+++ b/app/franchize/[slug]/rentals-analytics/RentalsAnalyticsClient.tsx
@@ -30,6 +30,8 @@ import {
   Send,
   List,
   Share2,
+  Plus,
+  X,
 } from "lucide-react";
 
 import { useAppContext } from "@/contexts/AppContext";
@@ -73,8 +75,11 @@ import {
 import {
   getCrewTodos,
   getCrewTodoStats,
+  createCrewTodo,
+  getCrewMembersForTodos,
   type CrewTodo,
   type TodoStatus,
+  type TodoPriority,
 } from "@/app/franchize/server-actions/crew-todos";
 import { RentalHandoffModal } from "./RentalHandoffModal";
 import { RentalsCalendar } from "./RentalsCalendar";
@@ -165,6 +170,14 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
   const [loadingTodos, setLoadingTodos] = useState(true);
   const [todoFilter, setTodoFilter] = useState<TodoStatus | "all">("all");
 
+  // New todo form state
+  const [showTodoForm, setShowTodoForm] = useState(false);
+  const [newTodoTitle, setNewTodoTitle] = useState("");
+  const [newTodoPriority, setNewTodoPriority] = useState<TodoPriority>("medium");
+  const [newTodoAssignee, setNewTodoAssignee] = useState<string | null>(null);
+  const [crewMembers, setCrewMembers] = useState<Array<{ user_id: string; full_name: string | null; username: string | null }>>([]);
+  const [creatingTodo, setCreatingTodo] = useState(false);
+
   // Handoff modal state
   const [handoffModalOpen, setHandoffModalOpen] = useState(false);
   const [handoffModalPhase, setHandoffModalPhase] = useState<"handout" | "return">("handout");
@@ -240,7 +253,13 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
 
   const loadRentals = useCallback(async (date: string, showRefresh = false) => {
     const actorUserId = getActorUserId();
-    if (!actorUserId) return;
+    if (!actorUserId) {
+      // Never get stuck in the initial loading state — flip the flag off
+      // so the UI can show the empty state / date nav remains clickable.
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
 
     if (showRefresh) setRefreshing(true);
     else setLoading(true);
@@ -277,7 +296,7 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
 
   const loadDateRange = useCallback(async () => {
     const actorUserId = getActorUserId();
-    if (!actorUserId) return;
+    if (!actorUserId) return; // no loading flag to reset for dateRange
 
     try {
       const result = await getRentalsDateRange({
@@ -297,7 +316,10 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
 
   const loadSales = useCallback(async (date: string) => {
     const actorUserId = getActorUserId();
-    if (!actorUserId) return;
+    if (!actorUserId) {
+      setLoadingSales(false);
+      return;
+    }
 
     setLoadingSales(true);
     try {
@@ -321,7 +343,10 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
 
   const loadCommercialProposals = useCallback(async (date: string) => {
     const actorUserId = getActorUserId();
-    if (!actorUserId) return;
+    if (!actorUserId) {
+      setLoadingProposals(false);
+      return;
+    }
 
     setLoadingProposals(true);
     try {
@@ -345,7 +370,10 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
 
   const loadSubrentContracts = useCallback(async (date: string) => {
     const actorUserId = getActorUserId();
-    if (!actorUserId) return;
+    if (!actorUserId) {
+      setLoadingSubrents(false);
+      return;
+    }
 
     setLoadingSubrents(true);
     try {
@@ -369,7 +397,10 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
 
   const loadPendingApplications = useCallback(async () => {
     const actorUserId = getActorUserId();
-    if (!actorUserId) return;
+    if (!actorUserId) {
+      setLoadingApplications(false);
+      return;
+    }
 
     setLoadingApplications(true);
     try {
@@ -447,7 +478,7 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
 
   const loadChecklistStates = useCallback(async () => {
     const actorUserId = getActorUserId();
-    if (!actorUserId) return;
+    if (!actorUserId) return; // no loading flag to reset
 
     try {
       const result = await getAllChecklistStates({ actorUserId, isPasswordAuth: !!passwordAuthOwnerId });
@@ -459,7 +490,10 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
 
   const loadTodos = useCallback(async () => {
     const actorUserId = getActorUserId();
-    if (!actorUserId || !crew.id) return;
+    if (!actorUserId || !crew.id) {
+      setLoadingTodos(false);
+      return;
+    }
 
     setLoadingTodos(true);
     try {
@@ -475,6 +509,65 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
       setLoadingTodos(false);
     }
   }, [getActorUserId, crew.id, todoFilter, passwordAuthOwnerId]);
+
+  // Load crew members for the todo assignee dropdown (called once when form opens)
+  const loadCrewMembers = useCallback(async () => {
+    const actorUserId = getActorUserId();
+    if (!actorUserId || !crew.id) return;
+    try {
+      const result = await getCrewMembersForTodos({
+        actorUserId,
+        crewId: crew.id,
+        isPasswordAuth: !!passwordAuthOwnerId,
+      });
+      if (result.success && result.data) setCrewMembers(result.data);
+    } catch (error) {
+      console.error("[Analytics] Crew members load error:", error);
+    }
+  }, [getActorUserId, crew.id, passwordAuthOwnerId]);
+
+  // Create a new todo via server action
+  const handleCreateTodo = async () => {
+    const title = newTodoTitle.trim();
+    if (!title) {
+      toast.error("Введите название задачи");
+      return;
+    }
+    const actorUserId = getActorUserId();
+    if (!actorUserId || !crew.id) {
+      toast.error("Нет авторизации");
+      return;
+    }
+    setCreatingTodo(true);
+    try {
+      const result = await createCrewTodo({
+        actorUserId,
+        todo: {
+          crewId: crew.id,
+          title,
+          assignedTo: newTodoAssignee,
+          priority: newTodoPriority,
+          category: "general",
+        },
+        isPasswordAuth: !!passwordAuthOwnerId,
+      });
+      if (result.success) {
+        toast.success("Задача добавлена");
+        setNewTodoTitle("");
+        setNewTodoPriority("medium");
+        setNewTodoAssignee(null);
+        setShowTodoForm(false);
+        await loadTodos();
+      } else {
+        toast.error(result.error || "Не удалось создать задачу");
+      }
+    } catch (error) {
+      console.error("[Analytics] Create todo error:", error);
+      toast.error("Ошибка создания задачи");
+    } finally {
+      setCreatingTodo(false);
+    }
+  };
 
   // ─── Password handling ─────────────────────────────────────────────────────────
 
@@ -977,11 +1070,11 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
               <div className="flex items-center gap-2 md:gap-3">
                 <button
                   onClick={() => navigateDate(-1)}
-                  disabled={loading}
                   className="p-1.5 md:p-2 rounded-lg md:rounded-xl border transition-all group"
                   style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
                   onMouseEnter={(e) => { e.currentTarget.style.borderColor = accentMain; e.currentTarget.style.backgroundColor = withAlpha(accentMain, 0.1); }}
                   onMouseLeave={(e) => { e.currentTarget.style.borderColor = borderSoft; e.currentTarget.style.backgroundColor = withAlpha(bgCard, 0.5); }}
+                  aria-label="Предыдущий день"
                 >
                   <ChevronLeft className="w-4 h-4 md:w-5 md:h-5 transition-colors" style={{ color: textSecondary }} />
                 </button>
@@ -1004,11 +1097,11 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
 
                 <button
                   onClick={() => navigateDate(1)}
-                  disabled={loading}
                   className="p-1.5 md:p-2 rounded-lg md:rounded-xl border transition-all group"
                   style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
                   onMouseEnter={(e) => { e.currentTarget.style.borderColor = accentMain; e.currentTarget.style.backgroundColor = withAlpha(accentMain, 0.1); }}
                   onMouseLeave={(e) => { e.currentTarget.style.borderColor = borderSoft; e.currentTarget.style.backgroundColor = withAlpha(bgCard, 0.5); }}
+                  aria-label="Следующий день"
                 >
                   <ChevronRight className="w-4 h-4 md:w-5 md:h-5 transition-colors" style={{ color: textSecondary }} />
                 </button>
@@ -1683,8 +1776,123 @@ export function RentalsAnalyticsClient({ initialSlug, initialDate, crew }: Renta
                         <span className="relative z-10">{filter.label}</span>
                       </button>
                     ))}
+                    <button
+                      onClick={() => {
+                        setShowTodoForm((v) => {
+                          const next = !v;
+                          if (next && crewMembers.length === 0) {
+                            void loadCrewMembers();
+                          }
+                          return next;
+                        });
+                      }}
+                      className="ml-1 flex items-center gap-1 px-2 md:px-2.5 py-1 rounded-lg text-[10px] md:text-xs font-bold transition-all duration-300"
+                      style={{
+                        backgroundColor: withAlpha(accentMain, 0.15),
+                        color: accentMain,
+                        border: "1.5px solid",
+                        borderColor: withAlpha(accentMain, 0.4),
+                      }}
+                      aria-label="Добавить задачу"
+                    >
+                      <Plus className="w-3 h-3 md:w-3.5 md:h-3.5" />
+                      <span className="hidden sm:inline">Добавить</span>
+                    </button>
                   </div>
                 </div>
+
+                {/* Inline "add todo" form */}
+                {showTodoForm && (
+                  <div
+                    className="px-4 md:px-5 py-3 md:py-4 border-b space-y-2.5 md:space-y-3"
+                    style={{
+                      borderColor: withAlpha(borderSoft, 0.3),
+                      backgroundColor: withAlpha(accentMain, 0.04),
+                    }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="text"
+                        value={newTodoTitle}
+                        onChange={(e) => setNewTodoTitle(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" && !creatingTodo) void handleCreateTodo();
+                          if (e.key === "Escape") setShowTodoForm(false);
+                        }}
+                        placeholder="Что нужно сделать?"
+                        autoFocus
+                        className="flex-1 px-3 py-2 rounded-lg text-sm outline-none"
+                        style={{
+                          backgroundColor: bgCard,
+                          border: `1px solid ${borderSoft}`,
+                          color: textPrimary,
+                        }}
+                      />
+                      <button
+                        onClick={() => setShowTodoForm(false)}
+                        className="p-2 rounded-lg"
+                        style={{ color: textSecondary, border: `1px solid ${borderSoft}` }}
+                        aria-label="Закрыть форму"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {/* Priority selector */}
+                      <div className="flex items-center gap-1">
+                        <span className="text-[10px] md:text-xs font-bold uppercase tracking-wide" style={{ color: textSecondary }}>Приоритет:</span>
+                        {(["low", "medium", "high"] as TodoPriority[]).map((p) => (
+                          <button
+                            key={p}
+                            onClick={() => setNewTodoPriority(p)}
+                            className="px-2 py-1 rounded-md text-[10px] md:text-xs font-bold transition-all"
+                            style={
+                              newTodoPriority === p
+                                ? { backgroundColor: withAlpha(accentMain, 0.25), color: accentMain, border: `1px solid ${withAlpha(accentMain, 0.4)}` }
+                                : { color: textSecondary, border: `1px solid ${borderSoft}` }
+                            }
+                          >
+                            {p === "low" ? "Низкий" : p === "medium" ? "Средний" : "Высокий"}
+                          </button>
+                        ))}
+                      </div>
+                      {/* Assignee selector */}
+                      <div className="flex items-center gap-1 ml-auto">
+                        <span className="text-[10px] md:text-xs font-bold uppercase tracking-wide" style={{ color: textSecondary }}>Кому:</span>
+                        <select
+                          value={newTodoAssignee || ""}
+                          onChange={(e) => setNewTodoAssignee(e.target.value || null)}
+                          className="px-2 py-1 rounded-md text-[10px] md:text-xs outline-none"
+                          style={{
+                            backgroundColor: bgCard,
+                            border: `1px solid ${borderSoft}`,
+                            color: textPrimary,
+                          }}
+                        >
+                          <option value="">Без исполнителя</option>
+                          {crewMembers.map((m) => (
+                            <option key={m.user_id} value={m.user_id}>
+                              {m.full_name || m.username || m.user_id}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      {/* Submit */}
+                      <button
+                        onClick={() => void handleCreateTodo()}
+                        disabled={creatingTodo || !newTodoTitle.trim()}
+                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all disabled:opacity-50"
+                        style={{
+                          backgroundColor: accentMain,
+                          color: "#ffffff",
+                        }}
+                      >
+                        <Plus className="w-3.5 h-3.5" />
+                        {creatingTodo ? "Создание..." : "Создать"}
+                      </button>
+                    </div>
+                  </div>
+                )}
                 <div className="p-3 md:p-4">
                   {todos.length === 0 ? (
                     <div className="text-center py-6 md:py-8">

--- a/app/franchize/[slug]/rentals-analytics/RentalsCalendar.tsx
+++ b/app/franchize/[slug]/rentals-analytics/RentalsCalendar.tsx
@@ -72,7 +72,11 @@ export function RentalsCalendar({ slug, crewId, crewTheme, isPasswordAuth, passw
   useEffect(() => {
     const loadRentals = async () => {
       const actorUserId = getActorUserId();
-      if (!actorUserId) return;
+      if (!actorUserId) {
+        // Never get stuck in the initial loading state.
+        setLoading(false);
+        return;
+      }
 
       setLoading(true);
       try {

--- a/app/franchize/[slug]/sales-analytics/SalesAnalyticsClient.tsx
+++ b/app/franchize/[slug]/sales-analytics/SalesAnalyticsClient.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { format } from "date-fns";
+import { ru } from "date-fns/locale";
+import {
+  Calendar,
+  ChevronLeft,
+  ChevronRight,
+  RefreshCw,
+  Tag,
+  Mail,
+  User,
+  Bike,
+  Shield,
+  BarChart3,
+  FileText,
+} from "lucide-react";
+
+import { useAppContext } from "@/contexts/AppContext";
+import {
+  getSalesDashboard,
+  validateAnalyticsPassword,
+  type SaleDashboardItem,
+  type SalesDashboardResult,
+} from "@/app/franchize/server-actions/rentals-dashboard";
+import { useFranchizeTheme } from "@/app/franchize/hooks/useFranchizeTheme";
+import { withAlpha } from "@/app/franchize/lib/theme";
+
+const formatRubles = (amount: number | string | null | undefined): string => {
+  if (amount == null) return "—";
+  const n = typeof amount === "string" ? Number(amount.replace(/\s/g, "")) : amount;
+  if (!Number.isFinite(n)) return "—";
+  return new Intl.NumberFormat("ru-RU", {
+    style: "currency",
+    currency: "RUB",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(n);
+};
+
+const formatRussianDate = (dateStr: string | null): string => {
+  if (!dateStr) return "—";
+  try {
+    return format(new Date(dateStr), "dd MMM yyyy, HH:mm", { locale: ru });
+  } catch {
+    return "—";
+  }
+};
+
+const formatRussianDateOnly = (dateStr: string | null): string => {
+  if (!dateStr) return "—";
+  try {
+    return format(new Date(dateStr), "dd MMM yyyy", { locale: ru });
+  } catch {
+    return "—";
+  }
+};
+
+interface SalesAnalyticsClientProps {
+  initialSlug: string;
+  initialDate: string;
+  crew: { id: string; name: string; theme: any };
+}
+
+export function SalesAnalyticsClient({ initialSlug, initialDate, crew }: SalesAnalyticsClientProps) {
+  const { dbUser, isLoading: authLoading } = useAppContext();
+  const theme = useFranchizeTheme(crew.theme);
+
+  const [selectedDate, setSelectedDate] = useState(initialDate);
+  const [sales, setSales] = useState<SaleDashboardItem[]>([]);
+  const [summary, setSummary] = useState<SalesDashboardResult["summary"] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Password auth (optional — mirrors rentals-analytics flow)
+  const [showPasswordEntry, setShowPasswordEntry] = useState(false);
+  const [passwordInput, setPasswordInput] = useState("");
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [isPasswordValidating, setIsPasswordValidating] = useState(false);
+  const [passwordAuthOwnerId, setPasswordAuthOwnerId] = useState<string | null>(null);
+
+  const getActorUserId = useCallback((): string | null => dbUser?.user_id || passwordAuthOwnerId, [dbUser?.user_id, passwordAuthOwnerId]);
+
+  const navigateDate = (delta: number) => {
+    const d = new Date(selectedDate);
+    d.setDate(d.getDate() + delta);
+    setSelectedDate(d.toISOString().split("T")[0]);
+  };
+
+  const loadSales = useCallback(async (date: string, showRefresh = false) => {
+    const actorUserId = getActorUserId();
+    if (!actorUserId) {
+      // Never get stuck in the initial loading state.
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+
+    if (showRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    try {
+      const result = await getSalesDashboard({
+        slug: initialSlug?.trim() || "vip-bike",
+        actorUserId,
+        date,
+        isPasswordAuth: !!passwordAuthOwnerId,
+      });
+
+      if (!result.success) {
+        if (result.error?.includes("прав") || result.error?.includes("доступ")) {
+          setShowPasswordEntry(true);
+          toast.error("Требуется пароль");
+          return;
+        }
+        toast.error(result.error || "Не удалось загрузить продажи");
+        return;
+      }
+
+      setSales(result.data?.items || []);
+      setSummary(result.data?.summary || null);
+    } catch (error) {
+      console.error("[SalesAnalytics] Load error:", error);
+      toast.error("Ошибка загрузки");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [getActorUserId, initialSlug, passwordAuthOwnerId]);
+
+  useEffect(() => {
+    if (getActorUserId()) {
+      void loadSales(selectedDate);
+    }
+  }, [getActorUserId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (getActorUserId() && !authLoading) {
+      void loadSales(selectedDate, true);
+    }
+  }, [selectedDate]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handlePasswordSubmit = async () => {
+    if (!passwordInput.trim()) return;
+    setIsPasswordValidating(true);
+    setPasswordError(null);
+    try {
+      const result = await validateAnalyticsPassword({ password: passwordInput });
+      if (!result.success) {
+        setPasswordError(result.error || "Неверный пароль");
+        return;
+      }
+      if (result.data?.slug && result.data.slug !== initialSlug?.trim()) {
+        setPasswordError(`Пароль для другого экипажа: ${result.data.slug}`);
+        return;
+      }
+      setPasswordAuthOwnerId(result.data?.ownerId || null);
+      setShowPasswordEntry(false);
+      setPasswordInput("");
+      toast.success("Доступ разрешён");
+    } catch {
+      setPasswordError("Ошибка проверки пароля");
+    } finally {
+      setIsPasswordValidating(false);
+    }
+  };
+
+  // Theme tokens
+  const bgBase = "var(--franchize-bg-base)";
+  const bgCard = "var(--franchize-bg-card)";
+  const accentMain = "var(--franchize-accent-main)";
+  const textPrimary = "var(--franchize-text-primary)";
+  const textSecondary = "var(--franchize-text-secondary)";
+  const borderSoft = "var(--franchize-border-soft)";
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ backgroundColor: bgBase }}>
+        <div className="w-12 h-12 rounded-full border-4 animate-spin" style={{ borderColor: withAlpha(accentMain, 0.2), borderTopColor: accentMain }} />
+      </div>
+    );
+  }
+
+  if (showPasswordEntry) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4" style={{ backgroundColor: bgBase }}>
+        <div
+          className="w-full max-w-sm p-6 rounded-2xl border"
+          style={{ backgroundColor: bgCard, borderColor: borderSoft }}
+        >
+          <h2 className="text-lg font-bold mb-2" style={{ color: textPrimary }}>Доступ по паролю</h2>
+          <p className="text-sm mb-4" style={{ color: textSecondary }}>Введите пароль аналитики для доступа к продажам.</p>
+          <input
+            type="password"
+            value={passwordInput}
+            onChange={(e) => setPasswordInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") void handlePasswordSubmit(); }}
+            className="w-full px-3 py-2 rounded-lg mb-3 outline-none"
+            style={{ backgroundColor: bgBase, border: `1px solid ${borderSoft}`, color: textPrimary }}
+            autoFocus
+          />
+          {passwordError && <p className="text-sm mb-3" style={{ color: "#f87171" }}>{passwordError}</p>}
+          <button
+            onClick={() => void handlePasswordSubmit()}
+            disabled={isPasswordValidating}
+            className="w-full py-2 rounded-lg font-bold disabled:opacity-50"
+            style={{ backgroundColor: accentMain, color: "#ffffff" }}
+          >
+            {isPasswordValidating ? "Проверка..." : "Войти"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const totalRevenue = summary?.totalRevenue || 0;
+  const totalCount = summary?.totalCount ?? sales.length;
+  const basePath = `/franchize/${initialSlug}`;
+
+  return (
+    <div className="space-y-4">
+      {/* Cross-analytics navigation */}
+      <div
+        className="flex items-center gap-1.5 flex-wrap p-2 rounded-xl border"
+        style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+      >
+        <BarChart3 className="w-3.5 h-3.5 ml-1.5 flex-shrink-0" style={{ color: textSecondary }} />
+        <span className="text-[10px] uppercase font-bold tracking-wide mr-1" style={{ color: textSecondary }}>Аналитика:</span>
+        <a
+          href={`${basePath}/rentals-analytics`}
+          className="flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-bold transition-all"
+          style={{ color: textSecondary, border: `1px solid ${borderSoft}` }}
+        >
+          <Calendar className="w-3 h-3" /> Аренды
+        </a>
+        <span
+          className="flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-bold"
+          style={{ backgroundColor: withAlpha(accentMain, 0.2), color: accentMain, border: `1px solid ${withAlpha(accentMain, 0.4)}` }}
+        >
+          <Tag className="w-3 h-3" /> Продажи
+        </span>
+        <a
+          href={`${basePath}/commercial-offers-analytics`}
+          className="flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-bold transition-all"
+          style={{ color: textSecondary, border: `1px solid ${borderSoft}` }}
+        >
+          <FileText className="w-3 h-3" /> КП
+        </a>
+      </div>
+
+      {/* Toolbar */}
+      <div
+        className="flex items-center justify-between gap-2 flex-wrap p-3 rounded-xl border"
+        style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+      >
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => navigateDate(-1)}
+            className="p-2 rounded-lg border"
+            style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+            aria-label="Предыдущий день"
+          >
+            <ChevronLeft className="w-4 h-4" style={{ color: textSecondary }} />
+          </button>
+          <div
+            className="flex items-center gap-2 px-3 py-1.5 rounded-lg border"
+            style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+          >
+            <Calendar className="w-4 h-4" style={{ color: accentMain }} />
+            <span className="text-sm font-medium" style={{ color: textPrimary }}>
+              {formatRussianDateOnly(selectedDate)}
+            </span>
+          </div>
+          <button
+            onClick={() => navigateDate(1)}
+            className="p-2 rounded-lg border"
+            style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft }}
+            aria-label="Следующий день"
+          >
+            <ChevronRight className="w-4 h-4" style={{ color: textSecondary }} />
+          </button>
+          <button
+            onClick={() => { const d = new Date().toISOString().split("T")[0]; setSelectedDate(d); }}
+            className="px-3 py-1.5 rounded-lg border text-xs font-bold"
+            style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft, color: textSecondary }}
+          >
+            Сегодня
+          </button>
+        </div>
+        <button
+          onClick={() => void loadSales(selectedDate, true)}
+          disabled={refreshing}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-bold disabled:opacity-50"
+          style={{ backgroundColor: withAlpha(bgCard, 0.5), borderColor: borderSoft, color: textSecondary }}
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${refreshing ? "animate-spin" : ""}`} />
+          Обновить
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard label="Всего продаж" value={String(totalCount)} icon={<Tag className="w-4 h-4" />} accentMain={accentMain} bgCard={bgCard} borderSoft={borderSoft} textPrimary={textPrimary} textSecondary={textSecondary} />
+        <StatCard label="Выручка" value={formatRubles(totalRevenue)} icon={<Shield className="w-4 h-4" />} accentMain={accentMain} bgCard={bgCard} borderSoft={borderSoft} textPrimary={textPrimary} textSecondary={textSecondary} />
+        <StatCard label="Средний чек" value={totalCount > 0 ? formatRubles(totalRevenue / totalCount) : "—"} icon={<Tag className="w-4 h-4" />} accentMain={accentMain} bgCard={bgCard} borderSoft={borderSoft} textPrimary={textPrimary} textSecondary={textSecondary} />
+        <StatCard label="Дата" value={formatRussianDateOnly(selectedDate)} icon={<Calendar className="w-4 h-4" />} accentMain={accentMain} bgCard={bgCard} borderSoft={borderSoft} textPrimary={textPrimary} textSecondary={textSecondary} />
+      </div>
+
+      {/* List */}
+      <div
+        className="rounded-xl border overflow-hidden"
+        style={{ backgroundColor: withAlpha(bgCard, 0.4), borderColor: borderSoft }}
+      >
+        <div
+          className="px-4 py-3 border-b"
+          style={{ borderColor: borderSoft, background: `linear-gradient(to right, ${withAlpha(accentMain, 0.05)}, transparent)` }}
+        >
+          <h3 className="text-sm font-black tracking-tight" style={{ color: textPrimary }}>ДОГОВОРЫ КУПЛИ-ПРОДАЖИ</h3>
+        </div>
+
+        {loading ? (
+          <div className="p-4 space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-20 rounded-lg animate-pulse" style={{ backgroundColor: withAlpha(bgCard, 0.5) }} />
+            ))}
+          </div>
+        ) : sales.length === 0 ? (
+          <div className="p-8 text-center">
+            <p className="text-sm" style={{ color: textSecondary }}>За этот день продажи отсутствуют.</p>
+          </div>
+        ) : (
+          <div className="divide-y" style={{ borderColor: borderSoft }}>
+            {sales.map((sale) => (
+              <div
+                key={sale.id}
+                className="p-4 flex flex-col md:flex-row md:items-center gap-3"
+                style={{ borderColor: borderSoft }}
+              >
+                <div className="flex-1 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <User className="w-3.5 h-3.5 flex-shrink-0" style={{ color: textSecondary }} />
+                    <span className="text-sm font-semibold" style={{ color: textPrimary }}>
+                      {sale.buyer_full_name || "Без имени"}
+                    </span>
+                  </div>
+                  {sale.buyer_email && (
+                    <div className="flex items-center gap-2">
+                      <Mail className="w-3.5 h-3.5 flex-shrink-0" style={{ color: textSecondary }} />
+                      <a href={`mailto:${sale.buyer_email}`} className="text-xs hover:underline" style={{ color: accentMain }}>
+                        {sale.buyer_email}
+                      </a>
+                    </div>
+                  )}
+                  <div className="flex items-center gap-2">
+                    <Bike className="w-3.5 h-3.5 flex-shrink-0" style={{ color: textSecondary }} />
+                    <span className="text-xs" style={{ color: textSecondary }}>
+                      {sale.vehicle ? `${sale.vehicle.make || ""} ${sale.vehicle.model || ""}`.trim() : "Техника не определена"}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex flex-col md:items-end gap-1">
+                  <div className="text-lg font-black" style={{ color: accentMain }}>
+                    {formatRubles(sale.sale_price)}
+                  </div>
+                  {sale.warranty_months && (
+                    <div className="text-[10px] uppercase tracking-wide" style={{ color: textSecondary }}>
+                      Гарантия: {sale.warranty_months} мес.
+                    </div>
+                  )}
+                  <div className="text-[10px]" style={{ color: textSecondary }}>
+                    {formatRussianDate(sale.created_at)}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Small stat card ────────────────────────────────────────────────────────────
+function StatCard({
+  label,
+  value,
+  icon,
+  accentMain,
+  bgCard,
+  borderSoft,
+  textPrimary,
+  textSecondary,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  accentMain: string;
+  bgCard: string;
+  borderSoft: string;
+  textPrimary: string;
+  textSecondary: string;
+}) {
+  return (
+    <div
+      className="p-3 rounded-xl border"
+      style={{ backgroundColor: withAlpha(bgCard, 0.4), borderColor: borderSoft }}
+    >
+      <div className="flex items-center gap-1.5 mb-1">
+        <div style={{ color: accentMain }}>{icon}</div>
+        <span className="text-[10px] md:text-xs uppercase tracking-wide font-bold" style={{ color: textSecondary }}>
+          {label}
+        </span>
+      </div>
+      <div className="text-lg md:text-xl font-black" style={{ color: textPrimary }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/app/franchize/[slug]/sales-analytics/page.tsx
+++ b/app/franchize/[slug]/sales-analytics/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+
+import { CrewHeader } from "@/app/franchize/components/CrewHeader";
+import { FranchizePageShell } from "@/app/franchize/components/FranchizePageShell";
+import { getFranchizeBySlug } from "@/app/franchize/actions";
+import { crewPaletteForSurface } from "@/app/franchize/lib/theme";
+import { buildFranchizeSectionMetadata } from "../metadata";
+import { SalesAnalyticsClient } from "./SalesAnalyticsClient";
+
+interface FranchizeSalesAnalyticsPageProps {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ date?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  return buildFranchizeSectionMetadata(slug, {
+    sectionTitle: "Аналитика продаж",
+    sectionDescription:
+      "Ежедневная статистика продаж: договоры купли-продажи, выручка, контакты покупателей.",
+    pathSuffix: "/sales-analytics",
+  });
+}
+
+export default async function FranchizeSalesAnalyticsPage({
+  params,
+  searchParams,
+}: FranchizeSalesAnalyticsPageProps) {
+  const { slug } = await params;
+  const { date: dateParam } = await searchParams;
+  const { crew } = await getFranchizeBySlug(slug);
+  const resolvedSlug = crew.slug || slug;
+  const activePath = `/franchize/${resolvedSlug}/sales-analytics`;
+  const surface = crewPaletteForSurface(crew.theme);
+
+  // Default to today if no date provided
+  const today = new Date().toISOString().split("T")[0];
+  const selectedDate = dateParam || today;
+
+  return (
+    <main className="min-h-screen" style={surface.page}>
+      <CrewHeader
+        crew={crew}
+        activePath={activePath}
+        groupLinks={[]}
+        showRail={false}
+      />
+      <FranchizePageShell theme={crew.theme} contentClassName="space-y-4" width="full">
+        <SalesAnalyticsClient
+          initialSlug={resolvedSlug}
+          initialDate={selectedDate}
+          crew={crew}
+        />
+      </FranchizePageShell>
+    </main>
+  );
+}


### PR DESCRIPTION
fix(franchize): rentals-analytics stuck loading, dead date buttons, missing add-todo UI, and add sales-analytics/commercial-offers-analytics routes (v2 — code-review fixes)

## Summary

Fixes all 5 user-reported issues on the franchize rentals-analytics page and adds two new parallel analytics routes (`/sales-analytics`, `/commercial-offers-analytics`). This is **v2** of the PR — the first version was caught in code review overwriting an existing `/sales` landing page; this version is corrected.

## ⚠️ What changed between v1 and v2 (code-review fixes)

The first version of this PR had three problems that code review caught:

1. **CRITICAL — `sales/page.tsx` was overwritten.** v1 replaced the existing `/sales` route (a "Sales vertical" landing page with new/electric/used/trade-in configurator cards) with the daily sales-list code. v2 **does not touch `sales/page.tsx` at all** — the existing landing page is preserved. The daily sales list moved to a new `/sales-analytics` route, parallel to `/rentals-analytics`.

2. **`section-links.ts` was modified.** v1 added `/commercial-offers` and `/rentals-analytics` entries to the nav. But the user had explicitly provided the 8-entry version of this file, and the original `/rentals-analytics` page intentionally had `showRail={false}` (analytics pages were not in the main nav). v2 **does not touch `section-links.ts`** — the user's original 8-entry version is preserved as-is.

3. **`rentals-analytics/page.tsx` was modified.** v1 re-enabled the section rail by passing `sectionLinks={...}`. v2 **reverts this** — `showRail={false}` is kept, matching the original behavior.

To compensate for the analytics routes not being in the main nav, **both new analytics pages include a cross-nav strip** at the top with links to the other two analytics pages (rentals/sales/commercial-offers). Users can navigate between the three analytics pages without needing main-nav entries.

## Root cause (unchanged from v1)

A single shared bug — `early-return-without-setLoading(false)` — was responsible for issues **1, 3, and 4**. When `getActorUserId()` returned null, every loader bailed before entering its try/finally, so the initial `loading = useState(true)` never flipped to `false`. The rentals table pulsed forever; the date buttons were `disabled={loading}` so they never became clickable; and the stats counters — all derived from the loader output arrays — stayed at `0`. The Todos card *looked* fine only because its UI never reads `loadingTodos`, just `todos.length === 0`.

## Fixes

### Issue 1 — Date-control buttons don't work
- Removed `disabled={loading}` from both prev/next day buttons in `RentalsAnalyticsClient.tsx` so date navigation is always clickable. The original bug was downstream of Issue 3 (`loading` was stuck at `true` forever), but `disabled={loading}` is bad UX even after the loader fix — date nav should never be blocked.

### Issue 2 — No "add todo" UI
- Extended the `crew-todos` import to include `createCrewTodo`, `getCrewMembersForTodos`, and `TodoPriority`.
- Added state for the new-todo form: `showTodoForm`, `newTodoTitle`, `newTodoPriority`, `newTodoAssignee`, `crewMembers`, `creatingTodo`.
- Added a `loadCrewMembers` helper that populates the assignee dropdown on first form open.
- Added `handleCreateTodo` that calls `createCrewTodo` then refreshes `loadTodos()`.
- Added a "+ Добавить" button next to the todos filter chips and an inline form with title input, priority selector, assignee dropdown, and submit button. Enter to submit, Esc to close.

### Issue 3 — Rentals stuck in loading state ⭐ (the linchpin)
- Patched **all 8 loaders** so the early-return path also calls `setLoading(false)` (and `setRefreshing(false)` where applicable):
  - `loadRentals`
  - `loadDateRange` (no loading flag, comment-only)
  - `loadSales`
  - `loadCommercialProposals`
  - `loadSubrentContracts`
  - `loadPendingApplications`
  - `loadChecklistStates` (no loading flag, comment-only)
  - `loadTodos`
  - `RentalsCalendar.tsx` `loadRentals`

### Issue 4 — All stats counters show 0
- No code change required — pure downstream of Issue 3. Stats are derived from `rentals`/`sales`/`proposals`/`subrents` state arrays; once the loaders resolve, the counters populate.

### Issue 5 — Missing list pages for commercial offers and sales
- Created `app/franchize/[slug]/sales-analytics/page.tsx` + `SalesAnalyticsClient.tsx` — full daily sales list reusing `getSalesDashboard`, with date nav, password-auth fallback, cross-analytics nav strip, and stats (count, revenue, average check).
- Created `app/franchize/[slug]/commercial-offers-analytics/page.tsx` + `CommercialOffersAnalyticsClient.tsx` — full daily commercial-proposals list reusing `getCommercialProposalsDashboard`, with date nav, password-auth fallback, cross-analytics nav strip, and stats (count, total, with-QR, types).
- Both new routes follow the same pattern as the existing `/rentals-analytics` route: server component fetches crew + date, wraps a client component in `<FranchizePageShell>`, and passes `showRail={false}` to `<CrewHeader>` (matching the existing analytics-page convention of not showing the main section rail).
- Cross-nav strip at the top of each new page links to the other two analytics pages, so users can navigate between `/rentals-analytics`, `/sales-analytics`, and `/commercial-offers-analytics` without needing main-nav entries.
- **Does NOT touch** the existing `/sales/page.tsx` (the Sales vertical landing page) — that page is preserved as-is.
- **Does NOT touch** `section-links.ts` — the user's original 8-entry version is preserved.

## Files changed (6 files — 2 modified, 4 new)

- `app/franchize/[slug]/rentals-analytics/RentalsAnalyticsClient.tsx` — Issues 1, 2, 3 (modified)
- `app/franchize/[slug]/rentals-analytics/RentalsCalendar.tsx` — Issue 3 (modified)
- `app/franchize/[slug]/sales-analytics/page.tsx` — Issue 5 (new route)
- `app/franchize/[slug]/sales-analytics/SalesAnalyticsClient.tsx` — Issue 5 (new route)
- `app/franchize/[slug]/commercial-offers-analytics/page.tsx` — Issue 5 (new route)
- `app/franchize/[slug]/commercial-offers-analytics/CommercialOffersAnalyticsClient.tsx` — Issue 5 (new route)

## Files explicitly NOT touched (preserved as-is)

- `app/franchize/[slug]/sales/page.tsx` — the existing Sales vertical landing page (new/electric/used/trade-in configurator). v1 incorrectly overwrote this; v2 leaves it alone.
- `app/franchize/lib/section-links.ts` — the user's original 8-entry version. v1 incorrectly added analytics routes; v2 leaves it alone.
- `app/franchize/[slug]/rentals-analytics/page.tsx` — original `showRail={false}` behavior. v1 incorrectly re-enabled the rail; v2 leaves it alone.

## Test plan

- [ ] Visit `/franchize/<slug>/rentals-analytics` while signed in — rentals table should populate within 1–2s, no infinite spinner.
- [ ] Stats counters (total rentals, revenue, sales, proposals, etc.) should reflect actual data.
- [ ] Click prev/next day buttons — should navigate immediately, no disabled state.
- [ ] Open the Todos card — click "+ Добавить", enter a title, pick priority/assignee, hit Enter — todo should appear in the list.
- [ ] Visit `/franchize/<slug>/sales-analytics?date=YYYY-MM-DD` — should show sales for that day. Cross-nav strip at top should link to rentals-analytics and commercial-offers-analytics.
- [ ] Visit `/franchize/<slug>/commercial-offers-analytics?date=YYYY-MM-DD` — should show proposals for that day. Cross-nav strip at top should link to rentals-analytics and sales-analytics.
- [ ] Visit `/franchize/<slug>/sales` — should still show the **original Sales vertical landing page** (new/electric/used/trade-in cards), NOT the analytics list. This confirms v1's overwrite is undone.
- [ ] Visit `/franchize/<slug>/rentals-analytics` while NOT signed in — should show empty state, not infinite spinner.

## Out of scope (intentionally not touched)

- Server-action split (`commercial-offers.ts` / `sales.ts`) — kept in `rentals-dashboard.ts` for backward compat.
- Initial `useState(true)` for loading flags — kept as-is; the loaders now reliably flip them to `false` regardless of auth state. Could be changed to `useState(false)` later if first-paint flash becomes a problem.
- Subrent route — server actions exist but route not added (not requested).
- Adding cross-nav strip to the existing `RentalsAnalyticsClient.tsx` — left alone to avoid scope-creep on the huge file. The new sales/commercial-offers analytics pages link TO rentals-analytics, so navigation works in that direction. Users on rentals-analytics can navigate via URL or via the existing inline sales/proposals tables.


---

**Файлы (6):**
- `app/franchize/[slug]/rentals-analytics/RentalsAnalyticsClient.tsx`
- `app/franchize/[slug]/rentals-analytics/RentalsCalendar.tsx`
- `app/franchize/[slug]/sales-analytics/page.tsx`
- `app/franchize/[slug]/sales-analytics/SalesAnalyticsClient.tsx`
- `app/franchize/[slug]/commercial-offers-analytics/page.tsx`
- `app/franchize/[slug]/commercial-offers-analytics/CommercialOffersAnalyticsClient.tsx`